### PR TITLE
Added padding back to terminal challenges

### DIFF
--- a/ui/lesson/Info.tsx
+++ b/ui/lesson/Info.tsx
@@ -17,7 +17,7 @@ export default function LessonInfo({
       <div className="max-w-full grow justify-center text-white md:max-w-[50%] md:basis-1/3">
         <div
           className={clsx(
-            'flex h-full flex-col content-center justify-items-start gap-1 px-1 py-6',
+            'flex h-full flex-col content-center justify-items-start gap-1 px-1 py-6 sm:px-12',
             className
           )}
         >


### PR DESCRIPTION
This PR closes  #758  for some weird reason sm:px-12 was missing, although i did check production to compare both instances
<img width="350" alt="Screenshot 2023-11-28 at 22 27 12" src="https://github.com/saving-satoshi/saving-satoshi/assets/90271995/c0c29408-2e80-4c62-a9f4-555d1493b9d1">
Production code

