### PR TITLE
Introduce themes using CSS variables

### DIFF
--- a/components/ui/BoxButton.tsx
+++ b/components/ui/BoxButton.tsx
@@ -29,9 +29,9 @@ export const BoxButton = ({ href, children, title, style, size, disabled, extern
     className += ''
 
     if(disabled) {
-      className += ' bg-white/50 text-black/50'
+      className += ' bg-white text-[var(--back)] opacity-50'
     } else {
-      className += ' bg-white text-black hover:bg-white/75'
+      className += ' bg-white text-[var(--back)] hover:bg-white/75'
     }
   }
 

--- a/components/ui/Tooltip.tsx
+++ b/components/ui/Tooltip.tsx
@@ -41,9 +41,9 @@ export const Tooltip = ({
   }) => {
     const nodeRef = useRef(null);
 
-    let classes = 'absolute bg-black border border-white pointer-events-none shadow-lg shadow-black/25 transition ease-in-out duration-250'
+    let classes = 'absolute bg-[var(--back)] border border-white pointer-events-none shadow-lg shadow-black/25 transition ease-in-out duration-250'
     let arrowDirection = null
-    let arrowClasses = "relative flex flex-col items-center px-5 py-2 after:content-[''] after:w-3 after:h-3 after:absolute after:bg-black"
+    let arrowClasses = "relative flex flex-col items-center px-5 py-2 after:content-[''] after:w-3 after:h-3 after:absolute after:bg-[var(--back)]"
 
     if(position == 'above-left') {
       classes += ' -top-full left-0'

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,6 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --back: #324760;
+}
+
+.-theme-purple {
+  --back: #4D2859;
+}
+
+.-theme-red {
+  --back: #6F272D;
+}
+
+.-theme-brown {
+  --back: #524445;
+}
+
 html {
   scroll-behavior: smooth;
 }


### PR DESCRIPTION
Chapters have unique background colors that get picked up by certain UI elements. This PR introduces a basic system using a `back` (= background) variable that gets changed by appending a theme class to the current page. Related to [this comment](https://github.com/saving-satoshi/saving-satoshi/pull/37#discussion_r1060170784).

Themes also include a background pattern, which is not included here. Something to add separately, we need to figure out the best way (optimizing file size and a fade on load) to implement this.

Here's a mock-up with an example of how the theme is expressed. See how the label on the button picks up the background color. Not that this is not needed in many places and it's fine to just overlay white or black with some opacity.
![image](https://user-images.githubusercontent.com/695901/210277105-c6b4c77f-ca9a-47e8-81eb-bf3668662dc0.png)

PR #37 includes various hardcoded color values that instead should use theme variables.