### PR TITLE
Template for Chapter Intro

### DIFF
--- a/app/chapters/[slug]/page.tsx
+++ b/app/chapters/[slug]/page.tsx
@@ -1,58 +1,10 @@
-import Image from 'next/image'
-import {
-  allChapters,
-  Chapter,
-  Introduction,
-  allIntroductions,
-} from 'contentlayer/generated'
-import { BoxButton } from 'components/ui/BoxButton'
-
-//TODO define better load
-
-async function _getIntro(slug: string) {
-  const intro = await allIntroductions.find(
-    (intro: Introduction) => intro.slugAsParams === slug
-  )
-  return intro
-}
-
-async function getIntro(slug: string) {
-  const chapter = await allChapters.find(
-    (chapter: Chapter) => chapter.slugAsParams === slug
-  )
-  const intro = await _getIntro(chapter.intro[0])
-  return intro
-}
+import ChapterIntroLayout from "components/templates/ChapterIntro/ChapterIntroLayout"
 
 export default async function Page({ params }) {
-  const intro = await getIntro(params.slug)
   return (
-    <div className="flex w-screen grow">
-      <div className="flex grow justify-center px-6 lg:px-0">
-        <div className="flex w-full shrink basis-1/2 justify-start text-white ">
-          <div className="flex flex-col content-center justify-items-start px-1 py-1 sm:p-10 sm:py-1">
-            <div
-              dangerouslySetInnerHTML={{ __html: intro.body.html }}
-              className="intro pt-8"
-            ></div>
-            <div className="mt-8">
-              <BoxButton
-                href="/chapters/chapter-1/genesis"
-              >Start</BoxButton>
-            </div>
-          </div>
-        </div>
-        <div className="flex shrink basis-1/2 justify-center border-l border-white/25">
-          <Image
-            src={intro.image}
-            alt={intro.title}
-            width={1440}
-            height={715}
-            layout="responsive"
-            objectFit="cover"
-          />
-        </div>
-      </div>
-    </div>
+    <ChapterIntroLayout 
+      slug={params.slug}
+      next="/chapters/chapter-1/genesis"
+    />
   )
 }

