### PR TITLE
Design: Darken the CodeExample element

### DIFF
--- a/ui/common/CodeExample.tsx
+++ b/ui/common/CodeExample.tsx
@@ -13,7 +13,7 @@ export default function CodeExample({
   className?: string
 }) {
   return (
-    <pre className={clsx('border-2 border-dashed border-white p-2', className)}>
+    <pre className={clsx('bg-[#00000033] p-2', className)}>
       <span
         className={`language-${language} flex items-center justify-between break-all pl-2 pr-0`}
       >


### PR DESCRIPTION
In chapter 6 we have some [really nice tables](https://savingsatoshi.com/en/chapters/chapter-6/in-out-5) where the background color is an opaque black. I thought it might be nice to update code examples to match this. What do we think? Are there any other areas of the project (other than challenges in other chapters) that use this CodeExample element that I should check on?

Screenshot from production:
![Screenshot from 2024-05-31 21-51-38](https://github.com/saving-satoshi/saving-satoshi/assets/1823216/fc51261a-cece-4c07-80e7-5a356e0a40ab)


After this PR:
![Screenshot from 2024-05-31 21-51-30](https://github.com/saving-satoshi/saving-satoshi/assets/1823216/bea13b68-d456-4d36-8f37-381dedbce4b7)
