### PR TITLE
Change footer color on chapters page to match main background

### DIFF
--- a/app/[lang]/chapters/page.tsx
+++ b/app/[lang]/chapters/page.tsx
@@ -25,7 +25,7 @@ export default async function ChaptersPage({ params }) {
         </section>
       </div>
 
-      <Footer className="bg-back" />
+      <Footer className="bg-black/25" />
     </div>
   )
 }


### PR DESCRIPTION
simple bg color change for the footer to contrast the bg of the chapters page, adds opacity instead of using a different blue

Old:
![image](https://github.com/saving-satoshi/saving-satoshi/assets/108441023/5b89da70-fe76-44b7-8add-7b62b88c9ad9)

New:
![image](https://github.com/saving-satoshi/saving-satoshi/assets/108441023/b502d5c0-f435-4417-87f2-7f6ce6d45536)

