### PR TITLE
Add link to bitcoin.design to README, link inline to channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Now be quick, Satoshi needs you!
 
 ## Contributing
 
-To contribute to the project, use issues and discussions in this GitHub repo (`saving-satoshi/saving-satoshi`), or join our Slack channel in the Bitcoin Design Community here:
-https://bitcoindesign.slack.com/archives/C0442BRGJ5U
+To contribute to the project, use issues and discussions in this GitHub repo (`saving-satoshi/saving-satoshi`), or join [our Slack channel](https://bitcoindesign.slack.com/archives/C0442BRGJ5U) in the [Bitcoin Design Community](https://bitcoin.design/).
+
 
 Generally, we have four tracks in this project:
 


### PR DESCRIPTION
The direct link to the Slack channel only works if the user is a member of bitcoindesign.slack.com. Otherwise they get an error and have to track down the invite link on the https://bitcoin.design/ website. I added a link to hopefully make it more intuitive.

Alternative changes could be:

- Link directly with the Slack invite URL. Not ideal if the invite link expires or changes in the future.
- Explain how to join the Bitcoin Design Slack in this section. This may be overkill.
