### PR TITLE
feat: Added ability to fold code on load

### DIFF
--- a/content/lessons/chapter-6/put-it-together-5.tsx
+++ b/content/lessons/chapter-6/put-it-together-5.tsx
@@ -156,8 +156,8 @@ console.log("KILL")
   `,
     rangesToCollapse: [
       {
-        start: 115,
-        end: 136,
+        start: countLines(prevData.data) + 1,
+        end: countLines(prevData.data) + 22,
       },
     ],
     defaultFunction: {
@@ -319,8 +319,8 @@ print("KILL")
 `,
     rangesToCollapse: [
       {
-        start: 78,
-        end: 87,
+        start: countLines(prevData.data) + 1,
+        end: countLines(prevData.data) + 10,
       },
     ],
     defaultFunction: {
@@ -373,6 +373,7 @@ print("KILL")
       python,
     },
   }
+  console.log(config)
 
   return (
     !isLoading && (

--- a/content/lessons/chapter-6/put-it-together-5.tsx
+++ b/content/lessons/chapter-6/put-it-together-5.tsx
@@ -154,6 +154,12 @@ const public_key_yirutads = ec.keyFromPublic(wit_key_ttefkgdk);
 console.log(public_key_yirutads.verify(hashed_message_bytes_aieoprds, wit_sig_okdakljl) && 'true');
 console.log("KILL")
   `,
+    rangesToCollapse: [
+      {
+        start: 115,
+        end: 136,
+      },
+    ],
     defaultFunction: {
       name: 'signInput',
       args: [],
@@ -311,6 +317,12 @@ verifying_key_zjkdhfxd = VerifyingKey.from_string(wit_key_ttefkgdk, curve=SECP25
 print(verifying_key_zjkdhfxd.verify_digest(wit_sig_okdakljl[:-1], hashed_message_bytes_aieoprds, ecdsa.util.sigdecode_der) and 'true')
 print("KILL")
 `,
+    rangesToCollapse: [
+      {
+        start: 78,
+        end: 87,
+      },
+    ],
     defaultFunction: {
       name: 'create_tx_message',
       args: [],

--- a/types/index.ts
+++ b/types/index.ts
@@ -66,3 +66,8 @@ export type StoredLessonData = {
   answer: string
   code?: Base64String
 }
+
+export type EditorRange = {
+  start: number
+  end: number
+}

--- a/types/interfaces.ts
+++ b/types/interfaces.ts
@@ -1,4 +1,4 @@
-import { LessonDirection, LessonView } from 'types'
+import { EditorRange, LessonDirection, LessonView } from 'types'
 
 export interface ChapterContextType {}
 
@@ -21,6 +21,7 @@ export interface EditorLanguages {
     validate: (answer: any) => Promise<any[]>
     constraints: any
     hiddenRange?: number[]
+    rangesToCollapse?: EditorRange[]
   }
 }
 

--- a/ui/lesson/ScriptingChallenge/Editor.tsx
+++ b/ui/lesson/ScriptingChallenge/Editor.tsx
@@ -7,7 +7,7 @@ import { monacoOptions } from './config'
 import { monaco } from 'react-monaco-editor'
 import { useEffect, useRef, useState } from 'react'
 import { Loader } from 'shared'
-import { LessonView } from 'types'
+import { EditorRange, LessonView } from 'types'
 import { useLessonContext } from 'ui'
 import { useMediaQuery } from 'hooks'
 // @ts-ignore
@@ -18,10 +18,11 @@ export default function Editor({
   value,
   onChange,
   onValidate,
-  code,
+  code = '',
   constraints,
   hiddenRange,
   loadingSavedCode,
+  rangesToCollapse = [],
 }: {
   language: string
   value?: string
@@ -31,6 +32,7 @@ export default function Editor({
   constraints: any
   hiddenRange?: number[]
   loadingSavedCode?: boolean
+  rangesToCollapse?: EditorRange[]
 }) {
   const { activeView } = useLessonContext()
   const isActive = activeView === LessonView.Code
@@ -77,6 +79,19 @@ export default function Editor({
     const constrainedInstance = constrainedEditor(monaco)
     constrainedInstance.initializeIn(editor)
     constrainedInstance.addRestrictionsTo(model, constraints)
+    const actions = editor.getSupportedActions()
+    if (rangesToCollapse.length > 0) {
+      const foldAction = actions.find((a) => a.id === 'editor.foldAllExcept')
+      rangesToCollapse.forEach((range) => {
+        editor.setSelection({
+          startLineNumber: range.start,
+          endLineNumber: range.end,
+          startColumn: 1,
+          endColumn: 1,
+        })
+        foldAction.run()
+      })
+    }
   }
 
   const isSmallScreen = useMediaQuery({ width: 767 })

--- a/ui/lesson/ScriptingChallenge/index.tsx
+++ b/ui/lesson/ScriptingChallenge/index.tsx
@@ -185,6 +185,7 @@ export default function ScriptingChallenge({
             code={code}
             constraints={constraints}
             loadingSavedCode={loadingSavedCode}
+            rangesToCollapse={config.languages[language].rangesToCollapse}
           />
           <Runner
             lang={lang}


### PR DESCRIPTION
The intention here is to be able to provide range blocks to fold in the editor.  Unfortunately the ability to pass in ranges to the fold function in the editor is currently broken in the version we are using.  As a workaround I'm using the `foldAllExcept` action instead.  This means that for now it only supports one element in the `rangesToCollapse` array but we should revisit this once the [fix](https://github.com/microsoft/vscode/pull/201315) is available in the [editor](@monaco-editor/react
) we are using.

## Pull Request checklist

Please review the below PR requirements:

- Build was run locally and any changes were pushed
- Ensure that the title clearly describes the changes
- Issue to be referenced in the PR description rather than in the commits or PR title
- Clean commit history
