### PR TITLE
Minor code fix for the about page

### DIFF
--- a/content/pages/about.mdx
+++ b/content/pages/about.mdx
@@ -1,0 +1,4 @@
+---
+title: About Saving Satoshi
+type: Page
+---

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -121,5 +121,5 @@ const Chapter = defineDocumentType(() => ({
 
 export default makeSource({
   contentDirPath: 'content',
-  documentTypes: [Lesson, Introduction, Chapter],
+  documentTypes: [Pages, Lesson, Introduction, Chapter],
 })


### PR DESCRIPTION
Next complains that the about page does not have a defined type. Looks like the type existed in the contentlayer config, but was not added correctly. Fixing this here.

<img width="792" alt="image" src="https://user-images.githubusercontent.com/695901/210958293-8036b593-5697-4a3b-8bdc-4712ecf22c6e.png">

## Pull Request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures

## Pull Request type

Please check the type of change your PR introduces:

- [x] :bug: Bugfix
- [ ] :sparkles: Feature
- [ ] :lipstick: :art: Code style update (formatting, renaming)
- [ ] :recycle: Refactoring (no functional changes, no api changes)
- [ ] :zap: Performance
- [ ] :pencil: Documentation content changes
- [ ] :wrench: Other (please describe):