### PR TITLE
Add FindChallengeBottomBar and refactor challenges validation

### DIFF
--- a/app/chapters/[slug]/genesis/code.tsx
+++ b/app/chapters/[slug]/genesis/code.tsx
@@ -2,6 +2,7 @@ import { BoxButton } from 'components/ui/BoxButton'
 import { useState } from 'react'
 import RICIBs from 'react-individual-character-input-boxes'
 import clsx from 'clsx'
+import { FindChallengeBottomBar, Status } from 'components/chapters/FindChallengeBottomBar'
 
 // TODO use environment
 const inputAmount = 154
@@ -13,24 +14,7 @@ export const Code = ({
 }: {
   isSmallScreen: boolean
 }) => {
-  const [correctAnswer, setCorrectAnswer] = useState(false)
-
-  function disableNext() {
-    setCorrectAnswer(false)
-  }
-
-  function enableNext() {
-    setCorrectAnswer(true)
-  }
-
-  // Todo create utils for repetitive validation
-  const validateInput = (string) => {
-    if (string == answer) {
-      enableNext()
-    } else {
-      disableNext()
-    }
-  }
+  const [userInput, setUserInput] = useState('');
 
   return (
     <div className="
@@ -64,7 +48,7 @@ export const Code = ({
             <RICIBs
               amount={inputAmount}
               autoFocus
-              handleOutputString={validateInput}
+              handleOutputString={str => setUserInput(str)}
               inputProps={{
                 className: 'bg-transparent',
                 placeholder: '_',
@@ -85,49 +69,7 @@ export const Code = ({
           </div>
         </div>
       </div>
-      <div className="
-          w-screen
-          border-t
-          border-white/25
-          max-md:px-4
-          max-md:py-8
-        ">
-        <div className="
-            flex
-            flex-col
-            md:flex-row
-            items-stretch
-            justify-between
-            max-md:gap-4
-          ">
-          <div
-            className={clsx(
-              'flex w-full items-center align-middle transition duration-150 ease-in-out md:px-5',
-              {
-                'bg-success/25': correctAnswer,
-              }
-            )}
-          >
-            <p
-              className={clsx(
-                'font-nunito text-[21px] text-white transition duration-150 ease-in-out',
-                {
-                  'opacity-50': !correctAnswer,
-                }
-              )}
-            >
-              {correctAnswer
-                ? 'Challenge completed!'
-                : 'Complete the challenge above to continue'}
-            </p>
-          </div>
-          <BoxButton
-            href="/chapters/chapter-1/genesis/genesis-pt2"
-            disabled={!correctAnswer}
-            size={!isSmallScreen ? 'big' : null}
-          >Next</BoxButton>
-        </div>
-      </div>
+      <FindChallengeBottomBar full next="/chapters/chapter-1/genesis/genesis-pt2" input={userInput} expected={answer} />
     </div>
   )
 }

--- a/app/chapters/[slug]/genesis/genesis-pt2/page.tsx
+++ b/app/chapters/[slug]/genesis/genesis-pt2/page.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react'
 import clsx from 'clsx'
 import { TerminalOutput } from 'react-terminal-ui'
 import PlayIcon from 'public/assets/icons/play.svg'
+import { FindChallengeBottomBar } from 'components/chapters/FindChallengeBottomBar'
 
 //Am i going to to this boilerplate for every view?
 // TODO make a factory (or other pattnern) to populate component data
@@ -73,19 +74,19 @@ export default function Genesispt2() {
                   : 'Waiting for you to write and run the script...'}
               </h2>
             </div>
-            <div className="flex border-t border-white/25 pt-4 pl-6 pb-[30px] text-[18px] sm:flex-col md:flex-row md:pl-5 md:pt-0 md:pb-0">
+            {!success && (
+            <div className="flex border-t h-16 border-white/25 pt-4 pl-6 pb-[30px] text-[18px] sm:flex-col md:flex-row md:pl-5 md:pt-0 md:pb-0">
               <button className="flex grow items-center gap-2 transition duration-150 ease-in-out hover:opacity-75">
                 <span className="flex h-7 w-7 items-center justify-center rounded bg-white">
                   <PlayIcon className="text-black" />
                 </span>
                 Run the script
               </button>
-              <BoxButton
-                href="/chapters/chapter-1/transacting/"
-                disabled={!success}
-                size="big"
-              >Next</BoxButton>
             </div>
+            )}
+            {success && (
+              <FindChallengeBottomBar input={"true"} expected={"true"} next="/chapters/chapter-1/transacting/" />
+            )}
           </div>
         </div>
       </div>

--- a/app/chapters/[slug]/transacting/transacting-1/page.tsx
+++ b/app/chapters/[slug]/transacting/transacting-1/page.tsx
@@ -6,6 +6,7 @@ import { BoxButton } from 'components/ui/BoxButton'
 import { useState } from 'react'
 import clsx from 'clsx'
 import RICIBs from 'react-individual-character-input-boxes'
+import { FindChallengeBottomBar, Status } from 'components/chapters/FindChallengeBottomBar'
 
 const inputAmount = 40
 const answer = '6a127461636f7320666f722065766572796f6e65'
@@ -24,24 +25,7 @@ function getTx2() {
 export default function Genesispt2() {
   const genesis = getTx2()
 
-  const [correctAnswer, setCorrectAnswer] = useState(false)
-
-  function disableNext() {
-    setCorrectAnswer(false)
-  }
-
-  function enableNext() {
-    setCorrectAnswer(true)
-  }
-
-  // Todo use a more nextjs13 way of validating
-  const validateInput = (string) => {
-    if (string == answer) {
-      enableNext()
-    } else {
-      disableNext()
-    }
-  }
+  const [userInput, setUserInput] = useState('')
 
   return (
     <div className="flex w-screen grow flex-col items-center px-6 lg:px-0">
@@ -67,7 +51,7 @@ export default function Genesispt2() {
             <RICIBs
               amount={inputAmount}
               autoFocus
-              handleOutputString={validateInput}
+              handleOutputString={str => setUserInput(str)}
               inputProps={{
                 className: 'bg-transparent',
                 placeholder: '_',
@@ -88,36 +72,7 @@ export default function Genesispt2() {
           </div>
         </div>
       </div>
-      <div className="w-screen border-t border-white/25">
-        <div className="flex items-center">
-          <div
-            className={clsx(
-              'flex w-full items-center px-5 align-middle transition duration-150 ease-in-out',
-              {
-                'bg-success/25': correctAnswer,
-              }
-            )}
-          >
-            <h2
-              className={clsx(
-                'font-nunito text-[21px] text-white opacity-50 transition duration-150 ease-in-out',
-                {
-                  'opacity-100': correctAnswer,
-                }
-              )}
-            >
-              {correctAnswer
-                ? 'Challenge completed!'
-                : 'Complete the challenge above to continue'}
-            </h2>
-          </div>
-          <BoxButton
-            href="/chapters/chapter-1/transacting/transacting-2"
-            disabled={!correctAnswer}
-            size="big"
-          >Next</BoxButton>
-        </div>
-      </div>
+      <FindChallengeBottomBar next="/chapters/chapter-1/transacting/transacting-2" full input={userInput} expected={answer} />
     </div>
   )
 }

--- a/app/chapters/[slug]/transacting/transacting-2/page.tsx
+++ b/app/chapters/[slug]/transacting/transacting-2/page.tsx
@@ -6,6 +6,7 @@ import Terminal from 'components/Terminal'
 import clsx from 'clsx'
 import { SignUpModal } from 'components/chapters/SignUpModal'
 import PlayIcon from 'public/assets/icons/play.svg'
+import { FindChallengeBottomBar } from 'components/chapters/FindChallengeBottomBar'
 
 //Am i going to to this boilerplate for every view?
 // TODO make a factory (or other pattnern) to populate component data
@@ -22,7 +23,6 @@ export default function Genesispt2() {
   const genesis = getTx2()
 
   const [lines, setLines] = useState([])
-  const [openModal, setOpenModal] = useState(false)
   const [success, setSuccess] = useState(false);
   const [answer, setAnswer] = useState('')
 
@@ -35,28 +35,15 @@ export default function Genesispt2() {
       const scriptSig = Buffer.from(scriptSigHex, 'hex').toString('utf8')
       setLines((lines) => [...lines, scriptSig])
 
+      console.log(scriptSigHex)
+
       if (scriptSigHex === '6a127461636f7320666f722065766572796f6e65') {
         setTimeout(() => {
-          setOpenModal(true)
           setSuccess(true)
         }, 1000)
         setAnswer(scriptSig)
       }
     }
-  }
-
-  function onSignUp(data) {
-    window.localStorage.setItem('user', JSON.stringify({
-      publicKey: data.keyPair.publicKey,
-      privateKey: data.keyPair.privateKey,
-      avatar: data.avatar,
-      progress: {
-        chapter: 'transacting',
-        lesson: 'transacting-2',
-      }
-    }))
-
-    setOpenModal(false)
   }
 
   return (
@@ -85,6 +72,7 @@ export default function Genesispt2() {
                   : 'Waiting for you to write and run the script...'}
               </h2>
             </div>
+            {!success && (
             <div className="flex border-t border-white/25 pt-4 pl-6 pb-[30px] text-[18px] sm:flex-col md:flex-row md:pl-5 md:pt-0 md:pb-0">
               <button className="flex grow items-center gap-2 py-5 transition duration-150 ease-in-out hover:opacity-75">
                 <span className="flex h-7 w-7 items-center justify-center rounded bg-white">
@@ -92,8 +80,11 @@ export default function Genesispt2() {
                 </span>
                 Run the script
               </button>
-              <SignUpModal onConfirm={onSignUp} onClose={() => setOpenModal(false)} open={openModal} />
             </div>
+            )}
+            {success && (
+              <FindChallengeBottomBar next="/" input={"true"} expected={"true"} />
+            )}
           </div>
         </div>
       </div>

--- a/components/chapters/FindChallengeBottomBar.tsx
+++ b/components/chapters/FindChallengeBottomBar.tsx
@@ -1,0 +1,62 @@
+import clsx from "clsx";
+import { BoxButton } from "components/ui/BoxButton";
+import { useMediaQuery } from "react-responsive";
+import CheckIcon from 'public/assets/icons/check.svg';
+
+export enum Status {
+    InProgress,
+    Error,
+    Success
+}
+export function FindChallengeBottomBar({ next, input, expected, successMsg, inProgressMsg, errorMsg, full }: { next: string, input: string, expected: string, successMsg?: string, inProgressMsg?: string, errorMsg?: string, full?: boolean }) {
+  const isSmallScreen = useMediaQuery({ query: '(max-width: 767px)' })
+
+    function getStatus() {
+        if (!input) return Status.InProgress;
+        if (input === expected) return Status.Success;
+        return Status.Error;
+    }
+
+    return (
+      <div className={`
+          ${full ? 'w-screen' : 'w-full'}
+          ${getStatus() === Status.Success ? 'bg-success/25' : 'bg-black/20'}
+          border-t
+          border-white/25
+          max-md:px-4
+          max-md:py-8
+        `}>
+        <div className="
+            flex
+            flex-col
+            md:flex-row
+            items-stretch
+            justify-between
+            max-md:gap-4
+          ">
+          <div
+            className='flex w-full items-center align-middle transition duration-150 ease-in-out md:px-5'
+          >
+            <p
+              className={clsx(
+                'font-nunito text-[21px] text-white transition duration-150 ease-in-out',
+                {
+                  'opacity-50': getStatus() === Status.InProgress,
+                }
+              )}
+            >
+              {getStatus() === Status.Success
+                ? successMsg || <span className="flex"><CheckIcon className='mr-2'/> Nicely done!</span>
+                : getStatus() === Status.InProgress ? inProgressMsg || 'Complete the challenge above to continue...'
+                : getStatus() === Status.Error ? errorMsg || 'Hm... that is not quite right yet...' : ''}
+            </p>
+          </div>
+          <BoxButton
+            href={next}
+            disabled={getStatus() !== Status.Success}
+            size={!isSmallScreen ? 'big' : null}
+          >Next</BoxButton>
+        </div>
+      </div>
+    );
+}

--- a/public/assets/icons/check.svg
+++ b/public/assets/icons/check.svg
@@ -1,0 +1,3 @@
+<svg width="29" height="29" viewBox="0 0 29 29" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.26562 16.4612L13.5983 21.7677L22.7323 8.23438" stroke="white" stroke-width="1.93333" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Fixes #70
Fixes #59

This PR adds a `FindChallengeBottomBar` that now handles the input validation with the props `input` and `expected`. I think it makes the user input validation flow easier.

![image](https://user-images.githubusercontent.com/22493292/211296328-db6237fd-de06-48ac-87f6-b5eb02ce5add.png)
![image](https://user-images.githubusercontent.com/22493292/211296358-7dbe4c98-636b-437f-96e8-16e4c27f094a.png)
![image](https://user-images.githubusercontent.com/22493292/211296380-cda197d8-3241-4595-9853-2291368fecb4.png)

![image](https://user-images.githubusercontent.com/22493292/211314555-122791d9-13ad-411d-ba61-0bb583b6c8a1.png)
![image](https://user-images.githubusercontent.com/22493292/211314605-c3b77192-acfb-40a7-bff3-18b381f257ab.png)
