### PR TITLE
Make device agnostic copy in Ch. 1

### DIFF
--- a/content/lessons/chapter-1/transacting-3.tsx
+++ b/content/lessons/chapter-1/transacting-3.tsx
@@ -41,28 +41,6 @@ export default function Transacting3({ lang }) {
         <Text className="mt-2 text-lg md:text-xl">
           {t('chapter_one.transacting_three.paragraph_two')}
         </Text>
-
-        <CodeExample
-          className="mt-4"
-          code="echo $scriptPubKeyBytes | xxd -r -p"
-          language="shell"
-          copy
-        />
-
-        <Text className="mt-4 text-lg md:text-xl">
-          {t('chapter_one.transacting_three.paragraph_three')}
-        </Text>
-
-        <div className="mt-4 flex">
-          <Button
-            size="small"
-            href="https://blockstream.info/tx/ee3b8caaeb58245338dd299467de89ec6833d2a4235493c95059934603b5e98d?expand"
-            external={true}
-            classes="w-full md:auto"
-          >
-            {t('chapter_one.transacting_three.link')}
-          </Button>
-        </div>
       </LessonInfo>
     </TerminalChallenge>
   )

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -126,7 +126,7 @@ const translations = {
       paragraph_one:
         'The message you found was encoded in a format called HEX. Now we will run a command to turn it into ASCII, which we will be able to read.',
       paragraph_two:
-        'Copy and paste the command below into the Terminal in the code tab and press “Enter”.',
+        'Copy and paste the command below into the Terminal in the code block and press “Enter”.',
       terminal_challenge_lines: `Enter your commands here and press Enter...\n The variable $scriptSigHex is already defined for you.\n\n var $scriptSigHex = '04fff...e6b73'`,
       waiting_for_input: 'Waiting for you to write and run the script...',
       success: `Great work! The decoded message references the front page of <Link href="https://en.bitcoin.it/wiki/Genesis_block" className="underline">The Times</Link> from January 3,2009, the same day Satoshi mined the genesis block. How cool is that?! This message also gives us some insight into his motivation for creating bitcoin.\n\n Let's keep going.`,

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -111,7 +111,7 @@ const translations = {
         'Let’s find the very first block in the bitcoin blockchain. Click the button below to open a <Tooltip id="genesis_two_paragraph_one" content="genesis_two.tooltip_block_explorer" className="underline">block explorer</Tooltip>  exactly at block 0, which is called the genesis block.',
       paragraph_two:
         'Scroll down and expand the details on the one transaction that is stored in this block. Find the input called “Coinbase”. Now look for the label “SCRIPTSIG (<Tooltip id="genesis_two_paragraph_two" content="genesis_two.tooltip_hex" className="underline">HEX</Tooltip>)”. The value next to it is an encoded message.',
-      paragraph_three: 'Copy that value and paste it below.',
+      paragraph_three: 'Copy that value and paste it in the code block.',
       tooltip_block_explorer:
         'A <a href="https://bitcoinops.org/en/topics/block-explorers/" target="_blank" rel="noreferrer">block explorer</a> is a useful tool to quickly look up information about bitcoin transactions.',
       tooltip_hex:
@@ -126,7 +126,7 @@ const translations = {
       paragraph_one:
         'The message you found was encoded in a format called HEX. Now we will run a command to turn it into ASCII, which we will be able to read.',
       paragraph_two:
-        'Copy and paste the command below into the Terminal to the right and press “Enter”.',
+        'Copy and paste the command below into the Terminal in the code tab and press “Enter”.',
       terminal_challenge_lines: `Enter your commands here and press Enter...\n The variable $scriptSigHex is already defined for you.\n\n var $scriptSigHex = '04fff...e6b73'`,
       waiting_for_input: 'Waiting for you to write and run the script...',
       success: `Great work! The decoded message references the front page of <Link href="https://en.bitcoin.it/wiki/Genesis_block" className="underline">The Times</Link> from January 3,2009, the same day Satoshi mined the genesis block. How cool is that?! This message also gives us some insight into his motivation for creating bitcoin.\n\n Let's keep going.`,
@@ -160,7 +160,7 @@ const translations = {
       paragraph_four:
         '3. Now locate the “SCRIPTPUBKEY (ASM)” field. See the “OP_RETURN OP_PUSHBYTES_33" part? These are called opcodes. We’re actually interested in what comes after them.',
       paragraph_five:
-        '4. Copy the long string of numbers after “OP_RETURN OP_PUSHBYTES_33” and paste it below. ',
+        '4. Copy the long string of numbers after “OP_RETURN OP_PUSHBYTES_33” and paste it in the code block. ',
       input_challenge_label: 'Enter the OP_RETURN type',
     },
 
@@ -170,13 +170,11 @@ const translations = {
       paragraph_one:
         'We’ve identified the part of the transaction output that holds the message.',
       paragraph_two:
-        'All that’s left now is to decode it, just like we did in the previous exercise.',
-      paragraph_three: 'Need to look up $scriptPubKeyBytes again? Here you go.',
-      link: 'View transaction',
+        'All that’s left now is to decode it, just like we did in the previous exercise. You can look up the transaction again <Link href="https://blockstream.info/tx/ff9148605a772a51cba39004df5fb042d40515967a3e38ff5294cfd017c452a9?expand" className="underline">here</Link>.',
       terminal_challenge_success:
         'That’s correct! Nice work.\n\n As you can see, the clue is an address. Go to it.\n\n Your next challenge awaits you.',
       terminal_challenge_lines:
-        'Enter your commands here and press Enter...\n\n Note that $scriptPubKeyBytes is not defined for you this time. You’ll need to replace this variable in the code with the value you found in the previous challenge',
+        'Enter your commands here and press Enter...\n\n Command: \n echo $scriptPubKeyBytes | xxd -r -p \n\n Note that $scriptPubKeyBytes is not defined for you this time. You’ll need to replace this variable in the code with the value you found in the previous page',
       terminal_challenge_error:
         'Almost! Remember that the variable $scriptPubKeyBytes is not set for you this time.',
     },


### PR DESCRIPTION
closes #309

base on the issue there was only exact changes for transacting-3 but i tried my best to have good copy that made no mention of direction of desktop or mobile specific pointers. i went with "code block" as i believe that still directs the user to press the code tab button after reading this, but I believe that "code tab" could work if not trying even more to remove any directional pointers in the copy

genesis-2
![image](https://user-images.githubusercontent.com/108441023/230823014-20affedc-0e91-4ba8-a622-7267ea9b8bbb.png)

genesis-3
![image](https://user-images.githubusercontent.com/108441023/230823080-7708108f-ac64-43fe-8e08-9fed2f76a644.png)

transacting-2
![image](https://user-images.githubusercontent.com/108441023/230823124-0e54d304-c5a7-4e02-bccc-dab71dbc1207.png)

transacting-3
![image](https://user-images.githubusercontent.com/108441023/230823174-7e5c3da9-4686-4225-8098-b5cc2bdc54e4.png)


I am not sure if the copy changes go far enough in some cases, I had thought about simply saying copy "and paste" the value you found. and maybe try to make the code tab button more noticeable.
