### PR TITLE
Auto save progress at the end of Chapter

### DIFF
--- a/components/Navbar/NavbarDesktop/NavbarDesktop.tsx
+++ b/components/Navbar/NavbarDesktop/NavbarDesktop.tsx
@@ -12,7 +12,8 @@ import HelpLink from '../HelpLink'
 import Icon from 'shared/Icon'
 import { usePathData } from 'hooks'
 import { navbarThemeSelector } from 'lib/themeSelector'
-import { getChapterKey, keys } from 'lib/progress'
+import { getChapterKey, getCurrentLessonKey, keys } from 'lib/progress'
+import { useAuthContext } from 'providers/AuthProvider'
 
 export default function NavbarDesktop({ params }) {
   const { chaptersUrl } = useLocalizedRoutes()
@@ -20,10 +21,11 @@ export default function NavbarDesktop({ params }) {
   const t = useTranslations(lang)
   const { slug, lesson: lessonId } = params
   const { chapterId } = usePathData()
+  const { account } = useAuthContext()
 
   const chapterLessons = lessons?.[chapterId]
   const lesson = chapterLessons?.[lessonId]?.metadata ?? null
-  const currentLessonKey = lesson?.key ?? keys[0]
+  const currentLessonKey = getCurrentLessonKey(lesson?.key ?? keys[0], account)
 
   const chapterKey = getChapterKey(currentLessonKey)
 

--- a/components/Navbar/NavbarMobile/NavbarMobile.tsx
+++ b/components/Navbar/NavbarMobile/NavbarMobile.tsx
@@ -17,7 +17,8 @@ import Link from 'next/link'
 import HelpLink from '../HelpLink'
 import Icon from 'shared/Icon'
 import { navbarThemeSelector } from 'lib/themeSelector'
-import { getChapterKey, keys } from 'lib/progress'
+import { getChapterKey, getCurrentLessonKey, keys } from 'lib/progress'
+import { useAuthContext } from 'providers/AuthProvider'
 
 export default function NavbarMobile({ params }) {
   const { chaptersUrl } = useLocalizedRoutes()
@@ -25,12 +26,13 @@ export default function NavbarMobile({ params }) {
   const t = useTranslations(lang)
   const { chapterId } = usePathData()
   const { slug, lesson: lessonId } = params
+  const { account } = useAuthContext()
 
   const [isOpen, setIsOpen] = useState(false)
 
   const chapterLessons = lessons?.[chapterId]
   const lesson = chapterLessons?.[lessonId]?.metadata ?? null
-  const currentLessonKey = lesson?.key ?? keys[0]
+  const currentLessonKey = getCurrentLessonKey(lesson?.key ?? keys[0], account)
 
   const chapterKey = getChapterKey(currentLessonKey)
 

--- a/hooks/useSaveAndProceed.ts
+++ b/hooks/useSaveAndProceed.ts
@@ -23,7 +23,7 @@ export default function useSaveAndProceed() {
   const currentLessonKey = lesson?.key ?? 'CH1INT1'
 
   const saveAndProceed = async () => {
-    const nextLessonKey = getNextLessonKey(currentLessonKey)
+    const nextLessonKey = getNextLessonKey(currentLessonKey, account)
     const nextLessonPath = getNextLessonPath(currentLessonKey)
     const route = routes.chaptersUrl + nextLessonPath
 

--- a/hooks/useSaveAndReturn.ts
+++ b/hooks/useSaveAndReturn.ts
@@ -19,7 +19,7 @@ export default function useSaveAndReturn() {
   const currentLessonKey = lesson?.key ?? 'CH1INT1'
 
   const saveAndReturn = async () => {
-    const nextLessonKey = getNextLessonKey(currentLessonKey)
+    const nextLessonKey = getNextLessonKey(currentLessonKey, account)
     const chapterKey = getChapterKey(nextLessonKey)
 
     if (progress && !isLessonUnlocked(progress, nextLessonKey)) {

--- a/lib/progress.ts
+++ b/lib/progress.ts
@@ -167,8 +167,8 @@ export const getNextLessonKey = (
 }
 
 export const getNextChapterNumber = (userProgressKey: string): number => {
-  const curLessonNumber = parseInt(userProgressKey.slice(2, 3))
-  return curLessonNumber + 1
+  const currentLessonNumber = parseInt(userProgressKey.slice(2, 3))
+  return currentLessonNumber + 1
 }
 
 export const getNextLessonPath = (userProgressKey: string): string => {

--- a/lib/progress.ts
+++ b/lib/progress.ts
@@ -129,16 +129,30 @@ export const getLastUnlockedLessonPath = (userProgressKey: string): string => {
   return path
 }
 
-export const getNextLessonKey = (userProgressKey: string): string => {
+export const getNextLessonKey = (
+  userProgressKey: string,
+  account?: any
+): string => {
   const id = keys.indexOf(userProgressKey)
-  const result = keys[id + 1]
+  const nextChapterIntro = 'CH' + getNextChapterNumber(userProgressKey) + 'INT1'
 
-  if (!result) {
+  let result
+
+  if (account && keys[id + 2] && keys[id + 2] === nextChapterIntro) {
+    return nextChapterIntro
+  }
+
+  if (keys[id + 1]) {
+    return keys[id + 1]
+  } else {
     console.error('There is no next lesson')
     return userProgressKey
   }
+}
 
-  return result
+export const getNextChapterNumber = (userProgressKey: string): number => {
+  const curLessonNumber = parseInt(userProgressKey.slice(2, 3))
+  return curLessonNumber + 1
 }
 
 export const getNextLessonPath = (userProgressKey: string): string => {

--- a/lib/progress.ts
+++ b/lib/progress.ts
@@ -129,14 +129,30 @@ export const getLastUnlockedLessonPath = (userProgressKey: string): string => {
   return path
 }
 
+export const getCurrentLessonKey = (
+  userProgressKey: string,
+  account?: any
+): string => {
+  if (!account) {
+    return userProgressKey
+  }
+
+  const id = keys.indexOf(userProgressKey)
+  const nextChapterIntro = 'CH' + getNextChapterNumber(userProgressKey) + 'INT1'
+
+  if (keys[id + 1] && keys[id + 1] === nextChapterIntro) {
+    return nextChapterIntro
+  }
+
+  return userProgressKey
+}
+
 export const getNextLessonKey = (
   userProgressKey: string,
   account?: any
 ): string => {
   const id = keys.indexOf(userProgressKey)
   const nextChapterIntro = 'CH' + getNextChapterNumber(userProgressKey) + 'INT1'
-
-  let result
 
   if (account && keys[id + 2] && keys[id + 2] === nextChapterIntro) {
     return nextChapterIntro

--- a/lib/progress.ts
+++ b/lib/progress.ts
@@ -140,6 +140,10 @@ export const getCurrentLessonKey = (
   const id = keys.indexOf(userProgressKey)
   const nextChapterIntro = 'CH' + getNextChapterNumber(userProgressKey) + 'INT1'
 
+  // Explaination: If the following lesson exist, and is equal to
+  // the intro of next chapter, that means we are on the outro of
+  // the current lesson, and can skip it to appropriately mark the
+  // progress
   if (keys[id + 1] && keys[id + 1] === nextChapterIntro) {
     return nextChapterIntro
   }
@@ -154,10 +158,15 @@ export const getNextLessonKey = (
   const id = keys.indexOf(userProgressKey)
   const nextChapterIntro = 'CH' + getNextChapterNumber(userProgressKey) + 'INT1'
 
+  // Explaination: If account exist, and the next to next lesson
+  // is the Intro of next chapter, then that means, we are on the
+  // penultimate lesson of the current chapter and can skip the
+  // following lesson to get the next chapter's intro key.
   if (account && keys[id + 2] && keys[id + 2] === nextChapterIntro) {
     return nextChapterIntro
   }
 
+  // If the next lesson exist. Return next lesson's key.
   if (keys[id + 1]) {
     return keys[id + 1]
   } else {


### PR DESCRIPTION
This PR addresses part-1 of #480 

> Auto-save progress at the end of the chapter. Make it reusable so we can continue to add it as we add more chapters.


<h3>Description:</h3>

Once the user reaches the final outro of the page and has created an account earlier, this PR allows the progress to be updated to the next chapter's intro page.
This PR also updates the relevant code to be directed to the correct chapter's tag on the chapter selection screen.
