### PR TITLE
Horizontal Scrolling fix for Chapters and About page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -5,7 +5,7 @@ import { BoxButton } from 'components/ui/BoxButton'
 
 export default function About() {
   return (
-    <div className="w-screen">
+    <div className="w-full">
       <Navbar items={sectionsConfig.mainNav} />
       <div className="m-auto px-6 lg:w-9/12 2xl:w-1/2">
         <div className="flex flex-col justify-center text-white">

--- a/app/chapters/page.tsx
+++ b/app/chapters/page.tsx
@@ -6,7 +6,7 @@ import { Chapters } from './chapters'
 export default async function ChaptersPage() {
   return (
     <>
-      <div className="w-screen">
+      <div className="w-full">
         <Navbar items={sectionsConfig.mainNav} />
         <div className="lg:px-0">
           <div className="flex flex-col justify-center text-white">

--- a/components/ui/Footer.tsx
+++ b/components/ui/Footer.tsx
@@ -2,7 +2,7 @@ import { siteConfig } from 'config/site'
 
 export const Footer = () => {
   return (
-    <div className="h-auto w-screen">
+    <div className="h-auto w-full">
       <div className="flex flex-col items-center justify-center px-6 py-4 text-white sm:flex-row">
         <p className="p-1">
           An open-source production by the bitcoin community.

--- a/components/ui/NavBar.tsx
+++ b/components/ui/NavBar.tsx
@@ -64,7 +64,7 @@ export const Navbar = ({ items }: { items: NavItem[] }) => {
   }
 
   return (
-    <div className="absolute left-0 top-0 w-screen">
+    <div className="absolute left-0 top-0 w-full">
       <div className="m-auto flex items-center justify-between px-6 py-4 text-white">
         <Link
           href="/"


### PR DESCRIPTION
Fixes #99 

Changed `w-screen` to `w-full` to fix the horizontal Scrolling issue on the Chapters and About pages.

Screenshots:
Before:
<img width="1512" alt="Screenshot 2023-01-26 at 5 32 01 AM" src="https://user-images.githubusercontent.com/54861487/214721410-6bedfe45-8f33-45dd-8a6d-6214df124ee7.png">
Now:
<img width="1512" alt="Screenshot 2023-01-26 at 5 31 54 AM" src="https://user-images.githubusercontent.com/54861487/214721434-ccb92e50-ca54-471c-b7ca-a9ac685fa3c3.png">
Before:
<img width="1512" alt="Screenshot 2023-01-26 at 5 31 48 AM" src="https://user-images.githubusercontent.com/54861487/214721441-88e0ac65-a3db-4336-b438-7ce9f258f117.png">
Now:
<img width="1512" alt="Screenshot 2023-01-26 at 5 31 41 AM" src="https://user-images.githubusercontent.com/54861487/214721445-ee3d97c6-1581-49bc-9c25-7cb78ade4dbf.png">
