### PR TITLE
Chapter 8 Updates

### DIFF
--- a/content/lessons/chapter-8/building-blocks-5.tsx
+++ b/content/lessons/chapter-8/building-blocks-5.tsx
@@ -40,6 +40,8 @@ const TX_HASH = "7bd09aa3b4795be2839d9159edff0811d6d4ec5a64abd81c0da1e73ab00bf52
 const getBlockTxFee = () => {
   let block = Bitcoin.rpc("getblock", BLOCK_HASH)
   // YOUR CODE HERE
+
+  return 0;
 }
 
 // Now let's find the miner's fee for this transaction.
@@ -79,6 +81,7 @@ TX_HASH = "7bd09aa3b4795be2839d9159edff0811d6d4ec5a64abd81c0da1e73ab00bf520"
 def get_block_tx_fee():
     block = Bitcoin.rpc("getblock", BLOCK_HASH)
     # YOUR CODE HERE
+    return 0
 
 # Now let's find the miner's fee for this transaction.
 # with the transaction from above determine the fee paid to miners

--- a/content/lessons/chapter-8/building-blocks-5.tsx
+++ b/content/lessons/chapter-8/building-blocks-5.tsx
@@ -137,7 +137,7 @@ def get_tx_fee(tx):
         <CodeExample
           className="mt-4"
           language="txt"
-          code="aaf2fd920b7e628b1480b88343ab3b49e49969cf61b059d8c1532b805b7a6d2f"
+          code="7bd09aa3b4795be2839d9159edff0811d6d4ec5a64abd81c0da1e73ab00bf520"
         />
         <Text className="mt-4 font-nunito text-xl text-white">
           {t('chapter_eight.building_blocks_five.paragraph_five')}
@@ -145,7 +145,7 @@ def get_tx_fee(tx):
         <CodeExample
           className="mt-4"
           language="txt"
-          code="003b9be2d96d14f02717c262bb4b9a0b23191e2f1d9a38413204f3be4f21613c"
+          code="dab5708b1b3db05407e35b2004156d74f7bb5bed7f677743945cac1465b5838f"
         />
         <Text className="mt-4 font-nunito text-xl text-white">
           {t('chapter_eight.building_blocks_five.paragraph_six')}

--- a/content/lessons/chapter-8/building-blocks-6.tsx
+++ b/content/lessons/chapter-8/building-blocks-6.tsx
@@ -25,6 +25,8 @@ getSubsidy(840000) === 312500000) {
   console.log('true')
 } else if (typeof getSubsidy(839999) === 'bigint') {
   console.log('be sure the subsidy is of type number')
+} else if (getSubsidy(10000000) < 1) {
+  console.log('Remember there is a maximum of 63 halvings, and the subsidy will never be a fraction of a satoshi');
 } else {
   console.log('false')
 }
@@ -97,13 +99,13 @@ print("KILL")`,
       onSelectLanguage={handleSelectLanguage}
     >
       <LessonInfo>
-        <Title>4. {t('chapter_eight.building_blocks_six.heading')}</Title>
+        <Title>{t('chapter_eight.building_blocks_six.heading')}</Title>
         <Text className="mt-4 font-nunito text-xl text-white">
           {t('chapter_eight.building_blocks_six.paragraph_one')}
         </Text>
         <CodeExample
           className="mt-4 whitespace-break-spaces font-space-mono"
-          code={`BLOCK_SUBSIDY + TOTAL_TRASNACTION_FEES_IN_BLOCK = COINBASE_OUTPUT_VALUE`}
+          code={`BLOCK_SUBSIDY + TOTAL_TRANSACTION_FEES_IN_BLOCK = COINBASE_OUTPUT_VALUE`}
           language="shell"
         />
         <Text className="mt-4 font-nunito text-xl text-white">

--- a/content/lessons/chapter-8/building-blocks-7.tsx
+++ b/content/lessons/chapter-8/building-blocks-7.tsx
@@ -59,18 +59,24 @@ export default function BuildingBlocks7({ lang }) {
 
   const javascript = {
     program: `//BEGIN VALIDATION BLOCK
