### PR TITLE
Fix public key and address 2 validation

### DIFF
--- a/content/lessons/chapter-4/address-2.tsx
+++ b/content/lessons/chapter-4/address-2.tsx
@@ -48,7 +48,6 @@ function hashCompressed(compressed) {
 }
 `,
     validate: async (answer) => {
-      console.log(dataObject, answer)
       if (answer.startsWith('<Buffer')) {
         return [false, 'Ensure you are properly decoding your answer']
       }

--- a/content/lessons/chapter-4/public-key-3.tsx
+++ b/content/lessons/chapter-4/public-key-3.tsx
@@ -20,12 +20,12 @@ export default function PublicKey3({ lang }) {
   const [privateKey, setPrivateKey] = useState('')
 
   if (account && !privateKey) {
-    setPrivateKey('0x' + account?.private_key.toString())
+    setPrivateKey(account?.private_key.toString())
   }
 
   const javascript = {
     program: `
-console.log(privateKeyToPublicKey(${privateKey + 'n'}))
+console.log(privateKeyToPublicKey(\`${privateKey}\`))
 console.log("KILL")`,
     defaultFunction: {
       name: 'privateKeyToPublicKey',
@@ -45,7 +45,6 @@ function privateKeyToPublicKey(privateKey) {
 }
 `,
     validate: async (answer: string) => {
-      console.log(answer, privateKey)
       const parsedAnswer = JSON.parse(answer)
       const correctPattern = /^0x[0-9a-fA-F]{64}$/
       if (parsedAnswer) {
@@ -72,7 +71,7 @@ function privateKeyToPublicKey(privateKey) {
 
   const python = {
     program: `
-print(privatekey_to_publickey(${privateKey}))
+print(privatekey_to_publickey("${privateKey}"))
 print("KILL")`,
     defaultFunction: {
       name: 'privatekey_to_publickey',

--- a/content/lessons/chapter-4/public-key-4.tsx
+++ b/content/lessons/chapter-4/public-key-4.tsx
@@ -19,8 +19,8 @@ function compressPublicKey(publickey) {
     y_is_odd: Buffer.from([3]),
   }
   const x_hex = BigInt(publickey.x)
-  const x_bytes = Buffer.from(x_hex.toString(16), 'hex') // Convert BigInt to a hex string and then to bytes
-  const y_is_even = (BigInt(publickey.y) & 1n) === 0n
+  const x_bytes = Buffer.from(x_hex.toString(16), 'hex')
+  const y_is_even = (BigInt(publickey.y) & BigInt(1)) === BigInt(0)
   const header = y_is_even ? header_byte['y_is_even'] : header_byte['y_is_odd']
   const compressed_key = Buffer.concat([header, x_bytes]).toString('hex')
 

--- a/content/lessons/chapter-4/public-key-4.tsx
+++ b/content/lessons/chapter-4/public-key-4.tsx
@@ -14,24 +14,17 @@ export const metadata = {
 }
 
 function compressPublicKey(publickey) {
-  var header_byte = {
-    y_is_even: new Buffer([2]),
-    y_is_odd: new Buffer([3]),
+  const header_byte = {
+    y_is_even: Buffer.from([2]),
+    y_is_odd: Buffer.from([3]),
   }
+  const x_hex = BigInt(publickey.x)
+  const x_bytes = Buffer.from(x_hex.toString(16), 'hex') // Convert BigInt to a hex string and then to bytes
+  const y_is_even = (BigInt(publickey.y) & 1n) === 0n
+  const header = y_is_even ? header_byte['y_is_even'] : header_byte['y_is_odd']
+  const compressed_key = Buffer.concat([header, x_bytes]).toString('hex')
 
-  let x_hex = BigInt(publickey.x)
-  let x_hex_string = x_hex.toString(16)
-  let x_bytes = new Buffer(x_hex_string, 'hex')
-
-  let y_hex = BigInt(publickey.y)
-  let y_hex_string = y_hex.toString(16)
-
-  let y_is_even = Number(y_hex_string[y_hex_string.length - 1]) % 2 === 0
-
-  let header = y_is_even ? header_byte['y_is_even'] : header_byte['y_is_odd']
-  let compressed_key = Buffer.concat([header, x_bytes])
-
-  return compressed_key.toString('hex')
+  return compressed_key
 }
 
 export default function PublicKey4({ lang }) {
@@ -65,7 +58,7 @@ console.log("KILL")`,
 
 // Determine if the y coordinate is even or odd and prepend the
 // corresponding header byte to the x coordinate.
-// Return 33-byte Buffer
+// Return a hex string
 function compressPublicKey(publicKey) {
   const header_byte = {
     'y_is_even': Buffer.from([2]),
@@ -107,7 +100,7 @@ print("KILL")`,
 
 # Determine if the y coordinate is even or odd and prepend
 # the corresponding header byte to the x coordinate.
-# Return 33-byte array
+# Return a hex string
 def compress_publickey(public_key):
     header_byte = {
           "y_is_even": bytes([2]),

--- a/content/resources/chapter-4/public-key.tsx
+++ b/content/resources/chapter-4/public-key.tsx
@@ -20,7 +20,7 @@ const javascript = {
   defaultCode: [
     `function privateKeyToPublicKey(privateKey) {
   // First your private key will need to be encoded into an integer from a hex string.
-  const encodedPrivateKey = BigInt(\`0x\${privateKey}n\`)
+  const encodedPrivateKey = BigInt(\`0x\${privateKey}\`)
   // From the library you need to use the .mul() method to multiply G by your private key
   const generatorPoint = G.mul(encodedPrivateKey)
   return generatorPoint
@@ -28,13 +28,13 @@ const javascript = {
     `function compress_publickey(publicKey) {
   // Determine if the y coordinate is even or odd and prepend the
   // corresponding header byte to the x coordinate.
-  // Return 33-byte Buffer
+  // Return a hex string
   const header_byte = {
     'y_is_even': Buffer.from([2]),
     'y_is_odd': Buffer.from([3])
   };
   const x_hex = BigInt(publicKey.x);
-  const x_bytes = Buffer.from(x_hex.toString(16), 'hex'); // Convert BigInt to a hex string and then to bytes
+  const x_bytes = Buffer.from(x_hex.toString(16), 'hex');
   const y_is_even = (BigInt(publicKey.y) & 1n) === 0n;
   const header = y_is_even ? header_byte['y_is_even'] : header_byte['y_is_odd'];
   const compressed_key = Buffer.concat([header, x_bytes]).toString('hex');
@@ -57,7 +57,7 @@ const python = {
   defaultCode: [
     `def privatekey_to_publickey(private_key):
     # First your private key will need to be encoded into an integer from a hex string.
-    encoded_private_key = int(0x\${private_key})
+    encoded_private_key = int(private_key, 16)
     # From the library you need to use the .mul() method to multiply G by your private key
     generator_point = G.mul(encoded_private_key)
     return generator_point`,

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -710,7 +710,7 @@ const translations = {
       paragraph_one:
         'The public key has an x and y coordinate for a total of 64 bytes. This can be compressed into 33 bytes by removing the y coordinate and prepending a single byte of metadata. That byte will indicate if the Y coordinate is even or odd. Because the elliptic curve equation only has two variables, the complete public key can be computed later by the verifier using only x and the metadata:',
       paragraph_two:
-        'The metadata byte should be `2` if y is even and `3` if y is odd. Complete the function `compress_publickey()` to accept a public key and return an array of 33 bytes representing the compressed public key.',
+        'The metadata byte should be `2` if y is even and `3` if y is odd. Complete the function `compress_publickey()` to accept a public key and return a 33 byte hex string representing the compressed public key.',
       success:
         'Excellent. Now we have our compressed public key. Next we need to hash it and encode it in a human-friendly format.',
     },


### PR DESCRIPTION
Closes #784 
- Fixes the python and javascript validation for public-key-4 and address 2
- Fixes the private key object  in private-key-3 to be parsed properly 
- Changes the expected answer copy to ask for a hex string instead of bytes

[Preview](https://saving-satoshi-git-fork-benalleng-issue784-savingsatoshi.vercel.app/en/chapters/chapter-4/public-key-3?dev=true)