### PR TITLE
Design: Resize HolocatQuestion avatar

### DIFF
--- a/ui/common/HolocatQuestion.tsx
+++ b/ui/common/HolocatQuestion.tsx
@@ -26,11 +26,11 @@ const HolocatQuestion = ({
         id={id}
         theme={theme || ''}
         content={question}
-        parentClassName="inline-flex align-bottom min-h-fit min-w-fit"
+        parentClassName="inline-flex align-middle min-h-fit min-w-fit mx-1"
         arrowPosition={arrowPosition}
         visibleOverride={visible}
       >
-        <Avatar avatar="/assets/avatars/holocat.jpg" size={32} />
+        <Avatar avatar="/assets/avatars/holocat.jpg" size={24} />
       </Tooltip>
     )) || (
       <a
@@ -40,7 +40,7 @@ const HolocatQuestion = ({
       gap-2 rounded-[100px] bg-black/20 p-2 transition ease-in-out
        hover:bg-black/40"
       >
-        <Avatar avatar="/assets/avatars/holocat.jpg" size={32} />
+        <Avatar avatar="/assets/avatars/holocat.jpg" size={24} />
         <Text className="text-lg font-semibold">{question}</Text>
       </a>
     )


### PR DESCRIPTION
Don't hate me for this one but the little Holocat avatar that links to ChatBTC is slightly too large for the surrounding text. It's ever so slightly tall enough that it changes the leading for the line that it's on, creating a bit more space between only the lines above and below it.

In this PR I've made the avatar smaller, added a small amount of left and right margin, and set the `vertical-align` CSS property to to middle instead of bottom. There is still something that seems off to me, but I think this gets things in the right direction. I wish I could bump the avatar up just a smidge however I tried all the other `vertical-align` values and this one seems the most appropriate.

Before:

![Screenshot from 2024-05-31 22-04-55](https://github.com/saving-satoshi/saving-satoshi/assets/1823216/cf03ed0b-fc99-46bd-aae3-e07969296329)

After:

![Screenshot from 2024-05-31 22-56-33](https://github.com/saving-satoshi/saving-satoshi/assets/1823216/4266d56a-8abc-42b8-afe2-f35865e4149c)
