### PR TITLE
Remove overflow hidden on body when navbar unmounts

### DIFF
--- a/components/Navbar/NavbarMobile/NavbarMobile.tsx
+++ b/components/Navbar/NavbarMobile/NavbarMobile.tsx
@@ -10,7 +10,7 @@ import { chapters, lessons } from 'content'
 import Address from 'components/Navbar/Address'
 import UserButton from '../UserButton'
 import HamburgerMenu from './HamburgerMenu'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Menu from './Menu'
 import clsx from 'clsx'
 import Link from 'next/link'
@@ -58,6 +58,13 @@ export default function NavbarMobile({ params }) {
     document.body.classList.remove('overflow-y-hidden')
     setIsOpen(false)
   }
+
+  useEffect(() => {
+    return () => {
+      document.body.classList.remove('overflow-y-hidden')
+      setIsOpen(false)
+    }
+  }, [])
 
   return (
     <div

--- a/components/Navbar/NavbarMobile/NavbarMobile.tsx
+++ b/components/Navbar/NavbarMobile/NavbarMobile.tsx
@@ -62,7 +62,6 @@ export default function NavbarMobile({ params }) {
   useEffect(() => {
     return () => {
       document.body.classList.remove('overflow-y-hidden')
-      setIsOpen(false)
     }
   }, [])
 


### PR DESCRIPTION
I noticed that the body doesn't scroll if a user leaves the navbar navigation with either the back button or the power button so I add an unMount function to remove the overflow hidden 

This is on mobile