### PR TITLE
Chapter 1, Challenge 2: Tweak block explorer link

### DIFF
--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -201,7 +201,7 @@ const translations = {
     paragraph_one:
       'There’s another way to hide secret messages in transactions. Bitcoin has a special type of code called OP_RETURN that allows users to attach messages to transaction outputs. Let’s see if we can find one.',
     paragraph_two:
-      '1. Click <Link href="https://blockstream.info/tx/ee3b8caaeb58245338dd299467de89ec6833d2a4235493c95059934603b5e98d?expand" className="underline">here</Link> to look at a specific transaction.',
+      '1. Click <Link href="https://blockstream.info/tx/ee3b8caaeb58245338dd299467de89ec6833d2a4235493c95059934603b5e98d" className="underline">here</Link> to look at a specific transaction.',
     paragraph_three:
       '2. Open up the details and find the part that is of type “OP_RETURN”.',
     paragraph_four:


### PR DESCRIPTION
In chapter 1, challenge 2, there are explicit instructions to open up the transaction details (see instruction number 2):

![Screenshot from 2023-03-13 17-10-57](https://user-images.githubusercontent.com/1823216/224833192-431a43f1-62eb-47a9-8152-50e39ce33ec6.png)

However, the link we provide already has the details opened up. There are two ways we can smooth this out:

1. Remove instruction number 2 and don't tell the user to expand the details
2. Don't expand the transaction details for the user and have them do it themselves

I like the idea of not expanding the transaction details for the user because it teaches them that you can open transactions up and take a look inside :smile:. But I acknowledge that all block explorers are different and there are pro's to the other option of just having less instructions. Happy to go either way on this!