### PR TITLE
Add pointer to Tooltips

### DIFF
--- a/lib/translate.tsx
+++ b/lib/translate.tsx
@@ -115,7 +115,11 @@ function injectComponent(result, type, lang) {
       switch (type) {
         case ComponentType.Link: {
           parts.push(
-            <Link href={href} className={className} target="_blank">
+            <Link
+              href={href}
+              className={`${className} cursor-pointer`}
+              target="_blank"
+            >
               {label}
             </Link>
           )
@@ -131,7 +135,7 @@ function injectComponent(result, type, lang) {
             <Tooltip
               key={tkey}
               href={href}
-              className={className}
+              className={`${className} cursor-pointer`}
               content={tvalue}
             >
               {label}


### PR DESCRIPTION
Closes #218
now tooltips have a cursor pointer baked in, no need to add it to the translation