### PR TITLE
Input Area Max-width

### DIFF
--- a/ui/common/Input.tsx
+++ b/ui/common/Input.tsx
@@ -100,7 +100,7 @@ export default function Input({
         onChange={handleChange}
         value={textAreaValue}
         spellCheck="false"
-        className={`absolute top-0 left-0 h-full w-full resize-none overflow-hidden bg-transparent font-space-mono text-[18px] leading-[180%] tracking-[1px] text-transparent outline-none md:text-[30px] md:tracking-[5px]`}
+        className={`absolute top-0 left-0 h-full w-full max-w-[95vw] resize-none overflow-hidden bg-transparent font-space-mono text-[18px] leading-[180%] tracking-[1px] text-transparent outline-none md:text-[30px] md:tracking-[5px]`}
         style={{
           caretColor: '#6e7d92',
         }}
@@ -108,7 +108,7 @@ export default function Input({
       <p
         className={`${
           correctAnswer ? 'overlay-complete' : 'overlay-incomplete'
-        } pointer-events-none h-full w-full font-space-mono text-[18px] leading-[180%] tracking-[1px] text-inherit md:text-[30px] md:tracking-[5px]`}
+        } pointer-events-none h-full w-full max-w-[95vw] font-space-mono text-[18px] leading-[180%] tracking-[1px] text-inherit md:text-[30px] md:tracking-[5px]`}
         style={{
           lineBreak: 'anywhere',
         }}

--- a/ui/common/Input.tsx
+++ b/ui/common/Input.tsx
@@ -100,7 +100,7 @@ export default function Input({
         onChange={handleChange}
         value={textAreaValue}
         spellCheck="false"
-        className={`absolute top-0 left-0 h-full w-full max-w-[95vw] resize-none overflow-hidden bg-transparent font-space-mono text-[18px] leading-[180%] tracking-[1px] text-transparent outline-none md:text-[30px] md:tracking-[5px]`}
+        className={`absolute top-0 left-0 h-full w-full resize-none overflow-hidden break-all bg-transparent font-space-mono text-[18px] leading-[180%] tracking-[1px] text-transparent outline-none md:text-[30px] md:tracking-[5px]`}
         style={{
           caretColor: '#6e7d92',
         }}
@@ -108,7 +108,7 @@ export default function Input({
       <p
         className={`${
           correctAnswer ? 'overlay-complete' : 'overlay-incomplete'
-        } pointer-events-none h-full w-full max-w-[95vw] font-space-mono text-[18px] leading-[180%] tracking-[1px] text-inherit md:text-[30px] md:tracking-[5px]`}
+        } pointer-events-none h-full w-full break-all font-space-mono text-[18px] leading-[180%] tracking-[1px] text-inherit md:text-[30px] md:tracking-[5px]`}
         style={{
           lineBreak: 'anywhere',
         }}


### PR DESCRIPTION
Fixes #154 

Added max width of the screen to prevent any input from extending beyond the screen size.
[iPhone input screenshot](https://user-images.githubusercontent.com/108441023/219769902-41700422-ce19-4a81-8913-f1794cef8149.PNG)

[Input Preview](https://saving-satoshi-git-fork-benalleng-safariwidth-savingsatoshi.vercel.app/en/chapters/chapter-1/genesis-1)

With just an iPhone some more testing may be needed on a Mac but this particular safari bug seems to be solved

Tested on
Safari (iPhone)
Chrome (Windows)
firefox (Android)