### PR TITLE
Fixed the Key Prop warning on derive-message-1

### DIFF
--- a/content/lessons/chapter-5/derive-message-1.tsx
+++ b/content/lessons/chapter-5/derive-message-1.tsx
@@ -2,7 +2,7 @@
 
 import { useProceed, useTranslations } from 'hooks'
 import { Button } from 'shared'
-import { ChapterIntro } from 'ui'
+import { ChapterIntro, Text } from 'ui'
 
 export const metadata = {
   title: 'chapter_five.derive_message_one.title',
@@ -19,11 +19,11 @@ export default function DeriveMessage1({ lang }) {
       heading={t('chapter_five.derive_message_one.heading')}
     >
       <div className="mt-[30px] border-2 border-dashed border-white">
-        <p className="max-w-[900px] px-[15px] py-[10px] text-left font-space-mono text-xl md:text-[22px]">
+        <Text className="max-w-[900px] whitespace-pre-line px-[15px] py-[10px] text-left font-space-mono text-xl md:text-[22px]">
           {t('chapter_five.derive_message_one.code_one')}
           {t('chapter_five.derive_message_one.code_two')}
           {t('chapter_five.derive_message_one.code_three')}
-        </p>
+        </Text>
       </div>
       <p className="mt-[30px] text-center font-nunito text-2xl font-bold text-white">
         {t('chapter_five.derive_message_one.paragraph_two')}

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -830,11 +830,10 @@ const translations = {
     derive_message_one: {
       title: 'Derive the message',
       heading: 'Vanderpoole says he signed a message with Satoshi’s keys:',
-      code_one:
-        '-----BEGIN BITCOIN SIGNED MESSAGE----- <br /> <br /> I am Vanderpoole and I have control of the private key Satoshi used to sign the first-ever Bitcoin transaction confirmed in block #170. This message is signed with the same private key. <br /> <br /> -----BEGIN BITCOIN SIGNATURE----- <br /> <br />',
+      code_one: `-----BEGIN BITCOIN SIGNED MESSAGE----- \n \n I am Vanderpoole and I have control of the private key Satoshi used to sign the first-ever Bitcoin transaction confirmed in block #170. This message is signed with the same private key. \n \n -----BEGIN BITCOIN SIGNATURE----- \n \n`,
       code_two:
         '<span className="break-all"> H4vQbVD0pLK7pkzPto8BHourzsBrHMB3Qf5oYVmr741pPwdU2m6FaZZmxh4ScHxFoDelFC9qG0PnAUl5qMFth8k= </span>',
-      code_three: '<br/> <br/>-----END BITCOIN SIGNATURE-----',
+      code_three: '\n \n-----END BITCOIN SIGNATURE-----',
       paragraph_two: 'What does this even mean?',
     },
     derive_message_two: {


### PR DESCRIPTION
This PR closes #858  and  replaces `<br/>` tag with \n 