### PR TITLE
handle old keys

### DIFF
--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1474,7 +1474,7 @@ const translations = {
       paragraph_one:
         'To complete our transaction we will need a serialize() method that outputs the entire transaction as bytes formatted for broadcast on the Bitcoin p2p network.',
       paragraph_two:
-        'Our script should create and sign a Transaction object. It will have one input (the UTXO we identified in <span className="underline">Populate the Input</span>) and two outputs:',
+        'Our script should create and sign a Transaction object. It will have one input (the UTXO we identified in <span className="underline">The input class</span>) and two outputs:',
       paragraph_three:
         'We know our input, we know our output. Are we ready to build and sign a transaction? Not quite. We have a 1.61 BTC input and a 1 BTC output... what happens to the other 0.61 BTC? Most of that will be "change" and we need to send it back to our own address!',
       paragraph_four:

--- a/lib/progress.ts
+++ b/lib/progress.ts
@@ -184,9 +184,9 @@ export const keysMeta = {
   CH6PUT2: { path: '/chapter-6/put-it-together-2' },
   CH6PUT3: { path: '/chapter-6/put-it-together-3' },
   //To be deleted after some testing
-  CH6PUT4: { path: '/chapter-6/intro-1' },
-  CH6PUT5: { path: '/chapter-6/intro-1' },
-  CH6PUT6: { path: '/chapter-6/intro-1' },
+  CH6PUT4: { path: '/chapter-6/outro-1' },
+  CH6PUT5: { path: '/chapter-6/outro-1' },
+  CH6PUT6: { path: '/chapter-6/outro-1' },
   //To be deleted after some testing
   CH6OUT1: { path: '/chapter-6/outro-1' },
 

--- a/lib/progress.ts
+++ b/lib/progress.ts
@@ -78,6 +78,11 @@ export const keys = [
   'CH6PUT1',
   'CH6PUT2',
   'CH6PUT3',
+  //To be deleted after some testing
+  'CH6PUT4',
+  'CH6PUT5',
+  'CH6PUT6',
+  //To be deleted after some testing
   'CH6OUT1',
 
   'CH7INT1',
@@ -178,6 +183,11 @@ export const keysMeta = {
   CH6PUT1: { path: '/chapter-6/put-it-together-1' },
   CH6PUT2: { path: '/chapter-6/put-it-together-2' },
   CH6PUT3: { path: '/chapter-6/put-it-together-3' },
+  //To be deleted after some testing
+  CH6PUT4: { path: '/chapter-6/intro-1' },
+  CH6PUT5: { path: '/chapter-6/intro-1' },
+  CH6PUT6: { path: '/chapter-6/intro-1' },
+  //To be deleted after some testing
   CH6OUT1: { path: '/chapter-6/outro-1' },
 
   CH7INT1: { path: '/chapter-7/intro-1' },


### PR DESCRIPTION
This is needed to prevent errors if the user is on `put-it-together-4/5/6`

These keys will not be hit by any user but likely that in Jonas' testing he may have progress stuck here