### PR TITLE
Fix localStorage

### DIFF
--- a/api/local/getProgress.ts
+++ b/api/local/getProgress.ts
@@ -2,11 +2,13 @@ import { defaultProgressContext } from 'providers/ProgressProvider'
 
 export default async function getProgressLocal(): Promise<string> {
   try {
-    const res = localStorage.getItem('SavingSatoshiProgress')
+    const progress = localStorage.getItem('SavingSatoshiProgress')
 
-    if (!res) {
+    if (!progress) {
       throw new Error('Could not read progress from LocalStorage')
     }
+
+    const res = progress.replace(/['"]/g, '')
 
     return res
   } catch (errors) {


### PR DESCRIPTION
The localStorage fails to work on Master.

![image](https://github.com/saving-satoshi/saving-satoshi/assets/85434418/e8f2d067-d0b5-47b8-8353-b357bb2b750d)

![image](https://github.com/saving-satoshi/saving-satoshi/assets/85434418/b91a2be7-dc80-40fb-af47-341c3a1e267a)

This is due to `progressKey` being saved and read with the wrong quotation marks.

This PR fixes this issue.