### PR TITLE
Bypass feature flags using dev query param

### DIFF
--- a/app/[lang]/chapters/[slug]/[lesson]/page.tsx
+++ b/app/[lang]/chapters/[slug]/[lesson]/page.tsx
@@ -20,6 +20,7 @@ import { useProgressContext } from 'providers/ProgressProvider'
 import { Loader } from 'shared'
 import { LoadingState } from 'types'
 import { notFound } from 'next/navigation'
+import useEnvironment from 'hooks/useEnvironment'
 
 const Portal = ({ children, id }) => {
   const [mounted, setMounted] = useState(false)
@@ -34,9 +35,7 @@ const Portal = ({ children, id }) => {
 }
 
 export default function Page({ params }) {
-  const searchParams = navigation.useSearchParams()
-  const devParam = searchParams?.get('dev') || ''
-  const dev = devParam === 'true'
+  const { isDevelopment } = useEnvironment()
   const t = useTranslations(params.lang)
 
   const routes = useLocalizedRoutes()
@@ -90,7 +89,7 @@ export default function Page({ params }) {
 
   const Lesson = chapterLessons[params.lesson].default
 
-  if (dev) {
+  if (isDevelopment) {
     return (
       <>
         <Head />

--- a/content/lessons/chapter-3/coop-1.tsx
+++ b/content/lessons/chapter-3/coop-1.tsx
@@ -77,7 +77,10 @@ export default function Coop1({ lang }) {
     <div className="grid grid-cols-1 justify-center justify-items-center md:my-auto md:flex md:flex-row">
       <div className="fade-in my-[30px] grid grid-cols-2 gap-[15px] md:order-last md:mx-[30px] md:h-[400px] md:w-[410px] md:gap-[30px]">
         {players.map((profile, i) => (
-          <div className="h-[160px] w-[160px] border-2 border-dotted border-white/25 p-[15px] md:h-[185px] md:w-[190px]">
+          <div
+            key={i}
+            className="h-[160px] w-[160px] border-2 border-dotted border-white/25 p-[15px] md:h-[185px] md:w-[190px]"
+          >
             <div className="flex justify-center md:mb-[15px]">
               {profile.display ? (
                 <Avatar

--- a/hooks/useEnvironment.ts
+++ b/hooks/useEnvironment.ts
@@ -1,0 +1,12 @@
+'use client'
+
+import * as navigation from 'next/navigation'
+
+export default function useEnvironment() {
+  const searchParams = navigation.useSearchParams()
+  const devParam = searchParams?.get('dev') || ''
+
+  return {
+    isDevelopment: devParam === 'true',
+  }
+}

--- a/hooks/useSaveAndProceed.ts
+++ b/hooks/useSaveAndProceed.ts
@@ -10,22 +10,25 @@ import { useProgressContext } from 'providers/ProgressProvider'
 import { usePathData, useLocalizedRoutes } from 'hooks'
 import { lessons } from 'content'
 import { useAuthContext } from 'providers/AuthProvider'
+import useEnvironment from './useEnvironment'
 
 export default function useSaveAndProceed() {
   const router = useRouter()
   const { account } = useAuthContext()
   const { progress, saveProgress, saveProgressLocal } = useProgressContext()
   const { chapterId, lessonId } = usePathData()
+  const { isDevelopment } = useEnvironment()
   const routes = useLocalizedRoutes()
 
   const chapterLessons = lessons?.[chapterId]
   const lesson = chapterLessons?.[lessonId]?.metadata ?? null
   const currentLessonKey = lesson?.key ?? 'CH1INT1'
+  const queryParams = isDevelopment ? '?dev=true' : ''
 
   const saveAndProceed = async () => {
     const nextLessonKey = getNextLessonKey(currentLessonKey, account)
     const nextLessonPath = getNextLessonPath(currentLessonKey)
-    const route = routes.chaptersUrl + nextLessonPath
+    const route = routes.chaptersUrl + nextLessonPath + queryParams
 
     if (progress && !isLessonUnlocked(progress, nextLessonKey)) {
       if (account) {
@@ -34,6 +37,7 @@ export default function useSaveAndProceed() {
         await saveProgressLocal(nextLessonKey)
       }
     }
+    console.log(route)
     router.push(route)
   }
 

--- a/ui/chapter/Chapter.tsx
+++ b/ui/chapter/Chapter.tsx
@@ -17,6 +17,7 @@ import { useProgressContext } from 'providers/ProgressProvider'
 import { getLessonKey } from 'lib/progress'
 import { keys, keysMeta } from 'lib/progress'
 import { useFeatureContext } from 'providers/FeatureProvider'
+import useEnvironment from 'hooks/useEnvironment'
 
 const ChapterContext = createContext<ChapterContextType | null>(null)
 
@@ -34,6 +35,7 @@ const tabData = [
 ]
 
 export default function Chapter({ children, metadata, lang }) {
+  const { isDevelopment } = useEnvironment()
   const { progress, isLoading } = useProgressContext()
   const { isFeatureEnabled } = useFeatureContext()
   const isEnabled = isFeatureEnabled(
@@ -45,7 +47,9 @@ export default function Chapter({ children, metadata, lang }) {
   )
 
   const display =
-    metadata.slug === 'chapter-1' || (isEnabled && isUnlocked && !isLoading)
+    metadata.slug === 'chapter-1' ||
+    isDevelopment ||
+    (isEnabled && isUnlocked && !isLoading)
 
   const [activeTab, setActiveTab] = useState('info')
 

--- a/ui/chapter/Chapter.tsx
+++ b/ui/chapter/Chapter.tsx
@@ -65,6 +65,7 @@ export default function Chapter({ children, metadata, lang }) {
     progress !== chapterLessons[0] &&
     progress !== keys[keys.length - 1] &&
     position === parseInt(progress.substring(2, 3))
+  const queryParams = isDevelopment ? '?dev=true' : ''
   const context = {}
 
   useEffect(() => {
@@ -150,8 +151,10 @@ export default function Chapter({ children, metadata, lang }) {
                       <Button
                         href={
                           isBetweenChapter
-                            ? `${routes.chaptersUrl + keysMeta[progress].path}`
-                            : `${routes.chaptersUrl}/${chapter.metadata.slug}/${chapter.metadata.intros[0]}`
+                            ? `${
+                                routes.chaptersUrl + keysMeta[progress].path
+                              }${queryParams}`
+                            : `${routes.chaptersUrl}/${chapter.metadata.slug}/${chapter.metadata.intros[0]}${queryParams}`
                         }
                         disabled={
                           chapter.metadata.lessons.length === 0 || !display


### PR DESCRIPTION
This PR resolves #600 so we can use `?dev=true` to bypass feature flags on the `/en/chapters` page, and it makes sure that the `?dev=true` query param will be passed along to lessons.