### PR TITLE
Chapter 8: add semicolons to default JS code, fix a success message

### DIFF
--- a/content/lessons/chapter-8/building-blocks-3.tsx
+++ b/content/lessons/chapter-8/building-blocks-3.tsx
@@ -23,11 +23,11 @@ console.log("KILL")`,
       name: 'privateKeyToPublicKey',
       args: ['privateKey'],
     },
-    defaultCode: `const Bitcoinrpc = require('@savingsatoshi/bitcoin_rpcjs')
-const Bitcoin = new Bitcoinrpc()
+    defaultCode: `const Bitcoinrpc = require('@savingsatoshi/bitcoin_rpcjs');
+const Bitcoin = new Bitcoinrpc();
 // https://github.com/saving-satoshi/bitcoin_rpcjs/blob/master/bitcoin_rpc.js
 
-console.log(Bitcoin.rpc())
+console.log(Bitcoin.rpc());
 `,
     validate: async (answer: string) => {
       if (answer) {

--- a/content/lessons/chapter-8/building-blocks-4.tsx
+++ b/content/lessons/chapter-8/building-blocks-4.tsx
@@ -34,8 +34,8 @@ console.log("KILL")`,
       name: 'getBlockHeight',
       args: ['height'],
     },
-    defaultCode: `const Bitcoinrpc = require('@savingsatoshi/bitcoin_rpcjs')
-const Bitcoin = new Bitcoinrpc()
+    defaultCode: `const Bitcoinrpc = require('@savingsatoshi/bitcoin_rpcjs');
+const Bitcoin = new Bitcoinrpc();
 
 const CODE_CHALLENGE_2_HEIGHT = 6929996;
 let txCount = Infinity;

--- a/content/lessons/chapter-8/building-blocks-5.tsx
+++ b/content/lessons/chapter-8/building-blocks-5.tsx
@@ -28,17 +28,17 @@ console.log("KILL")`,
       name: 'getBlockTxFee',
       args: [''],
     },
-    defaultCode: `const Bitcoinrpc = require('@savingsatoshi/bitcoin_rpcjs')
-const Bitcoin = new Bitcoinrpc()
-const BLOCK_HASH = "dab5708b1b3db05407e35b2004156d74f7bb5bed7f677743945cac1465b5838f"
-const TX_HASH = "7bd09aa3b4795be2839d9159edff0811d6d4ec5a64abd81c0da1e73ab00bf520"
+    defaultCode: `const Bitcoinrpc = require('@savingsatoshi/bitcoin_rpcjs');
+const Bitcoin = new Bitcoinrpc();
+const BLOCK_HASH = "dab5708b1b3db05407e35b2004156d74f7bb5bed7f677743945cac1465b5838f";
+const TX_HASH = "7bd09aa3b4795be2839d9159edff0811d6d4ec5a64abd81c0da1e73ab00bf520";
 
 
 // First we need to find the block associated with the corresponding tx hash
 // build a function that will call getTxFee when it finds a transaction with the correct TX_HASH
 // this is the function that we will call for validation
 const getBlockTxFee = () => {
-  let block = Bitcoin.rpc("getblock", BLOCK_HASH)
+  let block = Bitcoin.rpc("getblock", BLOCK_HASH);
   // YOUR CODE HERE
 
   return 0;
@@ -46,10 +46,10 @@ const getBlockTxFee = () => {
 
 // Now let's find the miner's fee for this transaction.
 // with the transaction from above determine the fee paid to miners
-const getTxFee = (tx) =>{
-  let fee = 0
+const getTxFee = (tx) => {
+  let fee = 0;
   // YOUR CODE HERE
-  return fee
+  return fee;
 }
 `,
     validate: async (answer) => {

--- a/content/lessons/chapter-8/building-blocks-7.tsx
+++ b/content/lessons/chapter-8/building-blocks-7.tsx
@@ -87,8 +87,8 @@ export default function BuildingBlocks7({ lang }) {
       name: 'privateKeyToPublicKey',
       args: ['privateKey'],
     },
-    defaultCode: `const Bitcoinrpc = require('@savingsatoshi/bitcoin_rpcjs')
-const Bitcoin = new Bitcoinrpc()
+    defaultCode: `const Bitcoinrpc = require('@savingsatoshi/bitcoin_rpcjs');
+const Bitcoin = new Bitcoinrpc();
 
 ${cleanedCombinedCode}
 

--- a/content/lessons/chapter-8/building-blocks-8.tsx
+++ b/content/lessons/chapter-8/building-blocks-8.tsx
@@ -68,8 +68,8 @@ console.log("KILL")`,
       name: 'showtime',
       args: [''],
     },
-    defaultCode: `const Bitcoinrpc = require('@savingsatoshi/bitcoin_rpcjs')
-const Bitcoin = new Bitcoinrpc()
+    defaultCode: `const Bitcoinrpc = require('@savingsatoshi/bitcoin_rpcjs');
+const Bitcoin = new Bitcoinrpc();
 
 ${cleanedCombinedCode}
 

--- a/content/resources/chapter-8/building-blocks-3.tsx
+++ b/content/resources/chapter-8/building-blocks-3.tsx
@@ -20,8 +20,8 @@ const javascriptChallenge = {
     name: '',
     args: [],
   },
-  defaultCode: `let info = Bitcoin.rpc("getinfo")
-console.log(info.difficulty)
+  defaultCode: `let info = Bitcoin.rpc("getinfo");
+console.log(info.difficulty);
   `,
   validate: async (answer) => {
     return [true, undefined]

--- a/content/resources/chapter-8/building-blocks-4.tsx
+++ b/content/resources/chapter-8/building-blocks-4.tsx
@@ -34,7 +34,7 @@ const javascriptChallenge = {
       answer = bhash;
     }
   }
-  return answer
+  return answer;
   }`,
   validate: async (answer) => {
     if (answer !== 'True') {

--- a/content/resources/chapter-8/building-blocks-5.tsx
+++ b/content/resources/chapter-8/building-blocks-5.tsx
@@ -21,10 +21,10 @@ const javascriptChallenge = {
     args: [],
   },
   defaultCode: `const getBlockTxFee = () => {
-    let block = Bitcoin.rpc("getblock", BLOCK_HASH)
+    let block = Bitcoin.rpc("getblock", BLOCK_HASH);
     for (const tx of block["txs"]) {
-      if(tx["txid"] === TX_HASH){
-        return getTxFee(tx)
+      if (tx["txid"] === TX_HASH){
+        return getTxFee(tx);
     }
   }
 }
@@ -32,14 +32,14 @@ const javascriptChallenge = {
 // Now let's find the miner's fee for this transaction.
 // with the transaction from above determine the fee paid to miners
 const getTxFee = (tx) =>{
-  let fee = 0
+  let fee = 0;
   for (const input of tx["inputs"]) {
-        fee+=input["value"]
+        fee+=input["value"];
   }
   for (const ouput of tx["outputs"]) {
-      fee-=ouput["value"]
+      fee-=ouput["value"];
   }
-  return fee
+  return fee;
 }`,
   validate: async (answer) => {
     return [true, undefined]

--- a/content/resources/chapter-8/building-blocks-6.tsx
+++ b/content/resources/chapter-8/building-blocks-6.tsx
@@ -28,7 +28,7 @@ const javascriptChallenge = {
   let subsidy = BigInt(5000000000);
   subsidy >>= halvings;
 
-  return Number(subsidy)
+  return Number(subsidy);
 }`,
   validate: async (answer) => {
     return [true, undefined]

--- a/content/resources/chapter-8/building-blocks-7.tsx
+++ b/content/resources/chapter-8/building-blocks-7.tsx
@@ -27,7 +27,7 @@ const javascriptChallenge = {
     fee += getTxFee(block["txs"][i]);
   }
 
-  return subsidy + fee === block["txs"][0]["outputs"][0]["value"]
+  return subsidy + fee === block["txs"][0]["outputs"][0]["value"];
 }`,
   validate: async (answer) => {
     return [true, undefined]

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1165,7 +1165,7 @@ const translations = {
       paragraph_three:
         "Let's see if you can verify Vanderpoole's message and signature using one of THESE keys?",
       success:
-        "The signature is valid for this public key of Vanderpoole's, this was not satoshi!",
+        "The signature is valid for this public key of Vanderpoole's, this was not Satoshi!",
     },
     outro_one: {
       title: 'Outro',
@@ -1804,7 +1804,7 @@ const translations = {
       paragraph_five: 'AND THAT LAST HALVING WAS YESTERDAY!',
       paragraph_six:
         'Finish the implementation of the following function that accepts a block height as an argument and returns the value of the subsidy in satoshis.',
-      success: 'The (get subsidy) function looks great. Nice work!',
+      success: 'The get_subsidy function looks great. Nice work!',
     },
     building_blocks_seven: {
       title: 'Building Blocks',


### PR DESCRIPTION
This PR adds semicolons to a lot of the default JS starter code that comes with challenges. I know it technically doesn't matter, but adding them makes the code consistent with the other chapters.

I also fixed the success message issue I filed here, https://github.com/saving-satoshi/saving-satoshi/issues/991. Didn't do anything fancy, just changed `(get subsidy)` to `get_subsidy` because I saw other success messages use the python function name.