### PR TITLE
New redirect logic to check for user progress

### DIFF
--- a/app/[lang]/chapters/[slug]/[lesson]/page.tsx
+++ b/app/[lang]/chapters/[slug]/[lesson]/page.tsx
@@ -104,8 +104,8 @@ export default function Page({ params }) {
     getLessonKey(pathData.chapterId, pathData.lessonId)
   )
   const isRestrictedFromLesson = !isLessonCompleted(
-    getLessonKey(pathData.chapterId, pathData.lessonId),
-    progress
+    progress,
+    getLessonKey(pathData.chapterId, pathData.lessonId)
   )
 
   if (

--- a/app/[lang]/chapters/[slug]/[lesson]/page.tsx
+++ b/app/[lang]/chapters/[slug]/[lesson]/page.tsx
@@ -7,8 +7,10 @@ import { usePathData, useTranslations } from 'hooks'
 import {
   getLastUnlockedLessonPath,
   getLessonKey,
+  getNextLessonKey,
   isLessonCompleted,
   isLessonUnlocked,
+  keys,
 } from 'lib/progress'
 
 import * as navigation from 'next/navigation'
@@ -98,7 +100,9 @@ export default function Page({ params }) {
   }
 
   const lastUnlockedLessonPath = getLastUnlockedLessonPath(progress)
-  const currentLessonPath = `/${pathData.pageId}/${pathData.chapterId}/${pathData.lessonId}`
+  const nextLessonKey = getNextLessonKey(
+    getLessonKey(pathData.chapterId, pathData.lessonId)
+  )
   const isRestrictedFromLesson = !isLessonCompleted(
     getLessonKey(pathData.chapterId, pathData.lessonId),
     progress
@@ -106,7 +110,7 @@ export default function Page({ params }) {
 
   if (
     unlocked === LoadingState.Failed &&
-    lastUnlockedLessonPath !== currentLessonPath &&
+    keys.indexOf(progress) <= keys.indexOf(nextLessonKey) - 1 &&
     isRestrictedFromLesson
   ) {
     return navigation.redirect(lastUnlockedLessonPath)

--- a/content/lessons/chapter-2/scripting-2.tsx
+++ b/content/lessons/chapter-2/scripting-2.tsx
@@ -4,6 +4,7 @@ import { ScriptingChallenge, LessonInfo } from 'ui'
 import { EditorConfig } from 'types'
 import { useTranslations } from 'hooks'
 import { Text } from 'ui'
+import { getLessonKey } from 'lib/progress'
 
 export const metadata = {
   title: 'chapter_two.scripting_one.title',
@@ -125,6 +126,7 @@ export default function Scripting2({ lang }) {
     <ScriptingChallenge
       lang={lang}
       config={config}
+      lessonKey={getLessonKey('chapter-2', 'scripting-2')}
       successMessage={t('chapter_two.scripting_two.success')}
     >
       <LessonInfo>

--- a/providers/ProgressProvider.tsx
+++ b/providers/ProgressProvider.tsx
@@ -35,6 +35,7 @@ export default function ProgressProvider({
     try {
       setIsLoading(true)
       const progress = await getProgress()
+      console.log(progress)
       setAccountProgress(progress)
     } catch (ex) {
       console.error(ex)
@@ -47,6 +48,7 @@ export default function ProgressProvider({
     try {
       setIsLoading(true)
       const progress = await getProgressLocal()
+      console.log(progress)
       setAccountProgress(progress)
     } catch (ex) {
       console.error(ex)

--- a/providers/ProgressProvider.tsx
+++ b/providers/ProgressProvider.tsx
@@ -47,7 +47,6 @@ export default function ProgressProvider({
     try {
       setIsLoading(true)
       const progress = await getProgressLocal()
-      console.log(progress)
       setAccountProgress(progress)
     } catch (ex) {
       console.error(ex)

--- a/providers/ProgressProvider.tsx
+++ b/providers/ProgressProvider.tsx
@@ -35,7 +35,6 @@ export default function ProgressProvider({
     try {
       setIsLoading(true)
       const progress = await getProgress()
-      console.log(progress)
       setAccountProgress(progress)
     } catch (ex) {
       console.error(ex)

--- a/ui/lesson/HashChallenge.tsx
+++ b/ui/lesson/HashChallenge.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx'
 import { useLang, useTranslations } from 'hooks'
 import { usePathname } from 'next/navigation'
 import { useProgressContext } from 'providers/ProgressProvider'
+import { useAuthContext } from 'providers/AuthProvider'
 
 /**
  * @answer {string} correct answer to the challenge problem
@@ -35,7 +36,8 @@ export default function HashChallenge({
   inProgressMessage?: string
   successMessage?: string
 }) {
-  const { saveProgress } = useProgressContext()
+  const { saveProgress, saveProgressLocal } = useProgressContext()
+  const { account } = useAuthContext()
   const lang = useLang()
   const t = useTranslations(lang)
   const pathName = usePathname() || ''
@@ -94,7 +96,11 @@ export default function HashChallenge({
     ) {
       inputRef.current?.blur()
       setSuccess(true)
-      saveProgress(lessonKey)
+      if (account) {
+        saveProgress(lessonKey)
+      } else {
+        saveProgressLocal(lessonKey)
+      }
     } else if (
       typeof answer === 'number' &&
       input.length < answer &&

--- a/ui/lesson/ScriptingChallenge/index.tsx
+++ b/ui/lesson/ScriptingChallenge/index.tsx
@@ -8,6 +8,8 @@ import Runner from './Runner'
 import { EditorConfig, LessonDirection } from 'types'
 import { Lesson, LessonTabs } from 'ui'
 import { useMediaQuery } from 'hooks'
+import { useProgressContext } from 'providers/ProgressProvider'
+import { useAuthContext } from 'providers/AuthProvider'
 
 const tabData = [
   {
@@ -27,14 +29,18 @@ const tabData = [
 export default function ScriptingChallenge({
   children,
   lang,
+  lessonKey,
   config,
   successMessage,
 }: {
   children?: React.ReactNode
   lang: string
+  lessonKey: string
   config: EditorConfig
   successMessage: string
 }) {
+  const { saveProgress, saveProgressLocal } = useProgressContext()
+  const { account } = useAuthContext()
   const [code, setCode] = useState(
     config.languages[config.defaultLanguage].defaultCode
   )
@@ -66,7 +72,11 @@ export default function ScriptingChallenge({
     const success = await config.languages[language].validate(answer)
 
     if (success) {
-      console.log('challenge complete')
+      if (account) {
+        saveProgress(lessonKey)
+      } else {
+        saveProgressLocal(lessonKey)
+      }
     }
 
     return success


### PR DESCRIPTION
Closes #457

This makes the redirect for locked lessons work only at the very end of the progress so a user should be allowed to freely roam around once they have completed a particular lesson