### PR TITLE
Ensure window is defined for useMediaQuery

### DIFF
--- a/hooks/useMediaQuery.ts
+++ b/hooks/useMediaQuery.ts
@@ -7,7 +7,7 @@ interface UseMediaQueryParams {
 
 export const useMediaQuery = ({ width }: UseMediaQueryParams): boolean => {
   const [isWidthMet, setIsWidthMet] = useState<boolean>(
-    window.innerWidth <= width
+    typeof window !== 'undefined' && window.innerWidth <= width
   )
 
   useEffect(() => {


### PR DESCRIPTION
Closes #264

when run locally the server no longer issues an error stating that the window is undefined.