### PR TITLE
chapter-3/split-1 title format fix

### DIFF
--- a/content/lessons/chapter-3/split-1.tsx
+++ b/content/lessons/chapter-3/split-1.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react'
 import { useTranslations } from 'hooks'
 import { Introduction, Text } from 'ui'
 import { cssVarThemeChange } from 'lib/themeSelector'
-import Title from 'ui/introduction/Title'
+import { Title } from 'ui'
 
 export const metadata = {
   title: 'chapter_three.split_one.title',
@@ -28,7 +28,7 @@ export default function Split1({ lang }) {
   return (
     <Introduction lang={lang} imagePosition="object-[55%_19%]">
       <Title>{t('chapter_three.split_one.heading')}</Title>
-      <Text className="text-lg md:text-xl">
+      <Text className="mt-2 text-lg md:text-xl">
         {t('chapter_three.split_one.paragraph_one')}
       </Text>
       <Text className="mt-4 text-lg md:text-xl">


### PR DESCRIPTION
All the page titles seem to usually use the `Title` component in the `ui` folder. This page (chapter-3/split-1) used the `Title` component in the `ui/introduction` folder, which did not apply the correct formatting. So I switched over.

Reason why I am keeping this a draft is that the `ui/introduction/Title` component appears to be no longer used in the site at all. Is this a legacy component that can be removed? What about other components in the `ui/introduction` folder? If so, should I remove it in this PR?

Before and after (on different devices):

![image](https://github.com/saving-satoshi/saving-satoshi/assets/695901/a4105f02-ad0d-4219-941f-348a21c09148)
