### PR TITLE
Sanitize input before checking if valid for Terminal challenges

### DIFF
--- a/ui/lesson/TerminalChallenge.tsx
+++ b/ui/lesson/TerminalChallenge.tsx
@@ -73,29 +73,31 @@ export default function TerminalChallenge({
   }
 
   const onChange = (input) => {
-    setLines((lines) => [...lines, { value: input, type: 'input' }])
+    const sanitizedInput = input.replace(/[\t\r\n]/g, '')
+
+    setLines((lines) => [...lines, { value: sanitizedInput, type: 'input' }])
     setLines((lines) => [...lines, { value: '...decoding...', type: 'output' }])
 
     const inputs = [
       `echo ${expectedInput} | xxd -r -p`,
       `echo ${expectedInput.userVariable} | xxd -r -p`,
       `echo ${expectedInput.value} | xxd -r -p`,
-      `echo ${input.split(' ')[1]?.match(/^[\da-f]+$/i)} | xxd -r -p`,
+      `echo ${sanitizedInput.split(' ')[1]?.match(/^[\da-f]+$/i)} | xxd -r -p`,
     ]
     let varInput: string
     let answerValue: string
     let newLines: { value: string; type: string }[]
 
-    if (inputs.includes(input)) {
-      if (input === `echo ${expectedInput} | xxd -r -p`) {
+    if (inputs.includes(sanitizedInput)) {
+      if (sanitizedInput === `echo ${expectedInput} | xxd -r -p`) {
         varInput = expectedInput
       } else if (
-        input ===
+        sanitizedInput ===
         `echo ${expectedInput.userVariable || expectedInput.value} | xxd -r -p`
       ) {
         varInput = expectedInput.value
       } else {
-        varInput = input.split(' ')[1]
+        varInput = sanitizedInput.split(' ')[1]
       }
 
       answerValue = Buffer.from(varInput, 'hex').toString('utf8')
@@ -125,7 +127,7 @@ export default function TerminalChallenge({
           ])
         }, 750)
       }
-    } else if (commonError && input.includes(commonError.error)) {
+    } else if (commonError && sanitizedInput.includes(commonError.error)) {
       setTimeout(() => {
         setSuccess('false')
         setLines((lines) => {


### PR DESCRIPTION
## Summary
This PR should close #197. Added some logic that removes `\t`, `\r` and `\n` from the input before it compares it with the `expectedInput`.

## Checklist
- [x] Build was run locally and any changes were pushed
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title
- [x] Clean commit history