### PR TITLE
Design: Update code examples on ch 2 help page

### DIFF
--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -508,7 +508,7 @@ const translations = {
         tip_two:
           'Think about how you would create a function to keep running until that answer is equal to a specific value',
         tip_three:
-          'Remember to log your answer with <span className="px-1 border-[2px] border-dashed">console.log()</span> or <span className="px-1 border-[2px] border-dashed">print()</span>. It is the only way our IDE will try to validate your answer.',
+          'Remember to log your answer with <span className="p-1 font-mono bg-[#00000033] m-1">console.log()</span> or <span className="p-1 font-mono bg-[#00000033] m-1">print()</span>. It is the only way our IDE will try to validate your answer.',
       },
       mining: {
         mining_heading: 'Mining',


### PR DESCRIPTION
On the chapter 2 help page we have a few bits of code mentioned in the Tips section. In this PR I update the formatting to better match the rest of the game.

Are there any React best practices that I should consider as we go forward? Is this the preferred way to apply this kind of styling? I plan to tackle some more help pages and will be likely be adding more content similar to this.

Before:

![Screenshot from 2024-06-02 18-40-52](https://github.com/saving-satoshi/saving-satoshi/assets/1823216/df6cdf74-bb63-41d6-af60-89af9ead5ccd)

After PR:

![Screenshot from 2024-06-02 21-08-17](https://github.com/saving-satoshi/saving-satoshi/assets/1823216/872311ab-8c77-46f1-ab0a-84d2e59ad757)


