### PR TITLE
Changed the transaction in Chapter-1, Challenge-2

### DIFF
--- a/content/lessons/transacting/transacting-2/index.tsx
+++ b/content/lessons/transacting/transacting-2/index.tsx
@@ -9,7 +9,7 @@ export default function Transacting2({ lang }) {
 
   return (
     <InputChallenge
-      answer={'6a127461636f7320666f722065766572796f6e65'}
+      answer={'6a1c5361746f7368693433335061726b53744368696e6f43413933323433'}
       next={'/chapters/chapter-1/transacting-3'}
       label={t('transacting_two.input_challenge_label')}
       pattern={/[a-z0-9]+/gi}
@@ -22,13 +22,13 @@ export default function Transacting2({ lang }) {
 
         <CodeExample
           code={
-            '75764fd0c95b4c17b728d10f7555509adfc0789ddc47683c45aeddd1c34727f8'
+            'ee3b8caaeb58245338dd299467de89ec6833d2a4235493c95059934603b5e98d'
           }
           language={'string'}
         />
 
         <Button
-          href="https://blockstream.info/tx/75764fd0c95b4c17b728d10f7555509adfc0789ddc47683c45aeddd1c34727f8?expand"
+          href="https://blockstream.info/tx/ee3b8caaeb58245338dd299467de89ec6833d2a4235493c95059934603b5e98d?expand"
           external={true}
           classes="mt-4"
         >

--- a/content/lessons/transacting/transacting-3/index.tsx
+++ b/content/lessons/transacting/transacting-3/index.tsx
@@ -6,7 +6,9 @@ export default function Transacting3({ lang }) {
   const t = useTranslations(lang)
   return (
     <TerminalChallenge
-      expectedInput={'6a127461636f7320666f722065766572796f6e65'}
+      expectedInput={
+        '6a1c5361746f7368693433335061726b53744368696e6f43413933323433'
+      }
       saveInfo={{
         chapter: 'chapter-1',
         challenge: 'done',

--- a/content/lessons/transacting/transacting-3/translations.ts
+++ b/content/lessons/transacting/transacting-3/translations.ts
@@ -14,7 +14,7 @@ export const translations = {
         'Once you’ve found it, decode the hidden message, just like we did in the previous exercise.',
       paragraph_three: 'And remember, ’Bitcoin is for everyone’.',
       terminal_challenge_success:
-        'That’s correct! Nice work. We don’t know why tacos were so important to the anonymous sender of this transaction, but here we are. And it’s an admirable goal at least.',
+        'That’s correct! Nice work.\n\n As you can see, the clue is an address. Go to it.\n\n There you’ll find an abandoned warehouse with all the tools you need to fight BitRey and bring equilibrium back to bitcoin.\n\n Your next challenge awaits you.',
       terminal_challenge_lines:
         'Enter your commands here and press Enter...\n\n Note that $scriptPubKeyHex is not defined for you this time. You’ll need to replace this variable in the code with the value you found in the previous challenge',
       terminal_challenge_error:


### PR DESCRIPTION
Resolves #185 

- This PR replaces the transaction from `75764fd0c95b4c17b728d10f7555509adfc0789ddc47683c45aeddd1c34727f8` to `ee3b8caaeb58245338dd299467de89ec6833d2a4235493c95059934603b5e98d` in both parts of Chapter-1, Challenge-2.
- I have removed the following part from the success message.

```
...We don’t know why tacos were so important to the anonymous sender of this transaction, but here we are.
And it’s an admirable goal at least.
```

- This can later be replaced with a more appropriate success message.
