### PR TITLE
Add tabs to genesis lesson on mobile

### DIFF
--- a/app/chapters/[slug]/genesis/code.tsx
+++ b/app/chapters/[slug]/genesis/code.tsx
@@ -1,0 +1,133 @@
+import { BoxButton } from 'components/ui/BoxButton'
+import { useState } from 'react'
+import RICIBs from 'react-individual-character-input-boxes'
+import clsx from 'clsx'
+
+// TODO use environment
+const inputAmount = 154
+const answer =
+  '04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73'
+
+export const Code = ({
+  isSmallScreen
+}: {
+  isSmallScreen: boolean
+}) => {
+  const [correctAnswer, setCorrectAnswer] = useState(false)
+
+  function disableNext() {
+    setCorrectAnswer(false)
+  }
+
+  function enableNext() {
+    setCorrectAnswer(true)
+  }
+
+  // Todo create utils for repetitive validation
+  const validateInput = (string) => {
+    if (string == answer) {
+      enableNext()
+    } else {
+      disableNext()
+    }
+  }
+
+  return (
+    <div className="
+      flex
+      flex-col
+      grow
+      md:justify-center
+      md:items-center"
+    >
+      <div className="
+        flex
+        grow
+        md:items-center
+        max-w-[840px]
+        px-4
+        py-8"
+      >
+        <div className="
+          content-center
+          justify-items-center
+          font-space-mono
+          text-white"
+        >
+          <h2 className="
+            text-center
+            text-xl
+          ">
+            Paste the ScriptSig HEX Representation
+          </h2>
+          <div className="w-full pt-8">
+            <RICIBs
+              amount={inputAmount}
+              autoFocus
+              handleOutputString={validateInput}
+              inputProps={{
+                className: 'bg-transparent',
+                placeholder: '_',
+                style: {
+                  fontSize: '20px',
+                  width: '20px',
+                  height: '20px',
+                  margin: '0px',
+                  borderRadius: '0px',
+                  textAlign: 'center',
+                  justifyContent: 'space-evenly',
+                  outline: 'none',
+                  fontFamily: 'var(--space-mono-font)',
+                }
+              }}
+              inputRegExp={/^[a-zA-Z0-9_.-]*$/}
+            />
+          </div>
+        </div>
+      </div>
+      <div className="
+          w-screen
+          border-t
+          border-white/25
+          max-md:px-4
+          max-md:py-8
+        ">
+        <div className="
+            flex
+            flex-col
+            md:flex-row
+            items-stretch
+            justify-between
+            max-md:gap-4
+          ">
+          <div
+            className={clsx(
+              'flex w-full items-center align-middle transition duration-150 ease-in-out md:px-5',
+              {
+                'bg-success/25': correctAnswer,
+              }
+            )}
+          >
+            <p
+              className={clsx(
+                'font-nunito text-[21px] text-white transition duration-150 ease-in-out',
+                {
+                  'opacity-50': !correctAnswer,
+                }
+              )}
+            >
+              {correctAnswer
+                ? 'Challenge completed!'
+                : 'Complete the challenge above to continue'}
+            </p>
+          </div>
+          <BoxButton
+            href="/chapters/chapter-1/genesis/genesis-pt2"
+            disabled={!correctAnswer}
+            size={!isSmallScreen ? 'big' : null}
+          >Next</BoxButton>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/chapters/[slug]/genesis/info.tsx
+++ b/app/chapters/[slug]/genesis/info.tsx
@@ -1,0 +1,31 @@
+import { BoxButton } from 'components/ui/BoxButton'
+
+export const Info = ({
+  isSmallScreen,
+  genesis
+}: {
+  isSmallScreen: boolean,
+  genesis: any
+}) => {
+  return (
+    <div className="
+      flex
+      flex-col
+      gap-6
+      grow
+      px-4
+      py-6
+      max-w-[840px]
+      md:justify-center
+    ">
+      <div
+        className="genesis text-white font-nunito"
+        dangerouslySetInnerHTML={{ __html: genesis.body.html }}
+      ></div>
+      <BoxButton
+        href="https://blockstream.info/block/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+        external={true}
+      >View Block 0</BoxButton>
+    </div>
+  )
+}

--- a/app/chapters/[slug]/genesis/info.tsx
+++ b/app/chapters/[slug]/genesis/info.tsx
@@ -1,10 +1,8 @@
 import { BoxButton } from 'components/ui/BoxButton'
 
 export const Info = ({
-  isSmallScreen,
   genesis
 }: {
-  isSmallScreen: boolean,
   genesis: any
 }) => {
   return (

--- a/app/chapters/[slug]/genesis/layout.tsx
+++ b/app/chapters/[slug]/genesis/layout.tsx
@@ -1,3 +1,3 @@
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return <div className="flex grow flex-col">{children}</div>
+  return <div className="flex flex-col md:grow">{children}</div>
 }

--- a/app/chapters/[slug]/genesis/page.tsx
+++ b/app/chapters/[slug]/genesis/page.tsx
@@ -60,7 +60,6 @@ export default function Genesis() {
       )}
       {(!isSmallScreen || (isSmallScreen && activeTab == 'info')) && (
         <Info
-          isSmallScreen={isSmallScreen}
           genesis={genesis}
         />
       )}

--- a/app/chapters/[slug]/genesis/page.tsx
+++ b/app/chapters/[slug]/genesis/page.tsx
@@ -3,14 +3,12 @@
 import { allLessons, Lesson } from 'contentlayer/generated'
 import Link from 'next/link'
 import { BoxButton } from 'components/ui/BoxButton'
-import RICIBs from 'react-individual-character-input-boxes'
-import { useState } from 'react'
+import { Tabs } from 'components/ui/Tabs'
+import { useState, useEffect } from 'react'
 import clsx from 'clsx'
-
-// TODO use environment
-const inputAmount = 154
-const answer =
-  '04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73'
+import { useMediaQuery } from 'react-responsive'
+import { Info } from './info'
+import { Code } from './code'
 
 //Am i going to to this boilerplate for every view?
 // TODO make a factory (or other pattern) to populate component data
@@ -23,103 +21,57 @@ function getGenesis() {
 }
 
 export default function Genesis() {
+  const [hydrated, setHydrated] = useState(false);
+  const [activeTab, setActiveTab] = useState('info')
   const genesis = getGenesis()
-
-  const [correctAnswer, setCorrectAnswer] = useState(false)
-
-  function disableNext() {
-    setCorrectAnswer(false)
-  }
-
-  function enableNext() {
-    setCorrectAnswer(true)
-  }
-
-  // Todo create utils for repetitive validation
-  const validateInput = (string) => {
-    if (string == answer) {
-      enableNext()
-    } else {
-      disableNext()
+  const isSmallScreen = useMediaQuery({ query: '(max-width: 767px)' })
+  const tabData = [
+    {
+      id: 'info',
+      text: 'Info'
+    },
+    {
+      id: 'code',
+      text: 'Code',
     }
-  }
+  ]
 
-  return (
-    <div className="flex w-screen grow flex-col items-center justify-center justify-items-center px-6 lg:px-0">
-      <div className="flex w-screen grow items-center py-4 text-white lg:w-1/2">
-        <div className="content-center justify-items-center px-6 font-nunito lg:px-0">
-          <div
-            className="genesis"
-            dangerouslySetInnerHTML={{ __html: genesis.body.html }}
-          ></div>
-          <BoxButton
-            href="https://blockstream.info/block/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
-            external={true}
-            classes="mt-8"
-          >View Block 0</BoxButton>
-        </div>
-      </div>
-      <hr className="border-1 h-1 w-screen border-white/25"></hr>
-      <div className="flex grow items-center justify-center font-space-mono text-white lg:w-1/2">
-        <div className="content-center justify-items-center">
-          <h1 className="text-center text-xl">
-            Paste the ScriptSig HEX Representation
-          </h1>
-          <div className="w-full pt-8">
-            <RICIBs
-              amount={inputAmount}
-              autoFocus
-              handleOutputString={validateInput}
-              inputProps={{
-                className: 'bg-transparent',
-                placeholder: '_',
-                style: {
-                  fontSize: '20px',
-                  width: '20px',
-                  height: '20px',
-                  margin: '0px',
-                  borderRadius: '0px',
-                  textAlign: 'center',
-                  justifyContent: 'space-evenly',
-                  outline: 'none',
-                  fontFamily: 'var(--space-mono-font)',
-                },
-              }}
-              inputRegExp={/^[a-zA-Z0-9_.-]*$/}
-            />
-          </div>
-        </div>
-      </div>
-      <div className="w-screen border-t border-white/25 sm:pb-[30px] md:pb-[0px]">
-        <div className="flex items-stretch justify-between sm:flex-col md:flex-row">
-          <div
-            className={clsx(
-              'flex w-full items-center px-5 align-middle transition duration-150 ease-in-out',
-              {
-                'bg-success/25': correctAnswer,
-              }
-            )}
-          >
-            <h2
-              className={clsx(
-                'font-nunito text-[21px] text-white opacity-50 transition duration-150 ease-in-out',
-                {
-                  'opacity-100': correctAnswer,
-                }
-              )}
-            >
-              {correctAnswer
-                ? 'Challenge completed!'
-                : 'Complete the challenge above to continue'}
-            </h2>
-          </div>
-          <BoxButton
-            href="/chapters/chapter-1/genesis/genesis-pt2"
-            disabled={!correctAnswer}
-            size="big"
-          >Next</BoxButton>
-        </div>
-      </div>
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  return (hydrated && (
+    <div className="
+      flex
+      w-screen
+      grow
+      flex-col
+      items-center
+      justify-center
+    ">
+      {isSmallScreen && (
+        <Tabs
+          items={tabData}
+          activeId={activeTab}
+          onChange={setActiveTab}
+          classes="px-4 py-2 w-full"
+          stretch={true}
+        />
+      )}
+      {(!isSmallScreen || (isSmallScreen && activeTab == 'info')) && (
+        <Info
+          isSmallScreen={isSmallScreen}
+          genesis={genesis}
+        />
+      )}
+      {!isSmallScreen && (
+        <hr className="border-1 h-1 w-screen border-white/25"></hr>
+      )}
+      {(!isSmallScreen || (isSmallScreen && activeTab == 'code')) && (
+        <Code
+          isSmallScreen={isSmallScreen}
+        />
+      )}
     </div>
-  )
+  ))
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "18.2.0",
     "react-individual-character-input-boxes": "^1.2.1",
     "react-modal": "^3.16.1",
+    "react-responsive": "^9.0.2",
     "react-terminal-ui": "^1.0.0",
     "react-transition-group": "^4.4.5"
   },


### PR DESCRIPTION
This PR introduces a tabbed layout on mobile where the user can switch between seeing the lesson info or code. Both at once can only be seen on desktop (no tabs there).

👳🏻[Check the preview](https://saving-satoshi-git-feature-genesis-respon-44c3c2-saving-satoshi.vercel.app/chapters/chapter-1/genesis)👲🏻

- Adds the 'react-responsive' module to more easily handle screen-size specific layouts
- Adds tabs to the genesis page on mobile only
- Splits up the genesis lesson into sub-components so they can be individually shown and hidden based on which tab is selected
- Lots of style tweaks to more closely match the Figma file

Designs:
![image](https://user-images.githubusercontent.com/695901/210398653-cc9810ac-b55c-4afc-8f91-7a72744b76c8.png)

It's a very common thing to show slightly different UI on mobile and desktop, but it seems to take a lot of extra code overhead to do this. First we need the `react-responsive` library. Then we need to hide stuff until the page is rendered once before showing content to avoid hydration errors (server-rendered HTML won't match client-rendered HTML because the server doesn't know what the client environment is). Would be awesome if this code could be packaged into a helper tool or so, but I don't know React well enough.

I am also curious if we can re-use layout styling. We have a few page templates for lessons. Ideally we can avoid copy/pasting the same layout Tailwind classes (e.g. `flex grow md:items-center max-w-[840px] px-4 py-8`) all over the place and instead have a single class like `-lesson-wrap` that bundles these definitions. Will have to see what a good way is to do that. That can be a separate PR.
