### PR TITLE
Change context menu color to match the background in chapter-2

### DIFF
--- a/ui/lesson/ScriptingChallenge/Editor.tsx
+++ b/ui/lesson/ScriptingChallenge/Editor.tsx
@@ -34,6 +34,7 @@ export default function Editor({
       inherit: true,
       rules: [],
       colors: {
+        'menu.background': '#66211FFF',
         'editor.background': '#00000000',
         'editor.lineHighlightBorder': '#00000000', // 4th channel is for transparency
       },


### PR DESCRIPTION
Resolves #473 

**Screenshot:**

|Dev|PR|
|-------|---|
|<img width="753" alt="image" src="https://github.com/saving-satoshi/saving-satoshi/assets/85434418/a787451b-60d8-4b08-8e75-fbb3c6816090">|<img width="753" alt="image" src="https://github.com/saving-satoshi/saving-satoshi/assets/85434418/49ff9277-3fa3-4fcd-988c-5ec2e95a9014">|

The color was chosen to minimize the difference between the gradient background color and the solid context menu color.
