### PR TITLE
Chapter 1, Challenge 2: Tweak block explorer link

### DIFF
--- a/app/chapters/[slug]/transacting/transacting-1/page.tsx
+++ b/app/chapters/[slug]/transacting/transacting-1/page.tsx
@@ -55,7 +55,7 @@ export default  function Genesispt2() {
                     ></div>
                     <div className='pb-16 pt-9'>
                         <Link
-                            href='https://blockstream.info/tx/75764fd0c95b4c17b728d10f7555509adfc0789ddc47683c45aeddd1c34727f8?expand'
+                            href='https://blockstream.info/tx/75764fd0c95b4c17b728d10f7555509adfc0789ddc47683c45aeddd1c34727f8'
                             className='py-2.5 px-12 w-full md:w-auto justify-center bg-white text-base-blue text-xl font-nunito font-bold'>
                             View transaction
                         </Link>


### PR DESCRIPTION
In chapter 1, challenge 2, there are explicit instructions to open up the transaction details (see instruction number 2):

![Screenshot from 2023-03-13 17-10-57](https://user-images.githubusercontent.com/1823216/224833192-431a43f1-62eb-47a9-8152-50e39ce33ec6.png)

However, the link we provide already has the details opened up. There are two ways we can smooth this out:

1. Remove instruction number 2 and don't tell the user to expand the details
2. Don't expand the transaction details for the user and have them do it themselves

I like the idea of not expanding the transaction details for the user because it teaches them that you can open transactions up and take a look inside :smile:. But I acknowledge that all block explorers are different and there are pro's to the other option of just having less instructions. Happy to go either way on this!