### PR TITLE
feat: add i18n to tailwind context for new styles in the translations

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,7 @@ module.exports = {
     './content/**/*.{js,ts,jsx,tsx}',
     './shared/**/*.{js,ts,jsx,tsx}',
     './ui/**/*.{js,ts,jsx,tsx}',
+    './i18n/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
     extend: {


### PR DESCRIPTION
Made in reference to #607 I realized that classes that only existed in the translation files were not scanned by the tailwind context.
This adds i18n files within the range of the tailwind compiler