### PR TITLE
Enhance validation script on scripting 2

### DIFF
--- a/content/lessons/chapter-2/scripting-2.tsx
+++ b/content/lessons/chapter-2/scripting-2.tsx
@@ -14,8 +14,14 @@ export const metadata = {
 }
 
 const javascript = {
-  program: `
-console.log(findHash())
+  program: `//BEGIN VALIDATION BLOCK
+const min = 1;
+const max = 100000000;
+const randomNumberOne = Math.floor(Math.random() * (max - min + 1)) + min;
+const randomNumberTwo = Math.floor(Math.random() * (max - min + 1)) + min;
+const testOne = findHash(randomNumberOne)
+const testTwo = findHash(randomNumberTwo)
+console.log(testOne !== testTwo ? testTwo : 'test-failed')
 console.log("KILL")`,
   defaultFunction: {
     name: 'findHash',
@@ -26,12 +32,18 @@ console.log("KILL")`,
 // Create a program that finds a sha256 hash starting with 5 zeroes.
 // To submit your answer, return it from the function.
 
-function findHash() {
-// Type your code here
-
+function findHash(nonce) {
+  // Type your code here
 }
 `,
   validate: async (answer) => {
+    if (answer === 'test-failed') {
+      return [
+        false,
+        'Be sure you are using the nonce param in your function as a random starting nonce will be used to test',
+      ]
+    }
+
     if (!answer.startsWith('00000')) {
       return [false, 'Hash must start with 5 zeroes.']
     }
@@ -44,15 +56,29 @@ function findHash() {
   },
   constraints: [
     {
-      range: [7, 1, 10, 1],
+      range: [7, 1, 8, 1],
       allowMultiline: true,
     },
   ],
 }
 
 const python = {
-  program: `
-print(find_hash())
+  program: `# BEGIN VALIDATION BLOCK
+import random
+
+min_value = 1
+max_value = 100000000
+random_number_one = random.randint(min_value, max_value)
+random_number_two = random.randint(min_value, max_value)
+test_one = find_hash(random_number_one)
+test_two = find_hash(random_number_two)
+print(test_one, test_two)
+if test_one == test_two:
+    print('test-failed')
+elif test_one != test_two:
+    print(test_two)
+else:
+    print('error')
 print("KILL")`,
   defaultFunction: {
     name: 'find_hash',
@@ -63,10 +89,16 @@ print("KILL")`,
 # Create a program that finds a sha256 hash starting with 5 zeroes.
 # To submit your answer, return it from the function.
 
-def find_hash():
-# Type your code here
+def find_hash(nonce):
+    # Type your code here
 `,
   validate: async (answer) => {
+    if (answer === 'test-failed' || answer === 'error') {
+      return [
+        false,
+        'Be sure you are using the nonce param in your function as a random starting nonce will be used to test',
+      ]
+    }
     if (!answer.startsWith('00000')) {
       return [false, 'Hash must start with 5 zeroes.']
     }

--- a/content/lessons/chapter-2/scripting-2.tsx
+++ b/content/lessons/chapter-2/scripting-2.tsx
@@ -19,7 +19,7 @@ const min = 1;
 const max = 100000000;
 const randomNumber = Math.floor(Math.random() * (max - min + 1)) + min;
 const testHash = findHash(randomNumber)
-console.log(findHash(1000000) === '000001f8479faf79c1a58152ffc6b027a93f6ae6b27dc19ef986b2c9e7cad3b3' ? testHash : 'test-failed')
+console.log((findHash(1000000) === '000001f8479faf79c1a58152ffc6b027a93f6ae6b27dc19ef986b2c9e7cad3b3' && findHash(0) !== '000001f8479faf79c1a58152ffc6b027a93f6ae6b27dc19ef986b2c9e7cad3b3') ? testHash : 'test-failed')
 console.log("KILL")`,
   defaultFunction: {
     name: 'findHash',
@@ -70,7 +70,7 @@ random_number = random.randint(min_value, max_value)
 test_hash = find_hash(random_number)
 if find_hash(1000000) != '000001f8479faf79c1a58152ffc6b027a93f6ae6b27dc19ef986b2c9e7cad3b3':
     print('test-failed')
-elif find_hash(1000000) == '000001f8479faf79c1a58152ffc6b027a93f6ae6b27dc19ef986b2c9e7cad3b3':
+elif find_hash(1000000) == '000001f8479faf79c1a58152ffc6b027a93f6ae6b27dc19ef986b2c9e7cad3b3' and find_hash(0) != '000001f8479faf79c1a58152ffc6b027a93f6ae6b27dc19ef986b2c9e7cad3b3':
     print(test_hash)
 else:
     print('error')

--- a/content/lessons/chapter-2/scripting-2.tsx
+++ b/content/lessons/chapter-2/scripting-2.tsx
@@ -17,11 +17,9 @@ const javascript = {
   program: `//BEGIN VALIDATION BLOCK
 const min = 1;
 const max = 100000000;
-const randomNumberOne = Math.floor(Math.random() * (max - min + 1)) + min;
-const randomNumberTwo = Math.floor(Math.random() * (max - min + 1)) + min;
-const testOne = findHash(randomNumberOne)
-const testTwo = findHash(randomNumberTwo)
-console.log(testOne !== testTwo ? testTwo : 'test-failed')
+const randomNumber = Math.floor(Math.random() * (max - min + 1)) + min;
+const testHash = findHash(randomNumber)
+console.log(findHash(1000000) === '000001f8479faf79c1a58152ffc6b027a93f6ae6b27dc19ef986b2c9e7cad3b3' ? testHash : 'test-failed')
 console.log("KILL")`,
   defaultFunction: {
     name: 'findHash',
@@ -68,15 +66,12 @@ import random
 
 min_value = 1
 max_value = 100000000
-random_number_one = random.randint(min_value, max_value)
-random_number_two = random.randint(min_value, max_value)
-test_one = find_hash(random_number_one)
-test_two = find_hash(random_number_two)
-print(test_one, test_two)
-if test_one == test_two:
+random_number = random.randint(min_value, max_value)
+test_hash = find_hash(random_number)
+if find_hash(1000000) != '000001f8479faf79c1a58152ffc6b027a93f6ae6b27dc19ef986b2c9e7cad3b3':
     print('test-failed')
-elif test_one != test_two:
-    print(test_two)
+elif find_hash(1000000) == '000001f8479faf79c1a58152ffc6b027a93f6ae6b27dc19ef986b2c9e7cad3b3':
+    print(test_hash)
 else:
     print('error')
 print("KILL")`,

--- a/content/resources/chapter-2/scripting.tsx
+++ b/content/resources/chapter-2/scripting.tsx
@@ -19,9 +19,9 @@ const javascript = {
   },
   defaultCode: [
     `function findHash(nonce) {
-let hash = '';
+  let hash = '';
 
-// while the hash does not start with 5 zeroes we want the prgram to repeat
+  // while the hash does not start with 5 zeroes we want the prgram to repeat
   while (hash.substring(0, 5) !== '00000') {
     // Hash the nonce using the crypto library and then increment the nonce
     hash = crypto.createHash('sha256').update(nonce.toString()).digest('hex');
@@ -48,14 +48,11 @@ const python = {
     # Lets initialize the hash here as an empty string
     hash = ''
 
-    # Write the nonce as a string
-    encoded_nonce = str(nonce).encode()
-
     # while the hash does not start with 5 zeroes we want the prgram to repeat
     while hash[0:5] != '00000':
         # Hash the nonce using the crypto library and then increment the nonce
-        hash = sha256(encoded_nonce).digest().hex()
-        nonce = nonce + 1
+        hash = sha256(str(nonce).encode()).digest().hex()
+        nonce += 1
     return hash`,
   ],
   validate: async (answer) => {
@@ -151,7 +148,7 @@ export default function AddressResources({ lang }) {
               <div className="relative grow bg-[#00000026] font-mono text-sm text-white">
                 <MonacoEditor
                   loading={<Loader className="h-10 w-10 text-white" />}
-                  height={`250px`}
+                  height={`235px`}
                   value={code}
                   beforeMount={handleBeforeMount}
                   onMount={handleMount}


### PR DESCRIPTION
Closes #547

With our better understanding of the possiblity for test vectors in our repl environment I enhanced our scripting 2 challenge to better prevent cheating and hopefully allows for more reliable results

try returning a string of length 64 that is all zeroes like 
```
return '0000000000000000000000000000000000000000000000000000000000000000'
```

In the past this return would have passed the challenge

[Preview](https://saving-satoshi-git-fork-benalleng-issue547-savingsatoshi.vercel.app/en/chapters/chapter-2/scripting-2?dev=true)