### PR TITLE
Fix signup, login and logout logic in the NavBar

### DIFF
--- a/components/chapters/LoginModal.tsx
+++ b/components/chapters/LoginModal.tsx
@@ -65,7 +65,7 @@ export const LoginModal = (props) => {
   }
 
   function copy() {
-    navigator.clipboard.writeText(userPrivateKey)
+    navigator.clipboard.writeText(user.privateKey)
     setCopied(true)
 
     setTimeout(() => {

--- a/components/chapters/LoginModal.tsx
+++ b/components/chapters/LoginModal.tsx
@@ -60,6 +60,7 @@ export const LoginModal = (props) => {
     window.localStorage.removeItem('user');
     window.localStorage.removeItem('loggedIn');
 
+    props.onClearProgress();
     props.onClose();
   }
 

--- a/components/chapters/SignUpModal.tsx
+++ b/components/chapters/SignUpModal.tsx
@@ -29,6 +29,19 @@ export const SignUpModal = (props) => {
   let [copied, setCopied] = useState(false)
   let [avatar, setAvatar] = useState(1)
 
+  function saveLocally() {
+    window.localStorage.setItem('user', JSON.stringify({
+      publicKey: keyPair.publicKey,
+      privateKey: keyPair.privateKey,
+      avatar: avatar,
+      progress: {
+        chapter: 'chapter-1',
+        lesson: 'genesis',
+      }
+    }))
+    window.localStorage.setItem('loggedIn', "true");
+  }
+
   function copy() {
     navigator.clipboard.writeText(keyPair.privateKey.toString(16))
     setCopied(true)
@@ -36,6 +49,12 @@ export const SignUpModal = (props) => {
     setTimeout(() => {
       setCopied(false)
     }, 2000)
+  }
+
+  function confirm() {
+    saveLocally()
+
+    props.onConfirm({ keyPair, avatar })
   }
 
   return (
@@ -98,7 +117,7 @@ export const SignUpModal = (props) => {
         recovered if you lose it.
       </p>
       <button
-        onClick={() => props.onConfirm({ keyPair, avatar })}
+        onClick={confirm}
         className="mt-4 w-full rounded-md border border-white px-4 py-2 text-white"
       >
         I’ve copied and backed up my code

--- a/components/ui/NavBar.tsx
+++ b/components/ui/NavBar.tsx
@@ -6,12 +6,14 @@ import { siteConfig } from 'config/site'
 import { NavItem } from 'types'
 import { useEffect, useState } from 'react'
 import { LoginModal } from 'components/chapters/LoginModal';
+import { SignUpModal } from 'components/chapters/SignUpModal';
 import Image from 'next/image';
 import User from 'public/assets/icons/avatar.svg';
 import { Avatar } from './Avatar';
 
 export const Navbar = ({ items }: { items: NavItem[] }) => {
   const [openSignInModal, setOpenSignInModal] = useState(false)
+  const [openSignUpModal, setOpenSignUpModal] = useState(false)
   const [loggedIn, setLoggedIn] = useState(false)
   const [user, setUser] = useState<any>({});
 
@@ -21,10 +23,7 @@ export const Navbar = ({ items }: { items: NavItem[] }) => {
   }, [])
 
   useEffect(() => {
-    const user = window.localStorage.getItem('user');
-    if (user) {
-      setUser(JSON.parse(user));
-    }
+    updateUser()
   }, [loggedIn])
 
   function onLogin() {
@@ -32,9 +31,39 @@ export const Navbar = ({ items }: { items: NavItem[] }) => {
     setLoggedIn(true)
   }
 
+  function updateUser() {
+    const userData = window.localStorage.getItem('user');
+    if (userData && userData.length > 0) {
+      setUser(JSON.parse(userData));
+    }
+  }
+
+  function onClearProgress() {
+    setUser(null)
+  }
+
   function onLogout() {
     window.localStorage.removeItem('loggedIn');
     setLoggedIn(false);
+  }
+
+  function onSignupConfirm() {
+    updateUser()
+    setLoggedIn(true)
+    setOpenSignUpModal(false)
+  }
+
+  function toggleModal(show) {
+    if (user && user.publicKey) {
+      setOpenSignInModal(show)
+    } else {
+      setOpenSignUpModal(show)
+    }
+  }
+
+  function hideModals() {
+    setOpenSignInModal(false)
+    setOpenSignUpModal(false)
   }
 
   return (
@@ -47,7 +76,7 @@ export const Navbar = ({ items }: { items: NavItem[] }) => {
           <h1 className="text-xl md:text-3xl">{siteConfig.name}</h1>
         </Link>
         <nav className="flex text-xl md:text-2xl">
-        {items?.length ? (
+          {items?.length ? (
             items?.map((item, idx) => (
               <Link
                 key={idx}
@@ -57,29 +86,36 @@ export const Navbar = ({ items }: { items: NavItem[] }) => {
                 {item.title}
               </Link>
             ))
-        ) : null}
-        {}
-        {!loggedIn && <button onClick={() => setOpenSignInModal(true)} className="text-grey-300 w-10 h-10 ml-4 cursor-pointer">
+          ) : null}
+
+          {!loggedIn && <button onClick={() => toggleModal(true)} className="text-grey-300 w-10 h-10 ml-4 cursor-pointer">
             <User />
-        </button>}
-        
-        {loggedIn && <button onClick={() => setOpenSignInModal(true)} className="text-grey-300 w-10 h-10 ml-4 cursor-pointer">
+          </button>}
+
+          {loggedIn && <button onClick={() => setOpenSignInModal(true)} className="text-grey-300 w-10 h-10 ml-4 cursor-pointer">
             <Avatar
-              avatar={JSON.parse(window.localStorage.getItem('user')).avatar}
+              avatar={user.avatar}
               size={30}
-          />
-        </button>}
+            />
+          </button>}
         </nav>
 
       </div>
 
-      <LoginModal 
+      <LoginModal
         signedIn={loggedIn}
         user={user}
         onLogin={onLogin}
         onLogout={onLogout}
         open={openSignInModal}
-        onClose={() => setOpenSignInModal(false)} 
+        onClearProgress={onClearProgress}
+        onClose={() => hideModals()}
+      />
+
+      <SignUpModal
+        onConfirm={onSignupConfirm}
+        open={openSignUpModal}
+        onClose={() => hideModals()}
       />
     </div>
   )


### PR DESCRIPTION
This logic was not properly working before, so users could not smoothly sign up, log out, back in, clear progress, etc.

**How to test:**
Sign up, log out, log back in, log back out, and then clear your user data again.

1. Clear your local storage (`user` and `loggedIn` items)
2. Go to the home page
3. Click account button in the top-right corner
4. In the sign-up modal, pick an avatar, copy your code and click the button at the bottom to close it
5. The account button in the nav bar should now should your avatar
6. Click it again to see the login modal stating that you are logged in
7. Click "Sign out"
8. The account button in the nav bar should now should the outline icon again
9. Click it again to see the login modal in the login state
10. Log in with the code you copied previously
11. The modal should show the "You're logged in now" state - click "Continue"
12. The account button in the nav bar should now should your avatar
13. Click it again and sign out again, then click the avatar icon again
14. Click "Clear saved progress" at the bottom
15. The modal disappears and the account icon switches to the outline icon again

Good luck 😀