### PR TITLE
Simplify templates for better reuseability

### DIFF
--- a/content/introductions/reaping-rewards/index.tsx
+++ b/content/introductions/reaping-rewards/index.tsx
@@ -6,8 +6,14 @@ export default function ReapingRewards({ lang }) {
 
   return (
     <Introduction lang={lang}>
-      <Text className="pt-2">{t('reaping_rewards.paragraph_one')}</Text>
-      <Text className="pt-2">{t('reaping_rewards.paragraph_two')}</Text>
+      <h1 className="font-cbrush text-5xl">{t('reaping_rewards.title')}</h1>
+      <h2 className="pt-3 font-nunito text-xl font-black">
+        {t('reaping_rewards.subtitle')}
+      </h2>
+      <div className="pt-3 font-nunito text-2xl">
+        <Text className="pt-2">{t('reaping_rewards.paragraph_one')}</Text>
+        <Text className="pt-2">{t('reaping_rewards.paragraph_two')}</Text>
+      </div>
     </Introduction>
   )
 }

--- a/ui/introduction/Introduction.tsx
+++ b/ui/introduction/Introduction.tsx
@@ -33,15 +33,7 @@ export default function Introduction({ children, lang }) {
         </div>
         <div className="flex shrink basis-1/2">
           <div className="flex flex-col gap-10 px-[15px] py-10 lg:px-10">
-            <div className="intro text-white">
-              <h1 className="font-cbrush text-5xl">
-                {t(intro.metadata.title)}
-              </h1>
-              <h2 className="pt-3 font-nunito text-xl font-black">
-                {t(intro.metadata.subtitle)}
-              </h2>
-              <div className="pt-3 font-nunito text-2xl">{children}</div>
-            </div>
+            <div className="intro text-white">{children}</div>
             <div>
               {chapter.metadata.lessons.length > 0 ? (
                 <Button


### PR DESCRIPTION
Some of the most recent copy PR's, #263, #266 are using a template but the template is still too limiting with what can be put in it so i removed some of the content from the template allowing them to be apart of the {children} in the content/index.ts route instead.
TODO:
Scope where else the templates can be simplified to aid in reuseability