### PR TITLE
Chapter 5: fix copy bug

### DIFF
--- a/content/lessons/chapter-5/verify-signature-2.tsx
+++ b/content/lessons/chapter-5/verify-signature-2.tsx
@@ -120,7 +120,7 @@ export default function VerifySignature2({ lang }) {
           {t(`chapter_five.verify_signature_two.paragraph_one`)}
         </Text>
         <Text className="mt-4 font-nunito text-xl text-white">
-          {t(`chapter_five.verify_signature_two.${language}.paragraph_two`)}
+          {t(`chapter_five.verify_signature_two.paragraph_two`)}
         </Text>
         <Text className="mt-4 font-nunito text-xl text-white">
           {t(`chapter_five.verify_signature_two.paragraph_three`)}


### PR DESCRIPTION
Just noticed this bug on one of the chapter 5 challenge instructions: https://savingsatoshi.com/en/chapters/chapter-5/verify-signature-2

![Screenshot from 2024-06-19 15-05-34](https://github.com/saving-satoshi/saving-satoshi/assets/1823216/0965eba3-2957-4311-a708-a0c1a5f9f5f1)


Fixed:

![Screenshot from 2024-06-19 15-07-06](https://github.com/saving-satoshi/saving-satoshi/assets/1823216/43290864-47f8-4ecc-a323-b6e347fbd58c)
