### PR TITLE
Replace btcmag link with bitcoin wiki

### DIFF
--- a/content/lessons/genesis/genesis-2/translations.ts
+++ b/content/lessons/genesis/genesis-2/translations.ts
@@ -4,7 +4,7 @@ export const translations = {
       title: 'Genesis',
       heading: 'Let’s make sense of this',
       waiting_for_input: 'Waiting for you to write and run the script...',
-      success: `Interesting! The message references a news article on the same day Satoshi mined the genesis block. This gives us an important clue about Satoshi's motivation for creating Bitcoin. You can read more about it <Link href="https://en.bitcoin.it/wiki/Genesis_block">here</Link>.`,
+      success: `Interesting! The message references a news article on the same day Satoshi mined the genesis block. This gives us an important clue about Satoshi's motivation for creating Bitcoin. You can read more about it <Link href="https://en.bitcoin.it/wiki/Genesis_block" className="underline">here</Link>.`,
     },
 
     nl: {

--- a/content/lessons/genesis/genesis-2/translations.ts
+++ b/content/lessons/genesis/genesis-2/translations.ts
@@ -4,7 +4,7 @@ export const translations = {
       title: 'Genesis',
       heading: 'Let’s make sense of this',
       waiting_for_input: 'Waiting for you to write and run the script...',
-      success: `Interesting! The message references a news article on the same day Satoshi mined the genesis block. This gives us an important clue about Satoshi's motivation for creating Bitcoin. You can read more about it <Link href="https://bitcoinmagazine.com/culture/ten-years-later-reflection-bitcoins-genesis-and-satoshis-timing" className="underline">here</Link>.`,
+      success: `Interesting! The message references a news article on the same day Satoshi mined the genesis block. This gives us an important clue about Satoshi's motivation for creating Bitcoin. You can read more about it <Link href="https://en.bitcoin.it/wiki/Genesis_block">here</Link>.`,
     },
 
     nl: {
@@ -12,7 +12,7 @@ export const translations = {
       heading: 'Laten we dit duidelijk maken',
       waiting_for_input: 'Wachten tot de script wordt uitgevoerd...',
       success:
-        'Interessant! Het bericht verwijst naar een nieuwsartikel dat op dezelfde dag dat Satoshi het genesis block heeft gemined, gepubliceerd is. Dit geeft ons een belangrijke aanwijzing over de motivatie van Satoshi voor het maken van Bitcoin. Je kunt er <Link href="https://bitcoinmagazine.com/culture/ten-years-later-reflection-bitcoins-genesis-and-satoshis-timing" className="underline">hier</Link> meer over lezen.',
+        'Interessant! Het bericht verwijst naar een nieuwsartikel dat op dezelfde dag dat Satoshi het genesis block heeft gemined, gepubliceerd is. Dit geeft ons een belangrijke aanwijzing over de motivatie van Satoshi voor het maken van Bitcoin. Je kunt er <Link href="https://en.bitcoin.it/wiki/Genesis_block" className="underline">hier</Link> meer over lezen.',
     },
   },
 }


### PR DESCRIPTION
This is a request by jonas to swap out the link to the bitcoin wiki.

## Pull Request checklist

Please review the below PR requirements:

- Build was run locally and any changes were pushed
- Ensure that the title clearly describes the changes
- Issue to be referenced in the PR description rather than in the commits or PR title
- Clean commit history