-let HEIGHT = 6929851
-let candidates = Bitcoin.rpc("getblocksbyheight", HEIGHT)
-for (const bhash of candidates){
+    const fs = require('fs');
+    const state = JSON.parse(fs.readFileSync('chainstate.json', 'utf8'));
 
- let block = Bitcoin.rpc("getblock", bhash)
+    const HEIGHT = 6929851;
+    let candidates = Bitcoin.rpc("getblocksbyheight", HEIGHT);
 
-  if(validateBlock(block)){
-    console.log(bhash)
-  }
+    for (const bhash of candidates){
+      let block = Bitcoin.rpc("getblock", bhash);
 
-}
-console.log("KILL")`,
+      if (state.blocks_by_hash[bhash].valid === false && validateBlock(block) == true) {
+        console.log('Looks like some invalid blocks are getting through. Try again!');
+        console.log('KILL');
+      }
+      if (state.blocks_by_hash[bhash].valid === true && validateBlock(block) === true) {
+        console.log(bhash);
+      }
+    }
+    console.log("KILL");`,
     rangeToNotCollapse: [
       {
         start: countLines(cleanedCombinedCode) + 5,
@@ -108,12 +114,19 @@ function validateBlock(block) {
 
   const python = {
     program: `# BEGIN VALIDATION BLOCK
+from json import load
+with open(f"{'chainstate.json'}", "r") as file:
+  state = load(file)
+
 HEIGHT = 6929851
 candidates = Bitcoin.rpc("getblocksbyheight", HEIGHT)
 
 for bhash in candidates:
   block = Bitcoin.rpc("getblock", bhash)
-  if validate_block(block):
+  if no state["blocks_by_hash"][bhash]["valid"] and validate_block(block):
+    print("Looks like some invalid blocks are getting through. Try again!")
+    print("KILL")
+  if state["blocks_by_hash"][bhash]["valid"] and validate_block(block):
       print(bhash)
 print("KILL")`,
     defaultFunction: {
@@ -173,14 +186,14 @@ for bhash in candidates:
     if validate_block(block):
         print(bhash)
         break`
-  const jsValidation = `const HEIGHT = 6929851
-const candidates = Bitcoin.rpc("getblocksbyheight", HEIGHT)
+  const jsValidation = `const HEIGHT = 6929851;
+const candidates = Bitcoin.rpc("getblocksbyheight", HEIGHT);
 for (const bhash of candidates) {
-let block = Bitcoin.rpc("getblock", bhash)
-if(validateBlock(block)){
-  return bhash;
-    }
-  }`
+  let block = Bitcoin.rpc("getblock", bhash);
+  if (validateBlock(block) == true) {
+    return bhash;
+  }
+}`
   const codeValidation =
     detectLanguage(combinedCode) === Language.JavaScript
       ? jsValidation
@@ -197,7 +210,7 @@ if(validateBlock(block)){
         onSelectLanguage={handleSelectLanguage}
       >
         <LessonInfo>
-          <Title>4. {t('chapter_eight.building_blocks_six.heading')}</Title>
+          <Title>{t('chapter_eight.building_blocks_six.heading')}</Title>
           <Text className="mt-4 font-nunito text-xl text-white">
             {t('chapter_eight.building_blocks_seven.paragraph_one')}
           </Text>

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1799,8 +1799,8 @@ const translations = {
       nav_title: 'Get the Valid Block',
       heading: 'That Pernicious Scallywag!',
       paragraph_one: `There are four block candidates at height 6929851. Only one of them is a valid block, the other three were mined by Vanderpoole's cartel in reckless attempts to inflate the Bitcoin money supply.`,
-      paragraph_two: `Use your block subsidy function and the JSON-RPC API to check the coinbase outputs in all four block candidates and print the hash of the one and only valid block at that height!`,
-      paragraph_three: `Your code will be tested using `,
+      paragraph_two: `Using the block subsidy function you wrote in the previous challenge and the JSON-RPC API, write a function to check the validity of a block candidate. Do this by checking if the coinbase output is correct. Your function should return true if the block is valid.`,
+      paragraph_three: `Here's how your code will be used to find the one valid block at height 6929851:`,
       success: 'The validate block function looks great. Nice work!',
     },
 

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1727,9 +1727,9 @@ const translations = {
       title: 'Building blocks',
       nav_title: 'Finding the chain tip',
       paragraph_one:
-        'You know Vanderpoole has been trying to confuse people by mining blocks that generate more Bitcoin than they are allowed to, in order to inflate the money supply. These blocks are invalid because they break hard-coded protocol rules, but they might still fool some people running buggy or malicious software, or light clients that do not fully verify data they receive from the network.',
+        'You know Vanderpoole has been trying to confuse people by mining blocks that generate more Bitcoin than they are allowed to, in order to inflate the money supply. These blocks are invalid because they break hard-coded protocol rules, but they might still fool some people running buggy or malicious software, or light clients that do not fully verify data received from the network.',
       paragraph_two:
-        'You also know that somewhere out there on the network is a chain of VALID blocks from the genesis block to today\'s "chain tip", where every transaction and every block follows all the rules exactly correctly. This chain is the only "real" chain, the only chain that matters, and the only chain where the 21 Million Bitcoin supply is intact.',
+        'You also know that somewhere out there on the network is a chain of VALID blocks from the genesis block to today\'s "chain tip", where every transaction and every block follows all the rules exactly correctly. This chain is the only "real" chain, the only chain that matters, and the only chain where the 21 million bitcoin supply is intact.',
       paragraph_three:
         "Now, on live TV in front of the entire world, you need to find the longest valid blockchain and verify the integrity of the coin supply. While you're at it, you'll also be able to prove that Vanderpoole has turned the Bitcoin network into a minefield of invalid blocks.",
     },
@@ -1747,10 +1747,8 @@ const translations = {
       title: 'Building Blocks',
       nav_title: `Explore the Bitcoin API`,
       heading: 'The Bitcoin API',
-      paragraph_one:
-        "To answer these questions, you'll need to interact with a Bitcoin full node, via it's JSON-RPC API. We've imported a library for you called bitcoin_rpc which handles the secure HTTP connection from your script to the full node, executes your commands, and returns the responses. Your full node is \"pruning\" so it only has access to the last 300 blocks, but that should be enough to include the entire timespan of Vanderpoole's recent muckery.",
-      paragraph_two:
-        "Let's start by getting familiar with the API. The library has one function that accepts one required argument (a string) and one optional argument (either a string or a number):",
+      paragraph_one: `To answer these questions, you'll need to interact with a Bitcoin full node, via its JSON-RPC API. We've imported a library for you called <span className="p-1 font-mono bg-[#00000033] m-1">bitcoin_rpc</span> which handles the secure HTTP connection from your script to the full node, executes your commands, and returns the responses. Your full node is \"pruning\" so it only has access to the last 300 blocks, but that should be enough to include the entire timespan of Vanderpoole's recent muckery.`,
+      paragraph_two: `Let's start by getting familiar with the API. The library has one function that accepts one required argument, <span className="p-1 font-mono bg-[#00000033] m-1">method</span> (a string) and one optional argument, <span className="p-1 font-mono bg-[#00000033] m-1">params</span> (either a string or a number):`,
       paragraph_three:
         'The API also has a convenient "help" method! Ask it for help to learn more about the available commands, then pass the challenge by printing the current network difficulty.',
       success: "Nice work exploring the API! Let's move on.",
@@ -1758,16 +1756,16 @@ const translations = {
     building_blocks_four: {
       title: 'Building Blocks',
       nav_title: `Find the Smallest Transaction Block`,
-      heading: `2. Block Data`,
+      heading: `Block Data`,
       paragraph_one: `Each Bitcoin full node has a database. That's where blocks are stored and indexed by their hash. The full node keeps track of which blocks are candidates at each height in the chain with a second index that maps height -> [block hashes].`,
-      paragraph_two: `The JSON-RPC API returns block data as JSON objects that include a property "txs" which is an array of transaction objects.`,
+      paragraph_two: `The JSON-RPC API returns block data as JSON objects that include a property<span className="p-1 font-mono bg-[#00000033] m-1">txs</span>which is an array of transaction objects.`,
       paragraph_three: `Retrieve all the block candidates at height 6929996 and print the hash of the block with the fewest transactions in it.`,
       success: `Nicely Done`,
     },
     building_blocks_five: {
       title: 'Building Blocks',
       nav_title: `Get the Transaction Fee`,
-      heading: `3. Transaction Data`,
+      heading: `Transaction Data`,
       paragraph_one: `The transaction objects confirmed in a block are JSON objects that include arrays of "inputs" and "outputs". Both of these arrays are lists of UTXOs, also known as "coins". Coin objects have a "value" property represented in satoshis.`,
       paragraph_two: `The "inputs" array is the coins spent (destroyed) by the transaction and the "outputs" array is the coins created by the transaction. You may recall from Chapter 6 that transactions always pay a fee to incentivize miners to include them in a block. That fee is exactly the difference in value between the total input and total output values of a transaction.`,
       paragraph_three: `In other words, the miner gets to keep whatever bitcoin that was sent in to the transaction but not sent back out to the transaction recipients.`,
@@ -1781,13 +1779,13 @@ const translations = {
       nav_title: 'Determine the subsidy',
       heading: 'The Coinbase Transaction',
       paragraph_one:
-        'The first transaction in every block is called the coinbase. It may also be referred to as the "0th" transaction (referring to txs[0]) and it has a few very special properties. First of all, it has no inputs! This is because it does not spend any existing coins. Second, it\'s output value is strictly defined by the protocol (despite what Vanderpoole might say!). This is the mechanism by which miners both collect fees from transactions, and generate new coins.',
+        'The first transaction in every block is called the coinbase. It may also be referred to as the "0th" transaction (referring to txs[0]) and it has a few very special properties. First of all, it has no inputs! This is because it does not spend any existing coins. Second, its output value is strictly defined by the protocol (despite what Vanderpoole might say!). This is the mechanism by which miners both collect fees from transactions, and generate new coins.',
       paragraph_two:
         "It's fairly easy to understand how total transaction fees in a block are summed up, but where does that block subsidy value come from? How does every participant in the Bitcoin network determine exactly how much new bitcoin miners are allowed to generate at any given time?",
       paragraph_three:
-        'This is the algorithm written by Satoshi Nakamoto that has remained an immutable core property of the Bitcoin system for over 120 years:',
+        'This is the algorithm written by Satoshi Nakamoto that has remained an immutable core property of the Bitcoin system since the beginning:',
       list_one:
-        'Starting with the block #1 mined in 2009, the block subsidy is 50 BTC (or 5000000000 satoshis)',
+        'Starting with the block #1 mined in 2009, the block subsidy is 50 BTC (or 5,000,000,000 satoshis)',
       list_two: 'Every 210,000 blocks that value is cut in half.',
       paragraph_four:
         'At block height 209,999 the subsidy was 50 BTC. In the very next block at height 210,000 the subsidy was 25 BTC, and so on. After 63 "halvings" the subsidy will be one single satoshi. The last halving will drop the subsidy to zero.',
@@ -1799,7 +1797,7 @@ const translations = {
     building_blocks_seven: {
       title: 'Building Blocks',
       nav_title: 'Get the Valid Block',
-      heading: '5. That Pernicious Scallywag!',
+      heading: 'That Pernicious Scallywag!',
       paragraph_one: `There are four block candidates at height 6929851. Only one of them is a valid block, the other three were mined by Vanderpoole's cartel in reckless attempts to inflate the Bitcoin money supply.`,
       paragraph_two: `Use your block subsidy function and the JSON-RPC API to check the coinbase outputs in all four block candidates and print the hash of the one and only valid block at that height!`,
       paragraph_three: `Your code will be tested using `,
@@ -1809,9 +1807,9 @@ const translations = {
     building_blocks_eight: {
       title: 'Building Blocks',
       nav_title: 'SHOWTIME!!',
-      heading_one: '6. SHOWTIME!!',
-      paragraph_one: `The cameras are rolling, there's two billion humans world-wide tuned in to the live stream, and there's only a few minutes left before the next commercial break. Deborah Chunk is sweating, holocat is sweating. Somewhere on the other end of the call-in phone line, Vanderpoole must be sweating. This is it!`,
-      paragraph_two: `Starting with the valid block you just found at height 6929851, find the longest chain of valid blocks you can. Store the chain as an array of block hashes. While you're at it, maintain an array of every invalid block you find as well, just to show the world how hard Vanderpoole tried to break Bitcoin. It doesn't matter what order these invalid block hashes are in, but your valid chain MUST start with the hash of block 6929851 followed by one block hash at each height all the way up to the chain tip.`,
+      heading_one: 'SHOWTIME!!',
+      paragraph_one: `The cameras are rolling, there's two billion humans world-wide tuned in to the live stream, and there's only a few minutes left before the next commercial break. Deborah Chunk is sweating, Holocat is sweating. Somewhere on the other end of the call-in phone line, Vanderpoole must be sweating. This is it!`,
+      paragraph_two: `Starting with the valid block just before the one you found at height 6929851, find the longest chain of valid blocks you can. Store the chain as an array of block hashes. While you're at it, maintain an array of every invalid block you find as well, just to show the world how hard Vanderpoole tried to break Bitcoin. It doesn't matter what order these invalid block hashes are in, but your valid chain MUST start with the hash of block 6929850 followed by one block hash at each height all the way up to the chain tip.`,
       paragraph_three: `Vanderpoole is sneaky! He mined valid blocks on top of invalid blocks, and invalid blocks on top of short valid blocks! It's a maze, a minefield, out there. You may need to keep track of several valid branches as you traverse the tree. There will be valid blocks with valid parents that are not in the longest chain! In the end, there will be only one valid leaf with a greater height than all the others.`,
       paragraph_four: `Remember: Block objects returned by the JSON API have a property "prev" which identifies that block's parent by its hash:`,
       heading_two: `A block is ONLY valid if:`,
@@ -1826,7 +1824,7 @@ const translations = {
       nav_title: 'Chapter complete',
       heading: "We're doing it live!",
       paragraph_one:
-        "You found the longest chain and proved it to everyone! You are one step closer to discrediting Vanderpoole, needless to say he didn't answer anymore of Ms. Chunk's questions.",
+        "You found the longest chain and proved it to everyone! You are one step closer to discrediting Vanderpoole. Needless to say he didn't answer anymore of Ms. Chunk's questions.",
     },
   },
 


### PR DESCRIPTION
I just finished playing chapter 8 and this PR contains a bunch of updates I have for it. It's best to review this PR by looking at each commit in sequential order.

**Commit 1** - copy changes and a few style updates similar to previous PRs I've made:

![Screenshot from 2024-06-10 21-22-38](https://github.com/saving-satoshi/saving-satoshi/assets/1823216/2622ef94-69fd-44c8-93d5-3d3ec570b146)

**Commit 2** - [building-blocks-5] Fix hashes in the challenge instructions. Prior to this change, the instructions did not match what is in
the pre-loaded code, and what the validation code is looking for.

**Commit 3** - [building-blocks-5] Add a default return value to the preloaded code. The user eventually has to change this, but it at least fixes an exception that prevented the user from debugging with `console.log()` statements.

**Commit 4** - [building-blocks-6] Add another custom (JavaScript) error message, this time for an incorrect solution that allows the subsidy to be a fraction of a satoshi. Can't remember how I ended up in this scenario but I think whatever I did, I missed the custom error message that the answer must be of type number. Also a few minor copy updates to this file.

**Commit 5** - [building-blocks-7] This challenge is a little buggy. It asks you to make a `validateBlock(block)` function that, when used on a a list of blocks, prints the hash of the one valid block. It's unusual that this method, not whatever calls it, is responsible for printing the hash of a valid block. However, to change that would require a larger rework. For now, I want to point out that our validation code checks for a specific hash (`88fd124d747cde1d8494d589ec6b82ce11356dd869823dfec8e84b111a72bc87`) that has been hard coded into `building-blocks-7.tsx` (`validate` method on the `javascript` and `python` objects).

We tell the user that the validation code will loop through a list of blocks and execute the following if statement on each block. If the block is valid, the hash will be returned:
```
  if(validateBlock(block)){
    return bhash;
  }
```
That sample code we provide assumes `validateBlock()` returns a boolean, but the only requirement given to the user is that `validateBlock()` prints the hash of the valid block. I propose we update this check to explicitly look for a `true` boolean, because if `validateBlock()` returns a string like "peanuts", it would still be truth-y and pass the check. 

![Screenshot from 2024-06-10 22-55-05](https://github.com/saving-satoshi/saving-satoshi/assets/1823216/718660ee-0ceb-4827-bff0-ed7a54c73aa2)

That addresses the sample validation code provided in the instructions :) The actual validation code is slightly different:

```
  if(validateBlock(block)){
    console.log(bhash)
  }
```

In this, all `validateBlock()` has to do is return something truth-y and the block hash is printed. That "peanuts" example I gave before will pass the `validateBlock()` check and print the block hash. The validation code will loop over every block, all  the `validateBlock()` calls will evaluate to true, it will print them all, and the part that compares what is printed  with the hash of the valid block (`88fd124d747cde1d8494d589ec6b82ce11356dd869823dfec8e84b111a72bc87`) will find what it's looking for and the user will pass the challenge.

In the instructions we tell the user to print the hash of the valid block, so before leaving the `validateBlock()` method, if the block is valid, the user should print the hash. That means our actual validation code doesn't need to do any printing, it just needs to execute `validateBlock(block)`.

In a follow up PR, I think it would be worthwhile to update this challenge so `validateBlock()` just needs to return a boolean, and the code that checks the answer can make sure that `validateBlock(88fd124d747cde1d8494d589ec6b82ce11356dd869823dfec8e84b111a72bc87)` returns true, while false for the other block candidate hashes.


