### PR TITLE
Chapter 6: fix number of bytes for sequence number

### DIFF
--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1425,7 +1425,7 @@ const translations = {
           item_one: 'The sequence value of the single input being signed',
           item_two: 'sequence',
           item_three: 'int',
-          item_four: '8',
+          item_four: '4',
         },
         row_eight: {
           item_one: 'The dSHA256 of all outputs, serialized',


### PR DESCRIPTION
In the chapter 6, Put it Together (https://savingsatoshi.com/en/chapters/chapter-6/put-it-together-1) challenge, there is a table for the elements that make up the transaction input digest (aka the thing you have to sign when you sign a transaction input). 

![Screenshot from 2024-05-14 22-03-41](https://github.com/saving-satoshi/saving-satoshi/assets/1823216/def52ac2-68cd-4930-b445-49aa632fd65d)

According to [BIP-143](https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki), the sequence number should be 4 bytes, not 8.

![Screenshot from 2024-05-14 22-01-09](https://github.com/saving-satoshi/saving-satoshi/assets/1823216/8f9c4d9a-948e-466f-8804-a4b7b3e3f7a8)






