### PR TITLE
Only render dynamic <head> client-side for lesson page

### DIFF
--- a/app/[lang]/chapters/[slug]/[lesson]/page.tsx
+++ b/app/[lang]/chapters/[slug]/[lesson]/page.tsx
@@ -17,7 +17,7 @@ import { useProgressContext } from 'providers/ProgressProvider'
 import { Loader } from 'shared'
 import { LoadingState } from 'types'
 import { notFound } from 'next/navigation'
-import ClientOnly from 'components/ClientOnly'
+import Client from 'components/Client'
 
 export default function Page({ params }) {
   const searchParams = navigation.useSearchParams()
@@ -58,11 +58,11 @@ export default function Page({ params }) {
     const title = lesson ? t(lesson.metadata.title) : 'Page not found'
 
     return (
-      <ClientOnly>
+      <Client>
         <head>
           <title>{`${title} - Saving Satoshi`}</title>
         </head>
-      </ClientOnly>
+      </Client>
     )
   }
 

--- a/app/[lang]/chapters/[slug]/[lesson]/page.tsx
+++ b/app/[lang]/chapters/[slug]/[lesson]/page.tsx
@@ -17,6 +17,7 @@ import { useProgressContext } from 'providers/ProgressProvider'
 import { Loader } from 'shared'
 import { LoadingState } from 'types'
 import { notFound } from 'next/navigation'
+import ClientOnly from 'components/ClientOnly'
 
 export default function Page({ params }) {
   const searchParams = navigation.useSearchParams()
@@ -57,9 +58,11 @@ export default function Page({ params }) {
     const title = lesson ? t(lesson.metadata.title) : 'Page not found'
 
     return (
-      <head>
-        <title>{`${title} - Saving Satoshi`}</title>
-      </head>
+      <ClientOnly>
+        <head>
+          <title>{`${title} - Saving Satoshi`}</title>
+        </head>
+      </ClientOnly>
     )
   }
 

--- a/components/Client.tsx
+++ b/components/Client.tsx
@@ -7,7 +7,7 @@ import { PropsWithChildren, useEffect, useState } from 'react'
  * different than the initial hydration from the server. Examples are
  * when rendering things like times, which might be in a different timezone than the server
  */
-export default function ClientOnly({ children }: PropsWithChildren<unknown>) {
+export default function Client({ children }: PropsWithChildren<unknown>) {
   const [hasMounted, setHasMounted] = useState(false)
 
   useEffect(() => {

--- a/components/ClientOnly.tsx
+++ b/components/ClientOnly.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { PropsWithChildren, useEffect, useState } from 'react'
+
+/**
+ * Use this component when you need to render something that is going to be
+ * different than the initial hydration from the server. Examples are
+ * when rendering things like times, which might be in a different timezone than the server
+ */
+export default function ClientOnly({ children }: PropsWithChildren<unknown>) {
+  const [hasMounted, setHasMounted] = useState(false)
+
+  useEffect(() => {
+    setHasMounted(true)
+  }, [])
+
+  if (!hasMounted) {
+    return null
+  }
+
+  return <>{children}</>
+}


### PR DESCRIPTION
This PR fixes #445 by only rendering the `<head>` client-side. To accomplish this I added a `<Client>` component that we can use to wrap around other elements which should only render on the client-side.