### PR TITLE
Contribution bar improvements

### DIFF
--- a/content/lessons/chapter-3/pool-1.tsx
+++ b/content/lessons/chapter-3/pool-1.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from 'hooks'
 import { ProfileWithHashPower } from 'types'
-import { Card, HashFrequency, Text } from 'ui'
+import { Card, ContributionBar, HashFrequency, Text } from 'ui'
 import Profile from 'ui/common/Profile'
 
 export const metadata = {
@@ -11,13 +11,50 @@ export const metadata = {
   key: 'CH3POL1',
 }
 
-const PROFILES: ProfileWithHashPower[] = [
-  { name: 'You', avatar: '/assets/avatars/1.png', hashpower: 4395 },
-  { name: 'Mining Maniacs', avatar: '/assets/avatars/2.png', hashpower: 5054 },
-  { name: 'Hash Hoppers', avatar: '/assets/avatars/3.png', hashpower: 7911 },
-  { name: 'Coin Crunchers', avatar: '/assets/avatars/4.png', hashpower: 2857 },
-  { name: 'BitRey', avatar: '/assets/avatars/5.png', hashpower: 18599 },
+const TOTAL_BLOCKS = 100
+
+const PROTAGONISTS = [
+  {
+    username: 'You',
+    avatar: '/assets/avatars/1.png',
+    hashpower: 4395,
+    color: '#F3AB29',
+    value: TOTAL_BLOCKS * 0.1,
+  },
+  {
+    username: 'Mining Maniacs',
+    avatar: '/assets/avatars/2.png',
+    hashpower: 5054,
+    color: '#FE5329',
+    value: TOTAL_BLOCKS * 0.1,
+  },
+  {
+    username: 'Hash Hoppers',
+    avatar: '/assets/avatars/3.png',
+    hashpower: 7911,
+    color: '#62BFB7',
+    value: TOTAL_BLOCKS * 0.1,
+  },
+  {
+    username: 'Coin Crunchers',
+    avatar: '/assets/avatars/4.png',
+    hashpower: 2857,
+    color: '#85BF09',
+    value: TOTAL_BLOCKS * 0.1,
+  },
 ]
+
+const ANTAGONISTS = [
+  {
+    username: 'BitRey',
+    avatar: '/assets/avatars/5.png',
+    hashpower: 18599,
+    color: '#7E002E',
+    value: TOTAL_BLOCKS * 0.3,
+  },
+]
+
+const PROFILES: ProfileWithHashPower[] = [...PROTAGONISTS, ...ANTAGONISTS]
 
 export default function POL1({ lang }) {
   const t = useTranslations(lang)
@@ -27,20 +64,29 @@ export default function POL1({ lang }) {
       <div className="flex h-full max-h-[69px] w-full max-w-[800px] flex-col items-start gap-[10px] text-white">
         <div className="flex items-center justify-between gap-[10px] self-stretch py-[2px]">
           <span className="h-[25px] text-left font-nunito text-[18px] font-semibold text-white">
-            10 blocks
+            <span>
+              {PROTAGONISTS.reduce((acc, profile) => acc + profile.value, 0)}
+            </span>
+            <span> blocks</span>
           </span>
           <span className="h-[25px] text-right font-nunito text-[18px] font-semibold text-white">
-            10 blocks
+            <span>
+              {ANTAGONISTS.reduce((acc, profile) => acc + profile.value, 0)}
+            </span>
+            <span> blocks</span>
           </span>
         </div>
-        {/*Contribution Bar added below*/}
-        <div className="h-[30px] w-full bg-red">Contribution Bar</div>
+        <ContributionBar
+          total={TOTAL_BLOCKS}
+          protagonists={PROTAGONISTS}
+          antagonists={ANTAGONISTS}
+        />
       </div>
       <div className="flex gap-[30px]">
         {PROFILES.map((profile, i) => (
           <Profile
             key={i}
-            name={profile.name}
+            username={profile.username}
             avatar={profile.avatar}
             description={profile.description}
           >

--- a/content/lessons/chapter-3/solo-1.tsx
+++ b/content/lessons/chapter-3/solo-1.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from 'hooks'
 import { ProfileWithHashPower } from 'types'
-import { Card, HashFrequency, Text } from 'ui'
+import { Card, ContributionBar, HashFrequency, Text } from 'ui'
 import Profile from 'ui/common/Profile'
 
 export const metadata = {
@@ -11,10 +11,29 @@ export const metadata = {
   key: 'CH3SOL1',
 }
 
-const PROFILES: ProfileWithHashPower[] = [
-  { name: 'You', avatar: '/assets/avatars/1.png', hashpower: 4395 },
-  { name: 'BitRey', avatar: '/assets/avatars/5.png', hashpower: 34421 },
+const TOTAL_BLOCKS = 100
+
+const PROTAGONISTS = [
+  {
+    username: 'You',
+    avatar: '/assets/avatars/1.png',
+    hashpower: 4395,
+    color: '#F3AB29',
+    value: TOTAL_BLOCKS * 0.1,
+  },
 ]
+
+const ANTAGONISTS = [
+  {
+    username: 'BitRey',
+    avatar: '/assets/avatars/5.png',
+    hashpower: 34421,
+    color: '#7E002E',
+    value: TOTAL_BLOCKS * 0.3,
+  },
+]
+
+const PROFILES: ProfileWithHashPower[] = [...PROTAGONISTS, ...ANTAGONISTS]
 
 export default function SOL1({ lang }) {
   const t = useTranslations(lang)
@@ -22,24 +41,33 @@ export default function SOL1({ lang }) {
   return (
     <div className="my-auto flex flex-col items-center justify-center gap-[30px] self-stretch px-[20px] py-[20px] md:flex-row-reverse md:py-0 lg:px-[200px]">
       <div className="flex w-full flex-col">
-        <div className="flex h-full max-h-[69px] w-full max-w-[800px] flex-col gap-[10px] text-white">
+        <div className="flex h-full max-h-[69px] w-full flex-col gap-[10px] text-white">
           <div className="flex items-center justify-between gap-[10px] self-stretch py-[2px]">
             <span className="h-[25px] text-left font-nunito text-[18px] font-semibold text-white">
-              10 blocks
+              <span>
+                {PROTAGONISTS.reduce((acc, profile) => acc + profile.value, 0)}
+              </span>
+              <span> blocks</span>
             </span>
             <span className="h-[25px] text-right font-nunito text-[18px] font-semibold text-white">
-              10 blocks
+              <span>
+                {ANTAGONISTS.reduce((acc, profile) => acc + profile.value, 0)}
+              </span>
+              <span> blocks</span>
             </span>
           </div>
-          {/*Contribution Bar added below*/}
-          <div className="h-[30px] w-full bg-red">Contribution Bar</div>
+          <ContributionBar
+            total={TOTAL_BLOCKS}
+            protagonists={PROTAGONISTS}
+            antagonists={ANTAGONISTS}
+          />
         </div>
 
         <div className="mt-[30px] flex gap-[30px]">
           {PROFILES.map((profile, i) => (
             <Profile
               key={i}
-              name={profile.name}
+              username={profile.username}
               avatar={profile.avatar}
               description={profile.description}
             >

--- a/types/index.ts
+++ b/types/index.ts
@@ -43,7 +43,7 @@ export type Chapter = {
 }
 
 export type Profile = {
-  name: string
+  username: string
   avatar?: string
   description?: string
 }

--- a/ui/common/ContributionBar.tsx
+++ b/ui/common/ContributionBar.tsx
@@ -1,69 +1,100 @@
 'use client'
 
+import { useRef } from 'react'
 import Image from 'next/image'
 
-interface ContributionInfo {
-  username: string
-  avatar: string
-  color: string
-  percentage: number
-  side: number
-}
+export default function ContributionBar({ total, protagonists, antagonists }) {
+  const elementRef = useRef<HTMLDivElement>(null)
 
-interface ContributionInfoProps {
-  contributionInfo: ContributionInfo[]
-}
-
-export default function ContributionBar({
-  contributionInfo,
-}: ContributionInfoProps) {
-  let value = 0
   return (
-    <div className="relative h-[30px] w-full rounded-[5px] bg-black/20">
-      <div className="absolute z-50 flex h-full w-1/2 border-r-2 border-dotted border-white/50"></div>
-      {contributionInfo.map((info, i) => {
-        value += info.percentage
-        return (
-          <>
-            <div className="absolute h-full w-full overflow-hidden rounded-[5px]">
-              <div
-                className={`absolute inset-0 flex transform-gpu border-r-2 border-black transition-transform`}
-                style={{
-                  transform: `translate3d(${
-                    info.side === 0 ? 100 - info.percentage : -(100 - value)
-                  }%,0,0)`,
-                  backgroundColor: `#${info.color}`,
-                  zIndex: (contributionInfo.length - i) * 10,
-                }}
-              />
-            </div>
+    <div
+      className="relative h-[30px] w-full overflow-hidden rounded-[5px] bg-black/20"
+      ref={elementRef}
+    >
+      <div className="pointer-events-none absolute z-50 flex h-full w-1/2 border-r-2 border-dotted border-white/50"></div>
+      <div className="relative flex h-full w-full">
+        {protagonists.map((player, i) => {
+          const predecessors = protagonists.slice(0, i)
+          const cumulativeValue = predecessors.reduce(
+            (acc, p) => acc + p.value,
+            0
+          )
+
+          const scale = player.value / total
+          const translation = cumulativeValue + '%'
+
+          return (
             <div
-              className="absolute inset-0 z-50 flex transform-gpu items-center justify-center transition-transform"
-              style={{
-                transform: `translate3d(${
-                  info.side === 0
-                    ? (100 - info.percentage) / 2
-                    : -(
-                        (100 -
-                          (value - info.percentage + info.percentage / 2) * 2) /
-                        2
-                      )
-                }%,0,0)`,
-              }}
+              key={i}
+              className="absolute h-full w-full"
+              style={{ transform: `translateX(${translation})` }}
             >
-              <div className="h-6 w-6 rounded-full">
-                <Image
-                  src={`/assets/avatars/${info.avatar}.png`}
-                  alt="Avatar"
-                  width={22}
-                  height={22}
-                  className="rounded-full border-2 border-white"
-                />
+              <div
+                key={i}
+                className="flex h-full w-full origin-left items-center justify-center"
+                style={{
+                  transform: `scaleX(${scale})`,
+                  background: player.color,
+                }}
+              >
+                <div
+                  style={{ transform: `scaleX(${1 / scale})` }}
+                  className="aspect-square h-[26px] overflow-hidden rounded-full border-2 border-white"
+                >
+                  <Image
+                    width={30}
+                    height={30}
+                    alt={player.username}
+                    src={player.avatar}
+                    className="h-full w-full object-cover"
+                  />
+                </div>
               </div>
             </div>
-          </>
-        )
-      })}
+          )
+        })}
+
+        {antagonists.map((player, i) => {
+          const predecessors = antagonists.slice(0, i)
+          const cumulativeValue = predecessors.reduce(
+            (acc, p) => acc + p.value,
+            0
+          )
+
+          const scale = player.value / total
+          const translation = cumulativeValue + '%'
+
+          return (
+            <div
+              key={i}
+              className="absolute h-full w-full"
+              style={{ transform: `translateX(${translation})` }}
+            >
+              <div
+                key={i}
+                className="flex h-full w-full origin-right items-center justify-center"
+                style={{
+                  transform: `scaleX(${scale})`,
+                  background: player.color,
+                }}
+              >
+                <div
+                  style={{ transform: `scaleX(${1 / scale})` }}
+                  className="aspect-square h-[26px] overflow-hidden rounded-full border-2 border-white"
+                >
+                  <Image
+                    width={30}
+                    height={30}
+                    alt={player.username}
+                    src={player.avatar}
+                    className="h-full w-full object-cover"
+                  />
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/ui/common/Profile.tsx
+++ b/ui/common/Profile.tsx
@@ -7,14 +7,14 @@ export default function Profile({
   className,
   avatar,
   chip,
-  name,
+  username,
   description,
 }: {
   children?: React.ReactNode
   className?: string
   avatar?: string
   chip?: React.ReactElement
-  name: string
+  username: string
   description?: string
 }) {
   return (
@@ -34,7 +34,7 @@ export default function Profile({
       </div>
       <div className="mb-[15px] flex flex-col gap-4">
         <span className="font-nunito text-2xl font-bold text-white">
-          {name}
+          {username}
         </span>
         {description && (
           <span className="font-nunito text-xl font-bold text-white">


### PR DESCRIPTION
Follow-up PR for #534

<img width="674" alt="image" src="https://github.com/saving-satoshi/saving-satoshi/assets/10757768/9fc9c1c4-b300-4c55-8597-556994cdb931">


Further improvements I think we can make in a separate PR:
- Render the avatars on a different place in the markup so that the `overflow-hidden` doesn't cut them off when the block amount is low.