### PR TITLE
Remove blocks from other miners in CH3COO2

### DIFF
--- a/content/lessons/chapter-3/coop-2.tsx
+++ b/content/lessons/chapter-3/coop-2.tsx
@@ -80,6 +80,11 @@ export default function Coop2({ lang }) {
 
   const PROFILES: ProfileWithHashPower[] = [...PROTAGONISTS, ...ANTAGONISTS]
 
+  const highestHashpowerProtagonist = findIndexOfHighestHashpower(
+    PROTAGONISTS,
+    'hashpower'
+  )
+
   const handleStepUpdate = async (newStep: number) => {
     setShowText(false)
     await sleep(325)
@@ -99,6 +104,18 @@ export default function Coop2({ lang }) {
 
   const handleAntagonsitBlockUpdate = (newBlock: number) => {
     setAntagonistsBlockAmount(newBlock)
+  }
+
+  function findIndexOfHighestHashpower(players, key) {
+    let highestScore = -Infinity
+    let indexOfHighestScore = 0
+    for (let i = 0; i < players.length; i++) {
+      if (players[i][key] > highestScore) {
+        highestScore = players[i][key]
+        indexOfHighestScore = i
+      }
+    }
+    return indexOfHighestScore
   }
 
   useEffect(() => {
@@ -175,7 +192,11 @@ export default function Coop2({ lang }) {
                   }
                 )}
               >
-                {PROFILES[i].value}
+                {i === PROFILES.length - 1
+                  ? profile.value
+                  : i === highestHashpowerProtagonist
+                  ? profile.value + 3
+                  : '0'}
               </span>
             </Card>
             <Card className="flex gap-4">

--- a/content/lessons/chapter-3/coop-2.tsx
+++ b/content/lessons/chapter-3/coop-2.tsx
@@ -107,14 +107,11 @@ export default function Coop2({ lang }) {
   }
 
   function findIndexOfHighestHashpower(players, key) {
-    let highestScore = -Infinity
-    let indexOfHighestScore = 0
-    for (let i = 0; i < players.length; i++) {
-      if (players[i][key] > highestScore) {
-        highestScore = players[i][key]
-        indexOfHighestScore = i
-      }
-    }
+    const indexOfHighestScore = players.reduce(
+      (highestIndex, current, index) =>
+        current.value > players[highestIndex].value ? index : highestIndex,
+      0
+    )
     return indexOfHighestScore
   }
 
@@ -192,11 +189,11 @@ export default function Coop2({ lang }) {
                   }
                 )}
               >
-                {i === PROFILES.length - 1
-                  ? profile.value
-                  : i === highestHashpowerProtagonist
-                  ? profile.value + 3
-                  : '0'}
+                {i === PROFILES.length - 1 && profile.value}
+                {i === highestHashpowerProtagonist && profile.value + 3}
+                {i !== PROFILES.length - 1 &&
+                  i !== highestHashpowerProtagonist &&
+                  '0'}
               </span>
             </Card>
             <Card className="flex gap-4">


### PR DESCRIPTION
Closes #585 

in CH3COO2 only one miner is supposed to find blocks based on the nonce overlap. I created a semi-hacky way of leaving the other miners to be visible while still giving the correct number fo blocks to the protagonists / antagonists.
