### PR TITLE
Fix: 404 for favicon and android-icon

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -45,6 +45,6 @@ export function middleware(request: NextRequest) {
 export const config = {
   // TODO: Find a way to handle these dynamically
   matcher: [
-    '/((?!_next/static|_next/image|assets|favicon.ico|manifest.json).*)',
+    '/((?!_next/static|_next/image|assets|favicon.ico|android-icon|favicon|manifest.json).*)',
   ],
 }


### PR DESCRIPTION
Fixes #222 (testing)

In firefox favicon and android-icon are being redirected to `/en