### PR TITLE
Adding green and tiny styles to the BoxButton

### DIFF
--- a/app/chapters/[slug]/genesis/genesis-pt2/page.tsx
+++ b/app/chapters/[slug]/genesis/genesis-pt2/page.tsx
@@ -65,7 +65,7 @@ export default function Genesispt2() {
             <div className="flex justify-center border-t border-white/25 bg-black/[.15] p-[20px] md:justify-start">
               <h2
                 className={clsx('font-space-mono text-[18px] text-white/50', {
-                  'bg-success/25': success,
+                  'bg-green/25': success,
                   'opacity-50': !success,
                 })}
               >

--- a/app/chapters/[slug]/transacting/transacting-2/page.tsx
+++ b/app/chapters/[slug]/transacting/transacting-2/page.tsx
@@ -63,7 +63,7 @@ export default function Genesispt2() {
             <div className="flex justify-center border-t border-white/25 bg-black/[.15] p-[20px] md:justify-start">
               <h2
                 className={clsx('font-space-mono text-[18px] text-white/50', {
-                  'bg-success/25': success,
+                  'bg-green/25': success,
                   'opacity-50': !success,
                 })}
               >

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -3,7 +3,7 @@ import { BoxButton } from './ui/BoxButton'
 export const Hero = () => {
   return (
     <div className="homepage-img -mt-20 flex grow items-end justify-center bg-cover bg-fixed bg-[-10em] md:bg-[0]">
-      <div className="flex w-screen flex-col justify-center bg-gradient-to-b from-base-blue/0 to-base-blue/100 p-10 font-cbrush text-white">
+      <div className="flex w-screen flex-col justify-center bg-gradient-to-b from-back/0 to-back/100 p-10 font-cbrush text-white">
         <h1 className="text-center text-6xl sm:text-7xl lg:text-8xl">
           Saving Satoshi
         </h1>

--- a/components/chapters/LoginModal.tsx
+++ b/components/chapters/LoginModal.tsx
@@ -81,7 +81,7 @@ export const LoginModal = (props) => {
   return (
     <Modal
       isOpen={props.open}
-      className="font-nunito top-1/2 left-1/2 outline-none p-5 transform -translate-x-1/2 -translate-y-1/2 absolute w-[32rem] rounded-lg shadow-lg bg-[var(--back)] text-white"
+      className="font-nunito top-1/2 left-1/2 outline-none p-5 transform -translate-x-1/2 -translate-y-1/2 absolute w-[32rem] rounded-lg shadow-lg bg-back text-white"
       contentLabel="Login Modal"
     >
       <div className="float-right flex justify-end">

--- a/components/chapters/SignUpModal.tsx
+++ b/components/chapters/SignUpModal.tsx
@@ -41,7 +41,7 @@ export const SignUpModal = (props) => {
   return (
     <Modal
       isOpen={props.open}
-      className="top-1/2 left-1/2 outline-none p-5 transform -translate-x-1/2 -translate-y-1/2 absolute w-[32rem] rounded-lg shadow-lg bg-[var(--back)] text-white"
+      className="top-1/2 left-1/2 outline-none p-5 transform -translate-x-1/2 -translate-y-1/2 absolute w-[32rem] rounded-lg shadow-lg bg-back text-white"
       contentLabel="Example Modal">
 
         <div className="float-right flex justify-end">

--- a/components/ui/BoxButton.tsx
+++ b/components/ui/BoxButton.tsx
@@ -24,14 +24,23 @@ export const BoxButton = ({ href, children, title, style, size, disabled, extern
     } else {
       className += ' text-white hover:bg-black/50'
     }
+  } else if(style == 'green') {
+    // Green background with opacity, green text
+    className += ' bg-green/20'
+
+    if(disabled) {
+      className += ' text-green/50'
+    } else {
+      className += ' text-green hover:bg-green/25'
+    }
   } else {
     // Filled white background, dark text
     className += ''
 
     if(disabled) {
-      className += ' bg-white text-[var(--back)] opacity-50'
+      className += ' bg-white text-back opacity-50'
     } else {
-      className += ' bg-white text-[var(--back)] hover:bg-white/75'
+      className += ' bg-white text-back hover:bg-white/75'
     }
   }
 
@@ -43,6 +52,8 @@ export const BoxButton = ({ href, children, title, style, size, disabled, extern
   // Apply size classes
   if(size == 'small') {
     className += ' text-xl py-2.5'
+  } else if(size == 'tiny') {
+    className += ' text-sm py-2'
   } else if(size == 'big') {
     className += ' text-2xl py-4'
   } else {

--- a/components/ui/Tooltip.tsx
+++ b/components/ui/Tooltip.tsx
@@ -41,9 +41,9 @@ export const Tooltip = ({
   }) => {
     const nodeRef = useRef(null);
 
-    let classes = 'absolute bg-[var(--back)] border border-white pointer-events-none shadow-lg shadow-black/25 transition ease-in-out duration-250'
+    let classes = 'absolute bg-back border border-white pointer-events-none shadow-lg shadow-black/25 transition ease-in-out duration-250'
     let arrowDirection = null
-    let arrowClasses = "relative flex flex-col items-center px-5 py-2 after:content-[''] after:w-3 after:h-3 after:absolute after:bg-[var(--back)]"
+    let arrowClasses = "relative flex flex-col items-center px-5 py-2 after:content-[''] after:w-3 after:h-3 after:absolute after:bg-back"
 
     if(position == 'above-left') {
       classes += ' -top-full left-0'

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,20 +3,21 @@
 @tailwind utilities;
 
 :root {
-  --back: #324760;
+  --back: 50, 71, 96; /* Theme background color (#324760) */
+  --green: 40, 177, 35; /* Success color (#28B123) */
   --terminal-output: #3DCFEF;
 }
 
 .-theme-purple {
-  --back: #4D2859;
+  --back: 77, 40, 89; /* #4D2859 */
 }
 
 .-theme-red {
-  --back: #6F272D;
+  --back: 111, 39, 45; /* #6F272D */
 }
 
 .-theme-brown {
-  --back: #524445;
+  --back: 82, 68, 69; /* #524445 */
 }
 
 html {
@@ -118,7 +119,7 @@ modules, extending theme perhaps ????
 
 @layer base {
   body {
-    @apply bg-base-blue;
+    @apply bg-back;
   }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,8 +5,27 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        'base-blue': '#293A60',
-        success: '#28b123',
+        back: ({ opacityVariable, opacityValue }) => {
+          if (opacityValue !== undefined) {
+            return `rgba(var(--back), ${opacityValue})`
+          }
+          if (opacityVariable !== undefined) {
+            return `rgba(var(--back), var(${opacityVariable}, 1))`
+          }
+          return `rgb(var(--back))`
+        },
+        green: ({ opacityVariable, opacityValue }) => {
+          if (opacityValue !== undefined) {
+            return `rgba(var(--green), ${opacityValue})`
+          }
+          if (opacityVariable !== undefined) {
+            return `rgba(var(--green), var(${opacityVariable}, 1))`
+          }
+          return `rgb(var(--green))`
+        },
+      },
+      opacity: {
+        '15': '0.15'
       },
       fontFamily: {
         cbrush: ['var(--cbrush-font)'],


### PR DESCRIPTION
Both styles are needed for the copy button in the Signup modal.

Learned a bit about Tailwind here that results in some tweaks. To get opacity with color variables, there needs to be a color transform function in the Tailwind config, so I added that. This way we also don't need to use color variables in Tailwind classes anymore, as the transform adds those.

Also replaced two existing color definitions with our new variable-based ones.