### PR TITLE
Make all future languages work in langSwitch regex

### DIFF
--- a/components/Navbar/LangSwitch.tsx
+++ b/components/Navbar/LangSwitch.tsx
@@ -9,10 +9,9 @@ import { usePathData } from 'hooks'
 import clsx from 'clsx'
 import Link from 'next/link'
 
-const languageCodes = Object.keys(locales).join('|')
-const regexPattern = new RegExp(`^\\/${languageCodes}\\b`)
-
 function generateNewUrl(pathname, language) {
+  const languageCodes = Object.keys(locales).join('|')
+  const regexPattern = new RegExp(`^\\/${languageCodes}\\b`)
   const pathnameWithoutLanguage = pathname.replace(regexPattern, '')
   const newUrl = `/${language}${pathnameWithoutLanguage}`
   return newUrl


### PR DESCRIPTION
Solves an error where each language has to be added for each new language added to Saving Satoshi. This should prevent the 404 error when switching from new languages in #362 
