### PR TITLE
Remove lang param from home-button

### DIFF
--- a/components/Topbar.tsx
+++ b/components/Topbar.tsx
@@ -13,7 +13,7 @@ export default function Topbar({ items }: { items: NavItem[] }) {
     <div className="absolute left-0 top-0 w-full">
       <div className="flex items-center justify-between px-6 py-4 text-white sm:m-auto">
         <Link
-          href={`/${lang}`}
+          href={`/`}
           className="transition duration-150 ease-in-out hover:opacity-75"
         >
           <h1 className="text-xl sm:text-3xl">{siteConfig.name}</h1>


### PR DESCRIPTION
Now that our homepage doesn't need the `/en` in the url this can be removed when clicking the home-button in the TopBar for consistency