### PR TITLE
Chapter 6: update solution for last challenge

### DIFF
--- a/content/resources/chapter-6/put-it-together.tsx
+++ b/content/resources/chapter-6/put-it-together.tsx
@@ -291,7 +291,10 @@ const javascriptChallengeThree = {
     locktime.writeUInt32LE(this.locktime);
 
     return Buffer.concat([buf, locktime]);
-  }`,
+  }
+  
+  // Update the change amount to account for miner fees
+  const out1 = Output.from_options(addr, 60999000);`,
   validate: async (answer) => {
     return [true, undefined]
   },
@@ -322,7 +325,10 @@ const pythonChallengeThree = {
         for wit in self.witnesses:
             r += wit.serialize()
         r += pack("<I", self.locktime)
-        return r`,
+        return r
+
+    # Update the change amount to account for miner fees
+    out1 = Output.from_options(addr, 60999000)`,
   validate: async (answer) => {
     return [true, undefined]
   },
@@ -511,7 +517,7 @@ export default function PutItTogetherResources({ lang }) {
               <div className="relative grow bg-[#00000026] font-mono text-sm text-white">
                 <MonacoEditor
                   loading={<Loader className="h-10 w-10 text-white" />}
-                  height={`365px`}
+                  height={`425px`}
                   value={codeThree}
                   beforeMount={handleBeforeMount}
                   onMount={handleMount}

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1512,7 +1512,7 @@ const translations = {
           item_four: '1',
         },
         row_four: {
-          item_one: 'All transaction inputs,serialized',
+          item_one: 'All transaction inputs, serialized',
           item_two: 'inputs',
           item_three: 'Inputs[]',
           item_four: '(var)',
@@ -1524,7 +1524,7 @@ const translations = {
           item_four: '1',
         },
         row_six: {
-          item_one: 'All transaction outputs,serialized',
+          item_one: 'All transaction outputs, serialized',
           item_two: 'outputs',
           item_three: 'Outputs[]',
           item_four: '(var)',


### PR DESCRIPTION
For the last challenge in chapter 6, "Sign the transaction", the player needs to update the change amount so miner fees are accounted for. I know we've [already added a comment](https://github.com/saving-satoshi/saving-satoshi/pull/931/files#diff-ea94042999c5e65bd33509c7502b7ab2a3ed6f8e8c24f93d2db08b56886e59c4R195) in the pre-loaded code that reminds the player to do this, but I think it also makes sense to call this out in the solution page as well. 

Does the JS text editor/code display frame dislike comments in solutions?
![Screenshot from 2024-05-15 23-51-35](https://github.com/saving-satoshi/saving-satoshi/assets/1823216/7eb1dff2-11a6-41dd-bbda-3ac1dd3edb4e)


Python looks good
![Screenshot from 2024-05-15 23-58-08](https://github.com/saving-satoshi/saving-satoshi/assets/1823216/a0359daa-b264-4425-83e4-5f2aa7f32d39)

