### PR TITLE
Adjust Scripting Challenge Editor height

### DIFF
--- a/ui/lesson/ScriptingChallenge/Editor.tsx
+++ b/ui/lesson/ScriptingChallenge/Editor.tsx
@@ -80,20 +80,15 @@ export default function Editor({
   }
 
   const isSmallScreen = useMediaQuery({ width: 767 })
-  const headerHeight = isSmallScreen ? 63 : 70
-  const languageTabsHeight = 40
-  const statusBarHeight = 56
-  const terminalHeight = 218
-  const terminalTabsHeight = 40
+  const headerHeight = 70
   const mobileMenuHeight = 48
+  const terminalTabsHeight = 48
+  const languageTabsHeight = 40
+  const terminalHeight = 204
 
   const totalHeight = isSmallScreen
-    ? headerHeight + mobileMenuHeight + languageTabsHeight + statusBarHeight
-    : headerHeight +
-      languageTabsHeight +
-      statusBarHeight +
-      terminalHeight +
-      terminalTabsHeight
+    ? headerHeight + mobileMenuHeight + languageTabsHeight
+    : headerHeight + languageTabsHeight + terminalHeight + terminalTabsHeight
 
   useEffect(() => {
     hiddenRange && setOptions(createMonacoOptions(hiddenRange[2]))


### PR DESCRIPTION
cleans up the dead space on the editor terminal now that some of the space has been more finalized

Current
![image](https://github.com/saving-satoshi/saving-satoshi/assets/108441023/da5fa57a-fc26-482a-ad5d-c2c1b3fd1c8c)

This PR
![image](https://github.com/saving-satoshi/saving-satoshi/assets/108441023/647617e0-672d-4f84-8192-6236af482e1f)

notice the bottom of the terminal no longer has blank space