--- a/components/chapters/ChaptersNavbar.tsx
+++ b/components/chapters/ChaptersNavbar.tsx
@@ -10,7 +10,7 @@ import ArrowLeftIcon from 'public/assets/icons/arrow-left.svg'
 export const ChaptersNavbar = ({ items, slug }) => {
   const router = useRouter()
   return (
-    <div className="left-0 top-0 w-screen">
+    <div className="left-0 top-0 w-full">
       <div className="flex items-stretch justify-between border-b border-white/80 text-white">
         <div className="flex items-stretch">
           <button

--- a/components/templates/ChapterIntro/ChapterIntroLayout.tsx
+++ b/components/templates/ChapterIntro/ChapterIntroLayout.tsx
@@ -1,28 +1,25 @@
 'use client'
 
- import { allLessons, Lesson } from 'contentlayer/generated'
- import { useState, useEffect } from 'react'
- import { useMediaQuery } from 'react-responsive'
- import { BoxButton } from 'components/ui/BoxButton'
- import Image from 'next/image'
- import {
+import { BoxButton } from 'components/ui/BoxButton'
+import Image from 'next/image'
+import {
   allChapters,
   Chapter,
   Introduction,
   allIntroductions,
 } from 'contentlayer/generated'
 
- /**
-  * @slug {string} for fetching challenge data
-  * @next {string} link to next part of chapter
-  */
- export default function ChapterIntroLayout({ 
-  slug, 
-  next
- } : {
-  slug : string,
-  next : string
- }) {
+/**
+* @slug {string} for fetching challenge data
+* @next {string} link to next part of chapter
+*/
+export default function ChapterIntroLayout({ 
+    slug, 
+    next
+  } : {
+    slug : string,
+    next : string
+  }) {
   function _getIntro(slug: string) {
     const intro = allIntroductions.find(
       (intro: Introduction) => intro.slugAsParams === slug
@@ -39,75 +36,34 @@
   }
 
   const intro =  getIntro(slug)
-  const [hydrated, setHydrated] = useState(false);
-  const isSmallScreen = useMediaQuery({ query: '(max-width: 767px)' })
 
-   useEffect(() => {
-   	setHydrated(true);
-   }, []);
-
-   return (hydrated &&(
-   <>
-     {
-     isSmallScreen ? (
-      <div className="
-      flex
-      w-full
-      grow
-      flex-col
-      ">
-        <Image
-          src={intro.image}
-          alt={intro.title}
-          width={600}
-          height={600}
-          className="w-full h-full object-cover"
-        />
+  return (
+    <div className="flex w-full grow">
+      <div className="lg:flex lg:grow lg:justify-center lg:px-0">
+        <div className="lg:order-last lg:flex lg:shrink lg:basis-1/2 lg:justify-center lg:border-l lg:border-white/25">
+          <Image
+            src={intro.image}
+            alt={intro.title}
+            width={600}
+            height={600}
+            className="w-full h-full object-cover"
+          />
+        </div>
         <div className="flex w-full shrink basis-1/2 justify-start text-white ">
-            <div className="flex flex-col content-center justify-items-start mx-[15px]">
-              <div
-                dangerouslySetInnerHTML={{ __html: intro.body.html }}
-                className="intro my-10"
-              ></div>
-              <div className="mb-10">
-                <BoxButton
-                  href={next}
-                  classes="w-full"
-                >Start</BoxButton>
-              </div>
+          <div className="flex flex-col content-center justify-items-start mx-[15px] lg:mx-10 ">
+            <div
+              dangerouslySetInnerHTML={{ __html: intro.body.html }}
+              className="intro my-10"
+            ></div>
+            <div className="mb-10">
+              <BoxButton
+                href={next}
+                classes="w-full"
+              >Start</BoxButton>
             </div>
-          </div>
-      </div>
-     ) : (
-      <div className="flex w-screen grow">
-        <div className="flex grow justify-center px-0">
-          <div className="flex w-full shrink basis-1/2 justify-start text-white ">
-            <div className="flex flex-col content-center justify-items-start px-1 py-1 sm:p-10 sm:py-1">
-              <div
-                dangerouslySetInnerHTML={{ __html: intro.body.html }}
-                className="intro pt-8"
-              ></div>
-              <div className="mt-8">
-                <BoxButton
-                  href={next}
-                >Start</BoxButton>
-              </div>
-            </div>
-          </div>
-          <div className="flex shrink basis-1/2 justify-center border-l border-white/25">
-            <Image
-              src={intro.image}
-              alt={intro.title}
-              width={1440}
-              height={715}
-              layout="responsive"
-              objectFit="cover"
-            />
           </div>
         </div>
       </div>
-     )
-     }
-   </>
-   ))
+    </div>
+  )
  }

--- a/components/templates/ChapterIntro/ChapterIntroLayout.tsx
+++ b/components/templates/ChapterIntro/ChapterIntroLayout.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+ import { allLessons, Lesson } from 'contentlayer/generated'
+ import { useState, useEffect } from 'react'
+ import { useMediaQuery } from 'react-responsive'
+ import { BoxButton } from 'components/ui/BoxButton'
+ import Image from 'next/image'
+ import {
+  allChapters,
+  Chapter,
+  Introduction,
+  allIntroductions,
+} from 'contentlayer/generated'
+
+ /**
+  * @slug {string} for fetching challenge data
+  * @next {string} link to next part of chapter
+  */
+ export default function ChapterIntroLayout({ 
+  slug, 
+  next
+ } : {
+  slug : string,
+  next : string
+ }) {
+  function _getIntro(slug: string) {
+    const intro = allIntroductions.find(
+      (intro: Introduction) => intro.slugAsParams === slug
+    )
+    return intro
+  }
+  
+  function getIntro(slug: string) {
+    const chapter = allChapters.find(
+      (chapter: Chapter) => chapter.slugAsParams === slug
+    )
+    const intro = _getIntro(chapter.intro[0])
+    return intro
+  }
+
+  const intro =  getIntro(slug)
+  const [hydrated, setHydrated] = useState(false);
+  const isSmallScreen = useMediaQuery({ query: '(max-width: 767px)' })
+
+   useEffect(() => {
+   	setHydrated(true);
+   }, []);
+
+   return (hydrated &&(
+   <>
+     {
+     isSmallScreen ? (
+      <div className="
+      flex
+      w-full
+      grow
+      flex-col
+      ">
+        <Image
+          src={intro.image}
+          alt={intro.title}
+          width={600}
+          height={600}
+          className="w-full h-full object-cover"
+        />
+        <div className="flex w-full shrink basis-1/2 justify-start text-white ">
+            <div className="flex flex-col content-center justify-items-start mx-[15px]">
+              <div
+                dangerouslySetInnerHTML={{ __html: intro.body.html }}
+                className="intro my-10"
+              ></div>
+              <div className="mb-10">
+                <BoxButton
+                  href={next}
+                  classes="w-full"
+                >Start</BoxButton>
+              </div>
+            </div>
+          </div>
+      </div>
+     ) : (
+      <div className="flex w-screen grow">
+        <div className="flex grow justify-center px-0">
+          <div className="flex w-full shrink basis-1/2 justify-start text-white ">
+            <div className="flex flex-col content-center justify-items-start px-1 py-1 sm:p-10 sm:py-1">
+              <div
+                dangerouslySetInnerHTML={{ __html: intro.body.html }}
+                className="intro pt-8"
+              ></div>
+              <div className="mt-8">
+                <BoxButton
+                  href={next}
+                >Start</BoxButton>
+              </div>
+            </div>
+          </div>
+          <div className="flex shrink basis-1/2 justify-center border-l border-white/25">
+            <Image
+              src={intro.image}
+              alt={intro.title}
+              width={1440}
+              height={715}
+              layout="responsive"
+              objectFit="cover"
+            />
+          </div>
+        </div>
+      </div>
+     )
+     }
+   </>
+   ))
+ }

--- a/components/templates/ChapterIntro/ChapterIntroLayout.tsx
+++ b/components/templates/ChapterIntro/ChapterIntroLayout.tsx
@@ -38,27 +38,27 @@ export default function ChapterIntroLayout({
   const intro =  getIntro(slug)
 
   return (
-    <div className="flex w-full grow">
-      <div className="lg:flex lg:grow lg:justify-center lg:px-0">
-        <div className="lg:order-last lg:flex lg:shrink lg:basis-1/2 lg:justify-center lg:border-l lg:border-white/25">
+    <div className="flex grow">
+      <div className="lg:flex lg:grow">
+        <div className="lg:order-last lg:flex lg:shrink lg:basis-1/2 lg:border-l lg:border-white/25">
           <Image
             src={intro.image}
             alt={intro.title}
             width={600}
             height={600}
-            className="w-full h-full object-cover"
+            className="w-full object-cover"
           />
         </div>
-        <div className="flex w-full shrink basis-1/2 justify-start text-white ">
-          <div className="flex flex-col content-center justify-items-start mx-[15px] lg:mx-10 ">
+        <div className="flex shrink basis-1/2">
+          <div className="flex flex-col px-[15px] lg:px-10 py-10 gap-10">
             <div
               dangerouslySetInnerHTML={{ __html: intro.body.html }}
-              className="intro my-10"
+              className="intro text-white"
             ></div>
-            <div className="mb-10">
+            <div>
               <BoxButton
                 href={next}
-                classes="w-full"
+                classes="w-full sm:w-auto"
               >Start</BoxButton>
             </div>
           </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,7 +32,7 @@ module.exports = {
         cbrush: ['var(--cbrush-font)'],
         'space-mono': ['var(--space-mono-font)'],
         nunito: ['var(--nunito-font)'],
-      },
+      }
     },
   },
   plugins: [],


### PR DESCRIPTION
Resolved #64 

Template for Chapter Intro page. Changed https://github.com/saving-satoshi/saving-satoshi/blob/master/components/chapters/ChaptersNavbar.tsx#L13 `w-screen` to `w-full` as it was causing horizontal scrolling.

Props required:
- `slug`: for fetching Intro data
- `Next`: link to the next part of the chapter

Screenshot:
<img width="363" alt="Screenshot 2023-01-22 at 7 00 10 AM" src="https://user-images.githubusercontent.com/54861487/213896601-97826a78-1097-4866-9623-0fecec0ffa62.png">
<img width="366" alt="Screenshot 2023-01-22 at 7 00 02 AM" src="https://user-images.githubusercontent.com/54861487/213896608-fc3e9c2f-2bc6-4f68-bd21-389f3642fb41.png">

