### PR TITLE
README: add linting notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,17 @@ To run this project locally:
 6. Run `yarn start` or `yarn dev` to spin up the development environment
 7. Open `http://localhost:3000` in your browser to access the site
 
+### Linting
+
+Before you write any git commit messages, there is a [Husky](https://typicode.github.io/husky/) hook that auto formats all staged files. If you would like to run the auto formatter yourself, before any files are staged, you can use the `yarn prettier:check` and/or the `yarn prettier` command(s).
+
+The Husky hook will execute when you add a commit message and the changes will be included in the commit.
+
 ## Roadmap
 
 This project was started during the [Bitcoin Designathon](http://event.bitcoin.design) in October 2022. It then continued with the [bolt.fun Legends of Lightning Tournament](https://makers.bolt.fun/project/saving-satoshi).
 
-Our first goal is to launch a V1 that provides a great basic experience around 2 chapters with lessons. Then we'd like to get feedback from the community to ensure that we are building something that resonates. Ideally, we'd then like to make necessary adjustments and open up contributions to everyone.
+Our first goal is to launch a V1 that provides a great basic experience. Then we'd like to get feedback from the community to ensure that we are building something that resonates. Ideally, we'd then like to make necessary adjustments and open up contributions to everyone.
 
 Some ideas we have for the future
 
@@ -67,4 +73,4 @@ Thank you so much for your interest in the project. We'd love to hear your feedb
 
 ## License
 
-Saving Satoshi is released under the terms of the MIT license. See [LICENSE](https://github.com/ecurrencyhodler/saving-satoshi/blob/master/license) for more information or see https://opensource.org/licenses/MIT.
+Saving Satoshi is released under the terms of the MIT license. See [LICENSE](https://github.com/saving-satoshi/saving-satoshi/blob/master/license) for more information or see https://opensource.org/licenses/MIT.

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,41 +1,41 @@
 {
- "name": "Saving Satoshi",
- "icons": [
-  {
-   "src": "\/android-icon-36x36.png",
-   "sizes": "36x36",
-   "type": "image\/png",
-   "density": "0.75"
-  },
-  {
-   "src": "\/android-icon-48x48.png",
-   "sizes": "48x48",
-   "type": "image\/png",
-   "density": "1.0"
-  },
-  {
-   "src": "\/android-icon-72x72.png",
-   "sizes": "72x72",
-   "type": "image\/png",
-   "density": "1.5"
-  },
-  {
-   "src": "\/android-icon-96x96.png",
-   "sizes": "96x96",
-   "type": "image\/png",
-   "density": "2.0"
-  },
-  {
-   "src": "\/android-icon-144x144.png",
-   "sizes": "144x144",
-   "type": "image\/png",
-   "density": "3.0"
-  },
-  {
-   "src": "\/android-icon-192x192.png",
-   "sizes": "192x192",
-   "type": "image\/png",
-   "density": "4.0"
-  }
- ]
+  "name": "Saving Satoshi",
+  "icons": [
+    {
+      "src": "/android-icon-36x36.png",
+      "sizes": "36x36",
+      "type": "image/png",
+      "density": "0.75"
+    },
+    {
+      "src": "/android-icon-48x48.png",
+      "sizes": "48x48",
+      "type": "image/png",
+      "density": "1.0"
+    },
+    {
+      "src": "/android-icon-72x72.png",
+      "sizes": "72x72",
+      "type": "image/png",
+      "density": "1.5"
+    },
+    {
+      "src": "/android-icon-96x96.png",
+      "sizes": "96x96",
+      "type": "image/png",
+      "density": "2.0"
+    },
+    {
+      "src": "/android-icon-144x144.png",
+      "sizes": "144x144",
+      "type": "image/png",
+      "density": "3.0"
+    },
+    {
+      "src": "/android-icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "density": "4.0"
+    }
+  ]
 }


### PR DESCRIPTION
Add notes to the README about linting and the Husky hook. Also update `public/manifest.json` with the changes made after running `yarn prettier`. The Husky hook is not configured to look at `.json` files so this never had `pretttier` run against it.  It changed the direction of the slash marks from back slashes to forward slashes. When I ran the changes locally and briefly clicked around, everything seemed okay.
