### PR TITLE
Fixes a few layout issues in lesson screens

### DIFF
--- a/app/[lang]/chapters/[slug]/[lesson]/layout.tsx
+++ b/app/[lang]/chapters/[slug]/[lesson]/layout.tsx
@@ -1,4 +1,4 @@
 import { chapters } from 'content'
 export default function Layout({ children }) {
-  return <div className="flex h-full grow flex-col">{children}</div>
+  return <div className="flex grow flex-col">{children}</div>
 }

--- a/ui/lesson/Info.tsx
+++ b/ui/lesson/Info.tsx
@@ -8,7 +8,7 @@ export default function LessonInfo({ children }) {
 
   if (direction === LessonDirection.Horizontal) {
     return (
-      <div className={clsx('w-full justify-center text-white')}>
+      <div className="grow justify-center text-white md:basis-1/3">
         <div className="flex h-full flex-col content-center justify-items-start gap-1 px-1 py-6 sm:px-12">
           {children}
         </div>

--- a/ui/lesson/Lesson.tsx
+++ b/ui/lesson/Lesson.tsx
@@ -21,9 +21,7 @@ export default function Lesson(props) {
   return (
     <LessonContext.Provider value={context}>
       {direction === LessonDirection.Horizontal && (
-        <div className="justify-stretch grid w-full grow grid-cols-1 md:grid-cols-2 lg:px-0">
-          {props.children}
-        </div>
+        <div className="flex grow flex-col md:flex-row">{props.children}</div>
       )}
       {direction === LessonDirection.Vertical && (
         <div className="flex w-full grow flex-col md:items-center md:justify-center">

--- a/ui/lesson/Terminal.tsx
+++ b/ui/lesson/Terminal.tsx
@@ -82,7 +82,7 @@ export default function Terminal({ success, lines, next, onChange }) {
   return (
     <div
       className={clsx(
-        'flex grow flex-col border-white/25 font-space-mono text-white md:border-l',
+        'flex grow flex-col border-white/25 font-space-mono text-white md:basis-1/3 md:border-l',
         {
           'hidden md:flex': !isActive,
           flex: isActive,


### PR DESCRIPTION
Replacing grid with flex layout to fix a few issues. Also removing some unnecessary Tailwind tags.

Should fix issue #214 and the problem pointed out in this comment: https://github.com/saving-satoshi/saving-satoshi/pull/146#issuecomment-1450874989

I'd recommend avoiding grid in favor of flex box. I only saw it in a few places in the codebase and on those a grid wasn't even used (meaning multiple rows and columns), but it's either a row a column. Safari follows an older spec in regards to height calculation, which caused one of the layout issue mentioned above.

Overall I also see a lot of unnecessary layout tags that have no effect. I wonder if everyone is clear on exactly how flexbox works. If not, I recommend [this guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/).

**[Live site](https://savingsatoshi.com/en/chapters/chapter-1/genesis-2):**
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/695901/223049110-fb500de1-e17a-4989-b8ed-de41a4ded43f.png">

**[Preview](https://saving-satoshi-git-feature-fix-lesson-layo-b18562-savingsatoshi.vercel.app/en/chapters/chapter-1/genesis-2):**
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/695901/223049158-a67871eb-27b5-4f97-986a-e76a0813c60f.png">

**Live site:**
<img width="574" alt="image" src="https://user-images.githubusercontent.com/695901/223049265-2bf944d9-b33c-4814-9235-bf432e18cff1.png">

**Preview:**
<img width="574" alt="image" src="https://user-images.githubusercontent.com/695901/223049327-0378f804-4327-4ffb-86d6-6c7a23c7626c.png">
