### PR TITLE
Chapter 6: Clarify "n" value in solution

### DIFF
--- a/content/resources/chapter-6/put-it-together.tsx
+++ b/content/resources/chapter-6/put-it-together.tsx
@@ -168,7 +168,7 @@ const javascriptChallengeTwo = {
     const r = R.x.val % secp256k1.ORDER;
     let s = ((r * key) + BigInt(\`0x\${msg.toString('hex')}\`)) * k_inverted % secp256k1.ORDER;
 
-    if (s > (secp256k1.ORDER / 2n))
+    if (s > (secp256k1.ORDER / BigInt(2)))
       s = secp256k1.ORDER - s;
     return [r, s];
   }

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1454,7 +1454,7 @@ const translations = {
       title: 'Putting it all together',
       nav_title: 'Build the witness class',
       heading: 'Sign and Populate the Witness!',
-      paragraph_one: `We wrote the ECDSA signature verification code in the last chapter, now we need to rearrange that a bit to create a valid signature. Add a method called compute_input_signature(index: int, key: int) to your Transaction class that accepts an input index number and a private key (a 32-byte integer!). It should compute the message digest for the chosen input using the digest() method from step 6, and return an ECDSA signature in the form of two 32-byte integers r and s.`,
+      paragraph_one: `We wrote the ECDSA signature verification code in the last chapter, now we need to rearrange that a bit to create a valid signature. Add a method called compute_input_signature(index: int, key: int) to your Transaction class that accepts an input index number and a private key (a 32-byte integer). It should compute the message digest for the chosen input using the digest() method from step 6, and return an ECDSA signature in the form of two 32-byte integers r and s.`,
       paragraph_two:
         'See <Link href="https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm" target="_blank" className="underline">this page</Link> for the ECDSA signing algorithm. Also <Link href="https://www.secg.org/sec1-v2.pdf#subsubsection.4.1.3" target="_blank" className="underline">this PDF</Link> (Page 44, Section 4.1.3).',
       paragraph_three:


### PR DESCRIPTION
**Chapter 6, Putting it all together, Build the witness class**

One part of this exercise is implementing the following (last step for signing an input with your private key):

```
    // Extra Bitcoin rule from BIP 146
    // https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki#user-content-LOW_S
    //   s = -s mod n, if s > n / 2
```

In the solutions page, it is implemented as:

![Screenshot from 2024-05-14 23-27-35](https://github.com/saving-satoshi/saving-satoshi/assets/1823216/25216428-ab67-426b-978f-0353f2e0b1a9)

~~However line 45 should be if (s > (secp256k1.ORDER / 2)) (as opposed to 2n). n is not defined in the code, and if you look through the rest of the solution, n actually represents the order of the curve, secp256k1.ORDER.~~

This is confusing because n represents the order of the curve, but it's also being used here to coerce a number into a BigInt.

This PR replaces `2n` with `BigInt(2)` so the "n" character isn't used to represent two different things.