### PR TITLE
Adjust object position for intro component images

### DIFF
--- a/content/lessons/chapter-1/intro-2.tsx
+++ b/content/lessons/chapter-1/intro-2.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useTranslations, useMediaQuery } from 'hooks'
+import { useTranslations } from 'hooks'
 import { Introduction, Text } from 'ui'
 
 export const metadata = {
@@ -13,13 +13,8 @@ export const metadata = {
 export default function Intro2({ lang }) {
   const t = useTranslations(lang)
 
-  const isSmallScreen = useMediaQuery({ width: 1024 })
-
   return (
-    <Introduction
-      lang={lang}
-      imagePosition={isSmallScreen ? 'object-left-top' : undefined}
-    >
+    <Introduction lang={lang} imagePosition="object-[30%_30%]">
       <Text className="text-lg md:text-xl">
         {t('chapter_one.intro_two.paragraph_one')}
       </Text>

--- a/content/lessons/chapter-2/intro-1.tsx
+++ b/content/lessons/chapter-2/intro-1.tsx
@@ -13,7 +13,7 @@ export default function Intro1({ lang }) {
   const t = useTranslations(lang)
 
   return (
-    <Introduction lang={lang}>
+    <Introduction lang={lang} imagePosition="object-[61%_67%]">
       <h1 className="mb-3 font-cbrush text-5xl">
         {t('chapter_two.intro_one.title')}
       </h1>

--- a/content/lessons/chapter-2/intro-2.tsx
+++ b/content/lessons/chapter-2/intro-2.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useTranslations, useMediaQuery } from 'hooks'
+import { useTranslations } from 'hooks'
 import { Introduction, Text } from 'ui'
 
 export const metadata = {
@@ -12,13 +12,8 @@ export const metadata = {
 export default function Intro2({ lang }) {
   const t = useTranslations(lang)
 
-  const isSmallScreen = useMediaQuery({ width: 1024 })
-
   return (
-    <Introduction
-      lang={lang}
-      imagePosition={isSmallScreen ? 'object-left' : undefined}
-    >
+    <Introduction lang={lang} imagePosition="object-[40%_67%]">
       <h1 className="mb-3 font-cbrush text-5xl">
         {t('chapter_two.intro_two.title')}
       </h1>

--- a/content/lessons/chapter-3/intro-1.tsx
+++ b/content/lessons/chapter-3/intro-1.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { useTranslations, useMediaQuery } from 'hooks'
-import { useEffect, useState } from 'react'
+import { useTranslations } from 'hooks'
 import { Introduction, Text } from 'ui'
 
 export const metadata = {
@@ -12,23 +11,9 @@ export const metadata = {
 
 export default function Intro1({ lang }) {
   const t = useTranslations(lang)
-  const [objectPosition, setObjectPosition] = useState<string | undefined>()
-
-  const isMediumScreen = useMediaQuery({ width: 1024 })
-  const isSmallScreen = useMediaQuery({ width: 640 })
-
-  useEffect(() => {
-    if (isSmallScreen) {
-      setObjectPosition('object-left')
-    } else if (isMediumScreen) {
-      setObjectPosition('object-left-top')
-    } else {
-      setObjectPosition('object-bottom')
-    }
-  }, [isMediumScreen, isSmallScreen])
 
   return (
-    <Introduction lang={lang} imagePosition={objectPosition}>
+    <Introduction lang={lang} imagePosition="object-[50%_31%]">
       <Text className="text-lg md:text-xl">
         {t('chapter_three.intro_one.paragraph_one')}
       </Text>

--- a/content/lessons/chapter-3/split-1.tsx
+++ b/content/lessons/chapter-3/split-1.tsx
@@ -26,7 +26,7 @@ export default function Split1({ lang }) {
   }, [])
 
   return (
-    <Introduction lang={lang} imagePosition="object-left-top">
+    <Introduction lang={lang} imagePosition="object-[55%_19%]">
       <Title>{t('chapter_three.split_one.heading')}</Title>
       <Text className="text-lg md:text-xl">
         {t('chapter_three.split_one.paragraph_one')}

--- a/content/lessons/chapter-4/intro-1.tsx
+++ b/content/lessons/chapter-4/intro-1.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { useMediaQuery, useTranslations } from 'hooks'
-import { useEffect, useState } from 'react'
+import { useTranslations } from 'hooks'
 import { Introduction, Text } from 'ui'
 
 export const metadata = {
@@ -12,20 +11,9 @@ export const metadata = {
 
 export default function Intro1({ lang }) {
   const t = useTranslations(lang)
-  const [objectPosition, setObjectPosition] = useState<string | undefined>()
-
-  const isMediumScreen = useMediaQuery({ width: 1024 })
-
-  useEffect(() => {
-    if (isMediumScreen) {
-      setObjectPosition('object-left')
-    } else {
-      setObjectPosition('object-bottom')
-    }
-  }, [isMediumScreen])
 
   return (
-    <Introduction lang={lang} imagePosition={objectPosition}>
+    <Introduction lang={lang} imagePosition="object-center">
       <Text className="text-lg md:text-xl">
         {t('chapter_four.intro_one.paragraph_one')}
       </Text>

--- a/content/lessons/chapter-5/intro-1.tsx
+++ b/content/lessons/chapter-5/intro-1.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { useMediaQuery, useTranslations } from 'hooks'
-import { useEffect, useState } from 'react'
+import { useTranslations } from 'hooks'
 import { Introduction, Text } from 'ui'
 
 export const metadata = {
@@ -12,20 +11,9 @@ export const metadata = {
 
 export default function Intro1({ lang }) {
   const t = useTranslations(lang)
-  const [objectPosition, setObjectPosition] = useState<string | undefined>()
-
-  const isMediumScreen = useMediaQuery({ width: 1024 })
-
-  useEffect(() => {
-    if (isMediumScreen) {
-      setObjectPosition('object-left')
-    } else {
-      setObjectPosition('object-bottom')
-    }
-  }, [isMediumScreen])
 
   return (
-    <Introduction lang={lang} imagePosition={objectPosition}>
+    <Introduction lang={lang} imagePosition="object-[50%_27%]">
       <Text className="text-lg md:text-xl">
         {t('chapter_five.intro_one.paragraph_one')}
       </Text>

--- a/content/lessons/chapter-5/intro-2.tsx
+++ b/content/lessons/chapter-5/intro-2.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { useMediaQuery, useTranslations } from 'hooks'
-import { useEffect, useState } from 'react'
+import { useTranslations } from 'hooks'
 import { Introduction, Text } from 'ui'
 
 export const metadata = {
@@ -12,20 +11,9 @@ export const metadata = {
 
 export default function Intro2({ lang }) {
   const t = useTranslations(lang)
-  const [objectPosition, setObjectPosition] = useState<string | undefined>()
-
-  const isMediumScreen = useMediaQuery({ width: 1024 })
-
-  useEffect(() => {
-    if (isMediumScreen) {
-      setObjectPosition('object-left')
-    } else {
-      setObjectPosition('object-bottom')
-    }
-  }, [isMediumScreen])
 
   return (
-    <Introduction lang={lang} imagePosition={objectPosition}>
+    <Introduction lang={lang} imagePosition="object-[50%_29%]">
       <Text className="text-lg md:text-xl">
         {t('chapter_five.intro_two.paragraph_one')}
       </Text>

--- a/content/lessons/chapter-5/intro-3.tsx
+++ b/content/lessons/chapter-5/intro-3.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { useMediaQuery, useTranslations } from 'hooks'
-import { useEffect, useState } from 'react'
+import { useTranslations } from 'hooks'
 import { Introduction, Text } from 'ui'
 
 export const metadata = {
@@ -12,20 +11,9 @@ export const metadata = {
 
 export default function Intro3({ lang }) {
   const t = useTranslations(lang)
-  const [objectPosition, setObjectPosition] = useState<string | undefined>()
-
-  const isMediumScreen = useMediaQuery({ width: 1024 })
-
-  useEffect(() => {
-    if (isMediumScreen) {
-      setObjectPosition('object-left')
-    } else {
-      setObjectPosition('object-bottom')
-    }
-  }, [isMediumScreen])
 
   return (
-    <Introduction lang={lang} imagePosition={objectPosition}>
+    <Introduction lang={lang} imagePosition="object-[50%_45%]">
       <Text className="text-lg md:text-xl">
         {t('chapter_five.intro_one.paragraph_one')}
       </Text>


### PR DESCRIPTION
Various images were cut off weirdly at various screen sizes. Reason is that our layouts provide specific aspect ratios. We instruct the browser to fill the available area with the images. The browser needs to decide how to crop and center them in the given area. With this update, we now use the object position CSS property to provide specific points of interest in each image. Basically like a coordinate in the image that should be visible as much as possible. I looked at each image and calculated the coordinates (defined as percentages in Tailwind).

I removed the media query logic because it's not needed. Just by defining the point of interest in the image, the browser can figure out the cropping.

Example of a before and after.

![image](https://github.com/saving-satoshi/saving-satoshi/assets/695901/6664b692-27cc-436f-a083-e3a1adb4ab88)

📸[Check the preview](https://saving-satoshi-git-feature-adjust-image-centering-savingsatoshi.vercel.app/en/chapters/chapter-5/intro-1?dev=true)🌾
[Same page on dev](https://dev.savingsatoshi.com/en/chapters/chapter-5/intro-1?dev=true)
