### PR TITLE
Template for Terminal Challenge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 # next.js
 /.next/
 /out/
+/.contentlayer/
 
 # production
 /build

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 # next.js
 /.next/
 /out/
-/.contentlayer/
 
 # production
 /build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-  "typescript.tsdk": "node_modules\\typescript\\lib",
+  "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true
 }

--- a/content/lessons/genesis/genesis-2.tsx
+++ b/content/lessons/genesis/genesis-2.tsx
@@ -31,7 +31,12 @@ export default function Genesis2() {
         <Text className="text-lg">{`Use the following command to decode Satoshi's secret HEX message
             into ASCII, a more human readable format:`}</Text>
 
-        <CodeExample code={'echo scriptSigHex | xxd -r -p'} language="shell" />
+        <div className="mb-[30px]">
+          <CodeExample
+            code={'echo scriptSigHex | xxd -r -p'}
+            language="shell"
+          />
+        </div>
 
         <Tips>
           <Tip title="What was the scriptSigHex value again?">

--- a/content/lessons/genesis/genesis-2.tsx
+++ b/content/lessons/genesis/genesis-2.tsx
@@ -1,65 +1,30 @@
 'use client'
 
-import { useState } from 'react'
 import {
   CopyButton,
   CodeExample,
-  Lesson,
   LessonInfo,
-  LessonTerminal,
   Title,
   Text,
   Tips,
   Tip,
+  TerminalChallenge,
 } from 'ui'
 
-import { setUserProgress } from 'lib/user'
-import { getUserLessonStatus } from 'lib/content'
-import { LessonDirection } from 'types'
-
-function saveProgress() {
-  const status = getUserLessonStatus('chapter-1', 'transacting')
-
-  if (!status.completed) {
-    setUserProgress('chapter-1', 'transacting')
-  }
-}
-
 export default function Genesis2() {
-  const [answer, setAnswer] = useState('')
-  const [success, setSuccess] = useState(false)
-  const [lines, setLines] = useState([
-    {
-      value: 'Enter your commands here and press Enter...',
-      type: 'output',
-    },
-  ])
-
-  const onChange = (value) => {
-    setLines((lines) => [...lines, { value, type: 'input' }])
-
-    // echo scriptSigHex | xxd -r -p
-    if (value.startsWith('echo') && value.endsWith('| xxd -r -p')) {
-      const scriptSigHex = value.split(' ')[1]
-      const scriptSig = Buffer.from(scriptSigHex, 'hex').toString('utf8')
-      setLines((lines) => [...lines, { value: scriptSig, type: 'output' }])
-
-      if (
-        scriptSigHex ===
-        '04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73'
-      ) {
-        setTimeout(() => {
-          saveProgress()
-          setSuccess(true)
-        }, 1000)
-
-        setAnswer(scriptSig)
-      }
-    }
-  }
-
   return (
-    <Lesson direction={LessonDirection.Horizontal}>
+    <TerminalChallenge
+      expectedInput={
+        '04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73'
+      }
+      saveInfo={{
+        chapter: 'chapter-1',
+        challenge: 'transacting',
+      }}
+      next={'/chapters/chapter-1/transacting'}
+      instruction="Waiting for you to write and run the script...."
+      successMessage="That’s correct! Nice work. We don’t know why tacos were so important to the anonymous sender of this transaction, but here we are. Some more lesson and story copy here..."
+    >
       <LessonInfo>
         <Title>{`Let's make sense of this`}</Title>
 
@@ -84,15 +49,7 @@ export default function Genesis2() {
           </Tip>
         </Tips>
       </LessonInfo>
-
-      <LessonTerminal
-        success={success}
-        answer={answer}
-        lines={lines}
-        onChange={onChange}
-        next="/chapters/chapter-1/transacting"
-      />
-    </Lesson>
+    </TerminalChallenge>
   )
 }
 

--- a/content/lessons/transacting/transacting-2.tsx
+++ b/content/lessons/transacting/transacting-2.tsx
@@ -1,48 +1,19 @@
 'use client'
 
-import { useState } from 'react'
-import {
-  Lesson,
-  LessonInfo,
-  CodeExample,
-  Text,
-  Title,
-  LessonTerminal,
-} from 'ui'
-import { LessonDirection } from 'types'
+import { LessonInfo, CodeExample, Text, Title, TerminalChallenge } from 'ui'
 
 export default function Transacting2() {
-  const [lines, setLines] = useState([
-    {
-      value: 'Enter your commands here and press Enter...',
-      type: 'output',
-    },
-  ])
-  const [success, setSuccess] = useState(false)
-  const [answer, setAnswer] = useState('')
-
-  function onChange(input) {
-    setLines((lines) => [...lines, { value: input, type: 'input' }])
-
-    // echo scriptSigHex | xxd -r -p
-    if (input.startsWith('echo') && input.endsWith('| xxd -r -p')) {
-      const scriptSigHex = input.split(' ')[1]
-      const scriptSig = Buffer.from(scriptSigHex, 'hex').toString('utf8')
-      setLines((lines) => [...lines, { value: scriptSig, type: 'output' }])
-
-      console.log(scriptSigHex)
-
-      if (scriptSigHex === '6a127461636f7320666f722065766572796f6e65') {
-        setTimeout(() => {
-          setSuccess(true)
-        }, 1000)
-        setAnswer(scriptSig)
-      }
-    }
-  }
-
   return (
-    <Lesson direction={LessonDirection.Horizontal}>
+    <TerminalChallenge
+      expectedInput={'6a127461636f7320666f722065766572796f6e65'}
+      saveInfo={{
+        chapter: 'chapter-1',
+        challenge: 'done',
+      }}
+      next="/chapters/chapter-1/done"
+      instruction="Waiting for you to write and run the script...."
+      successMessage="jtacos for everyone"
+    >
       <LessonInfo>
         <Title>Another secret message</Title>
 
@@ -55,22 +26,16 @@ export default function Transacting2() {
           the previous exercise.
         </Text>
 
-        <Text>And remember, ’Bitcoin is for everyone’.</Text>
+        <Text className="text-lg">
+          And remember, ’Bitcoin is for everyone’.
+        </Text>
 
         <CodeExample
           code={'echo scriptPubKeyHex | xxd -r -p'}
           language="shell"
         />
       </LessonInfo>
-
-      <LessonTerminal
-        answer={answer}
-        success={success}
-        onChange={onChange}
-        lines={lines}
-        next="/chapters/chapter-1/done"
-      />
-    </Lesson>
+    </TerminalChallenge>
   )
 }
 

--- a/ui/lesson/Lesson.tsx
+++ b/ui/lesson/Lesson.tsx
@@ -21,12 +21,12 @@ export default function Lesson(props) {
   return (
     <LessonContext.Provider value={context}>
       {direction === LessonDirection.Horizontal && (
-        <div className="justify-stretch grid w-full grow grid-cols-1 px-6 md:grid-cols-2 lg:px-0">
+        <div className="justify-stretch grid w-full grow grid-cols-1 md:grid-cols-2 lg:px-0">
           {props.children}
         </div>
       )}
       {direction === LessonDirection.Vertical && (
-        <div className="flex w-full grow flex-col items-center justify-center">
+        <div className="flex w-full grow flex-col md:items-center md:justify-center">
           {props.children}
         </div>
       )}

--- a/ui/lesson/Terminal.tsx
+++ b/ui/lesson/Terminal.tsx
@@ -4,11 +4,30 @@ import clsx from 'clsx'
 import React from 'react'
 import ReactTerminal, { ColorMode, TerminalOutput } from 'react-terminal-ui'
 import PlayIcon from 'public/assets/icons/play.svg'
-import { StatusBar } from 'ui'
+import { StatusBar, useLessonContext } from 'ui'
+import { LessonView } from 'types'
 
-export default function Terminal({ success, answer, lines, next, onChange }) {
+export default function Terminal({
+  success,
+  answer,
+  lines,
+  next,
+  onChange,
+  successMessage,
+  instruction,
+}) {
+  const { activeView } = useLessonContext()
+  const isActive = activeView === LessonView.Code
   return (
-    <div className="flex grow flex-col border-white/25 font-space-mono text-white md:border-l">
+    <div
+      className={clsx(
+        'flex grow flex-col border-white/25 font-space-mono text-white md:border-l',
+        {
+          'hidden md:flex': !isActive,
+          flex: isActive,
+        }
+      )}
+    >
       <div className="flex grow flex-col items-stretch text-white">
         <div className="flex grow">
           <ReactTerminal
@@ -38,9 +57,7 @@ export default function Terminal({ success, answer, lines, next, onChange }) {
               'opacity-50': !success,
             })}
           >
-            {success
-              ? answer
-              : 'Waiting for you to write and run the script...'}
+            {success ? successMessage : instruction}
           </h2>
         </div>
 

--- a/ui/lesson/TerminalChallenge.tsx
+++ b/ui/lesson/TerminalChallenge.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { LessonDirection } from 'types'
+import { Lesson, LessonTabs, LessonTerminal } from 'ui'
+import { useMediaQuery } from 'react-responsive'
+import { setUserProgress } from 'lib/user'
+import { getUserLessonStatus } from 'lib/content'
+
+const tabData = [
+  {
+    id: 'info',
+    text: 'Info',
+  },
+  {
+    id: 'code',
+    text: 'Code',
+  },
+]
+
+/**
+ * @expectedInput {string} answer to the challenge problem
+ * @saveInfo {chapter, challenge} information required for saving user progress
+ * @next {string} link to next part of chapter
+ * @instruction {string} terminal instruction for user
+ * @successMessage {string} Message displayed to the user upon finishing a challenge
+ */
+export default function TerminalChallenge({
+  children,
+  expectedInput,
+  saveInfo,
+  next,
+  instruction,
+  successMessage,
+}) {
+  const [hydrated, setHydrated] = useState(false)
+  const [answer, setAnswer] = useState('')
+  const [success, setSuccess] = useState(false)
+  const [lines, setLines] = useState([
+    {
+      value: 'Enter your commands here and press Enter...',
+      type: 'output',
+    },
+  ])
+
+  const isSmallScreen = useMediaQuery({ query: '(max-width: 767px)' })
+
+  function saveProgress() {
+    const status = getUserLessonStatus(saveInfo.chapter, saveInfo.challenge)
+
+    if (!status.completed) {
+      setUserProgress(saveInfo.chapter, saveInfo.challenge)
+    }
+  }
+
+  const onChange = (input) => {
+    setLines((lines) => [...lines, { value: input, type: 'input' }])
+
+    if (input.startsWith('echo') && input.endsWith('| xxd -r -p')) {
+      const givenInput = input.split(' ')[1]
+      const answerValue = Buffer.from(givenInput, 'hex').toString('utf8')
+      setLines((lines) => [...lines, { value: answerValue, type: 'output' }])
+
+      if (givenInput === expectedInput) {
+        setTimeout(() => {
+          saveProgress()
+          setSuccess(true)
+        }, 1000)
+        setAnswer(answerValue)
+      }
+    }
+  }
+
+  useEffect(() => {
+    setHydrated(true)
+  }, [])
+
+  return (
+    hydrated && (
+      <Lesson
+        direction={
+          isSmallScreen ? LessonDirection.Vertical : LessonDirection.Horizontal
+        }
+      >
+        <LessonTabs items={tabData} classes="px-4 py-2 w-full" stretch={true} />
+        {children}
+
+        <LessonTerminal
+          success={success}
+          answer={answer}
+          lines={lines}
+          onChange={onChange}
+          successMessage={successMessage}
+          instruction={instruction}
+          next={next}
+        />
+      </Lesson>
+    )
+  )
+}

--- a/ui/lesson/index.ts
+++ b/ui/lesson/index.ts
@@ -3,6 +3,7 @@ import LessonInfo from './Info'
 import LessonPrompt from './Prompt'
 import LessonTerminal from './Terminal'
 import LessonTabs from './Tabs'
+import TerminalChallenge from './TerminalChallenge'
 
 export {
   Lesson,
@@ -11,4 +12,5 @@ export {
   LessonTerminal,
   LessonTabs,
   useLessonContext,
+  TerminalChallenge
 }


### PR DESCRIPTION
Fixes #67, Fixes #68 

- Created a Template for Terminal-based Challenges
- Implemented the template for Chapter 1, challenge 1, part 2 and Chapter 1, challenge 2, part 2
- Props required by the template 
  - `expectedInput` : answer to the challenge problem
  - `saveInfo` : information required for saving user progress
  - `next` : link to next part of chapter
  - `instruction` : terminal instruction for user
  - `successMessage` : Message displayed to the user upon finishing a challenge

Screenshots:
<img width="200" alt="Screenshot 2023-02-02 at 6 33 32 PM" src="https://user-images.githubusercontent.com/54861487/216332481-053d1112-e3b0-46ff-a6f1-294af9815bdd.png">
<img width="200" alt="Screenshot 2023-02-02 at 6 33 17 PM" src="https://user-images.githubusercontent.com/54861487/216332495-ed8caa66-3223-4b12-ba1e-269039c02c22.png">
