### PR TITLE
Chapter 5, verify-signature-*: design and resource page updates

### DIFF
--- a/content/lessons/chapter-5/verify-signature-2.tsx
+++ b/content/lessons/chapter-5/verify-signature-2.tsx
@@ -34,7 +34,7 @@ console.log("KILL")
   defaultCode: `const {Hash} = require('crypto');
 
 function msg_to_integer(msg) {
-  // Given a hex string to sign, convert that string to bytes,
+  // Given a hex string to sign, convert that string to a Buffer of bytes,
   // double-SHA256 the bytes and then return a BigInt() from the 32-byte digest.
 
 }

--- a/content/lessons/chapter-5/verify-signature-3.tsx
+++ b/content/lessons/chapter-5/verify-signature-3.tsx
@@ -48,7 +48,7 @@ export default function DeriveMessage6({ lang }) {
           {t('chapter_five.verify_signature_three.paragraph_two')}
         </Text>
 
-        <div className="mt-[30px] border-2 border-dashed border-white">
+        <div className="mt-[30px] border border-white/50 bg-[#00000033] p-2">
           <p className="max-w-[900px] px-[15px] py-[10px] text-left font-space-mono text-base md:text-lg">
             {t('chapter_five.verify_signature_three.paragraph_three')}
           </p>

--- a/content/lessons/chapter-5/verify-signature-4.tsx
+++ b/content/lessons/chapter-5/verify-signature-4.tsx
@@ -44,7 +44,7 @@ export default function DeriveMessage6({ lang }) {
           {t('chapter_five.verify_signature_four.paragraph_one')}
         </Text>
 
-        <div className="mt-[30px] border-2 border-dashed border-white">
+        <div className="mt-[30px] border border-white/50 bg-[#00000033] p-2">
           <p className="max-w-[900px] px-[15px] py-[10px] text-left font-space-mono text-base md:text-lg">
             {t('chapter_five.verify_signature_four.paragraph_two')}
           </p>

--- a/content/resources/chapter-5/verify-signature-2.tsx
+++ b/content/resources/chapter-5/verify-signature-2.tsx
@@ -21,11 +21,14 @@ const javascriptChallenge = {
     args: [],
   },
   defaultCode: `function msg_to_integer(msg) {
-  // Given a hex string to sign, convert that string to bytes,
-  // double-SHA256 the bytes and then return a BigInt() from the 32-byte digest.
+  // Given a hex string to sign, convert that string to a buffer of bytes
   const bytes = Buffer.from(msg, 'hex');
+
+  // double-SHA256 the bytes
   const single_hash = Hash('sha256').update(bytes).digest();
   const double_hash = Hash('sha256').update(single_hash).digest();
+
+  // return a BigInt() from the 32-byte digest
   return BigInt('0x' + double_hash.toString('hex'));
 }`,
   validate: async (answer) => {
@@ -110,24 +113,6 @@ export default function VerifySignatureResourcesTwo({ lang }) {
       readingResources={
         <>
           <Text className="mt-[25px] text-xl font-bold">
-            {t('chapter_five.resources.verify_signature.eliptic_curve_heading')}
-          </Text>
-          <Text>
-            {t(
-              'chapter_five.resources.verify_signature.eliptic_curve_paragraph_one'
-            )}
-          </Text>
-          <Text className="mt-[25px] text-xl font-bold">
-            {t(
-              'chapter_five.resources.verify_signature.public_private_key_heading'
-            )}
-          </Text>
-          <Text>
-            {t(
-              'chapter_five.resources.verify_signature.public_private_key_paragraph_one'
-            )}
-          </Text>
-          <Text className="mt-[25px] text-xl font-bold">
             {t(
               'chapter_five.resources.verify_signature.signature_verification_heading'
             )}
@@ -137,35 +122,12 @@ export default function VerifySignatureResourcesTwo({ lang }) {
               'chapter_five.resources.verify_signature.signature_verification_paragraph_one'
             )}
           </Text>
-          <Text className="mt-[25px] text-xl font-bold">
-            {t(
-              'chapter_five.resources.verify_signature.finite_field_arithmetic_heading'
-            )}
-          </Text>
-          <Text>
-            {t(
-              'chapter_five.resources.verify_signature.finite_field_arithmetic_paragraph_one'
-            )}
-          </Text>
-          <Text className="mt-[25px] text-xl font-bold">
-            {t('chapter_five.resources.verify_signature.ge_and_fe_heading')}
-          </Text>
-          <Text>
-            {t(
-              'chapter_five.resources.verify_signature.ge_and_fe_paragraph_one'
-            )}
-          </Text>
-          <Text className="mt-[25px] text-xl font-bold">
-            {t(
-              'chapter_five.resources.verify_signature.modular_inverse_heading'
-            )}
-          </Text>
-          <Text>
-            {t(
-              'chapter_five.resources.verify_signature.modular_inverse_paragraph_one'
-            )}
-          </Text>
         </>
+      }
+      tipsResources={
+        <ul className="list-inside list-disc font-nunito text-white">
+          <li>{t('chapter_five.resources.verify_signature_two.tip_one')}</li>
+        </ul>
       }
       codeResources={
         <>

--- a/content/resources/chapter-5/verify-signature-3.tsx
+++ b/content/resources/chapter-5/verify-signature-3.tsx
@@ -23,24 +23,6 @@ export default function VerifySignatureResourcesThree({ lang }) {
       readingResources={
         <>
           <Text className="mt-[25px] text-xl font-bold">
-            {t('chapter_five.resources.verify_signature.eliptic_curve_heading')}
-          </Text>
-          <Text>
-            {t(
-              'chapter_five.resources.verify_signature.eliptic_curve_paragraph_one'
-            )}
-          </Text>
-          <Text className="mt-[25px] text-xl font-bold">
-            {t(
-              'chapter_five.resources.verify_signature.public_private_key_heading'
-            )}
-          </Text>
-          <Text>
-            {t(
-              'chapter_five.resources.verify_signature.public_private_key_paragraph_one'
-            )}
-          </Text>
-          <Text className="mt-[25px] text-xl font-bold">
             {t(
               'chapter_five.resources.verify_signature.signature_verification_heading'
             )}
@@ -48,34 +30,6 @@ export default function VerifySignatureResourcesThree({ lang }) {
           <Text>
             {t(
               'chapter_five.resources.verify_signature.signature_verification_paragraph_one'
-            )}
-          </Text>
-          <Text className="mt-[25px] text-xl font-bold">
-            {t(
-              'chapter_five.resources.verify_signature.finite_field_arithmetic_heading'
-            )}
-          </Text>
-          <Text>
-            {t(
-              'chapter_five.resources.verify_signature.finite_field_arithmetic_paragraph_one'
-            )}
-          </Text>
-          <Text className="mt-[25px] text-xl font-bold">
-            {t('chapter_five.resources.verify_signature.ge_and_fe_heading')}
-          </Text>
-          <Text>
-            {t(
-              'chapter_five.resources.verify_signature.ge_and_fe_paragraph_one'
-            )}
-          </Text>
-          <Text className="mt-[25px] text-xl font-bold">
-            {t(
-              'chapter_five.resources.verify_signature.modular_inverse_heading'
-            )}
-          </Text>
-          <Text>
-            {t(
-              'chapter_five.resources.verify_signature.modular_inverse_paragraph_one'
             )}
           </Text>
         </>

--- a/content/resources/chapter-5/verify-signature-4.tsx
+++ b/content/resources/chapter-5/verify-signature-4.tsx
@@ -22,59 +22,23 @@ export default function VerifySignatureResourcesFour({ lang }) {
       readingResources={
         <>
           <Text className="mt-[25px] text-xl font-bold">
-            {t('chapter_five.resources.verify_signature.eliptic_curve_heading')}
+            {t(
+              'chapter_five.resources.verify_signature_four.eliptic_curve_heading'
+            )}
           </Text>
           <Text>
             {t(
-              'chapter_five.resources.verify_signature.eliptic_curve_paragraph_one'
+              'chapter_five.resources.verify_signature_four.eliptic_curve_paragraph_one'
             )}
           </Text>
           <Text className="mt-[25px] text-xl font-bold">
             {t(
-              'chapter_five.resources.verify_signature.public_private_key_heading'
+              'chapter_five.resources.verify_signature_four.public_private_key_heading'
             )}
           </Text>
           <Text>
             {t(
-              'chapter_five.resources.verify_signature.public_private_key_paragraph_one'
-            )}
-          </Text>
-          <Text className="mt-[25px] text-xl font-bold">
-            {t(
-              'chapter_five.resources.verify_signature.signature_verification_heading'
-            )}
-          </Text>
-          <Text>
-            {t(
-              'chapter_five.resources.verify_signature.signature_verification_paragraph_one'
-            )}
-          </Text>
-          <Text className="mt-[25px] text-xl font-bold">
-            {t(
-              'chapter_five.resources.verify_signature.finite_field_arithmetic_heading'
-            )}
-          </Text>
-          <Text>
-            {t(
-              'chapter_five.resources.verify_signature.finite_field_arithmetic_paragraph_one'
-            )}
-          </Text>
-          <Text className="mt-[25px] text-xl font-bold">
-            {t('chapter_five.resources.verify_signature.ge_and_fe_heading')}
-          </Text>
-          <Text>
-            {t(
-              'chapter_five.resources.verify_signature.ge_and_fe_paragraph_one'
-            )}
-          </Text>
-          <Text className="mt-[25px] text-xl font-bold">
-            {t(
-              'chapter_five.resources.verify_signature.modular_inverse_heading'
-            )}
-          </Text>
-          <Text>
-            {t(
-              'chapter_five.resources.verify_signature.modular_inverse_paragraph_one'
+              'chapter_five.resources.verify_signature_four.public_private_key_paragraph_one'
             )}
           </Text>
         </>

--- a/content/resources/chapter-5/verify-signature-5.tsx
+++ b/content/resources/chapter-5/verify-signature-5.tsx
@@ -199,24 +199,6 @@ export default function VerifySignatureResourcesFive({ lang }) {
       readingResources={
         <>
           <Text className="mt-[25px] text-xl font-bold">
-            {t('chapter_five.resources.verify_signature.eliptic_curve_heading')}
-          </Text>
-          <Text>
-            {t(
-              'chapter_five.resources.verify_signature.eliptic_curve_paragraph_one'
-            )}
-          </Text>
-          <Text className="mt-[25px] text-xl font-bold">
-            {t(
-              'chapter_five.resources.verify_signature.public_private_key_heading'
-            )}
-          </Text>
-          <Text>
-            {t(
-              'chapter_five.resources.verify_signature.public_private_key_paragraph_one'
-            )}
-          </Text>
-          <Text className="mt-[25px] text-xl font-bold">
             {t(
               'chapter_five.resources.verify_signature.signature_verification_heading'
             )}
@@ -228,30 +210,32 @@ export default function VerifySignatureResourcesFive({ lang }) {
           </Text>
           <Text className="mt-[25px] text-xl font-bold">
             {t(
-              'chapter_five.resources.verify_signature.finite_field_arithmetic_heading'
+              'chapter_five.resources.verify_signature_five.finite_field_arithmetic_heading'
             )}
           </Text>
           <Text>
             {t(
-              'chapter_five.resources.verify_signature.finite_field_arithmetic_paragraph_one'
-            )}
-          </Text>
-          <Text className="mt-[25px] text-xl font-bold">
-            {t('chapter_five.resources.verify_signature.ge_and_fe_heading')}
-          </Text>
-          <Text>
-            {t(
-              'chapter_five.resources.verify_signature.ge_and_fe_paragraph_one'
+              'chapter_five.resources.verify_signature_five.finite_field_arithmetic_paragraph_one'
             )}
           </Text>
           <Text className="mt-[25px] text-xl font-bold">
             {t(
-              'chapter_five.resources.verify_signature.modular_inverse_heading'
+              'chapter_five.resources.verify_signature_five.ge_and_fe_heading'
             )}
           </Text>
           <Text>
             {t(
-              'chapter_five.resources.verify_signature.modular_inverse_paragraph_one'
+              'chapter_five.resources.verify_signature_five.ge_and_fe_paragraph_one'
+            )}
+          </Text>
+          <Text className="mt-[25px] text-xl font-bold">
+            {t(
+              'chapter_five.resources.verify_signature_five.modular_inverse_heading'
+            )}
+          </Text>
+          <Text>
+            {t(
+              'chapter_five.resources.verify_signature_five.modular_inverse_paragraph_one'
             )}
           </Text>
         </>

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1090,7 +1090,7 @@ const translations = {
       paragraph_two:
         'The ECDSA signature verification algorithm is explained <Link className="underline" href="https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm#Signature_verification_algorithm" target="_blank">here</Link> and <Link className="underline" href="https://www.secg.org/sec1-v2.pdf#page=52" target="_blank">here</Link>.',
       paragraph_three:
-        'We created a Group Element object from the public key X and Y elements for you. You need to finish implementing the ECDSA signature verification function <span className="text-green">verify()</span> that should only return True if everything is valid!',
+        'We created a Group Element object from the public key X and Y elements for you. You need to finish implementing the ECDSA signature verification function <span className="text-green p-1 font-mono bg-[#00000033] m-1">verify()</span> that should only return True if everything is valid!',
       paragraph_four:
         "We know Satoshi's signature is valid, it has been checked by every Bitcoin full node since 2010! If your program does not return True something is wrong.",
       python: {
@@ -1101,7 +1101,7 @@ const translations = {
       },
       javascript: {
         paragraph_five_part_one:
-          'We have provided a helper function <span className="text-green">invert()</span>',
+          'We have provided a helper function <span className="text-green p-1 font-mono bg-[#00000033] m-1">invert()</span>',
         paragraph_five_part_two:
           'which you will need in lieu of a JavaScript native modular exponentiation function.',
       },
@@ -1181,6 +1181,15 @@ const translations = {
           'OP_PUSHDATA in Bitcoin script plays a crucial role in facilitating the insertion of arbitrary pieces of data into the blockchain. It is an opcode that allows for the inclusion of data elements of varying sizes, making Bitcoin’s scripting language more versatile. This opcode is particularly significant in enabling the implementation of various smart contract functionalities and custom transaction types. You can read more about some of these OP_CODES and more <Link href="https://en.bitcoin.it/wiki/Script#Constants" target="_blank" className="underline">here</Link>.',
       },
       verify_signature: {
+        signature_verification_heading: 'Signature Verification',
+        signature_verification_paragraph_one:
+          'Signature verification is crucial in Bitcoin to confirm that a transaction is authorized by the holder of the private key. In the context of ECDSA, it involves checking that a signature (comprising two numbers, r and s) is valid for a given public key and message. This verification ensures the integrity and authenticity of a transaction.',
+      },
+      verify_signature_two: {
+        tip_one:
+          'JavaScript hint: You can convert a hex string to a buffer of bytes using <span className="p-1 font-mono bg-[#00000033] m-1">Buffer.from(someString, \'hex\');</span>',
+      },
+      verify_signature_four: {
         eliptic_curve_heading:
           'Elliptic Curve Digital Signature Algorithm (ECDSA)',
         eliptic_curve_paragraph_one:
@@ -1188,9 +1197,8 @@ const translations = {
         public_private_key_heading: 'Public and Private Keys',
         public_private_key_paragraph_one:
           'In Bitcoin, a pair of keys is used to ensure secure transactions. The private key, kept secret, is used to sign transactions and prove ownership of a Bitcoin address. The public key, derived from the private key, can be shared and is used to verify that a signature is made by the private key holder, without revealing the private key.',
-        signature_verification_heading: 'Signature Verification',
-        signature_verification_paragraph_one:
-          'Signature verification is crucial in Bitcoin to confirm that a transaction is authorized by the holder of the private key. In the context of ECDSA, it involves checking that a signature (comprising two numbers, r and s) is valid for a given public key and message. This verification ensures the integrity and authenticity of a transaction.',
+      },
+      verify_signature_five: {
         finite_field_arithmetic_heading: 'Finite Field Arithmetic',
         finite_field_arithmetic_paragraph_one:
           "This type of arithmetic, used in ECDSA, involves numbers within a fixed range or field. Operations such as addition, subtraction, multiplication, and finding modular inverses are performed with respect to the size of this field. This is essential for the elliptic curve calculations in Bitcoin's cryptography.",


### PR DESCRIPTION
This PR is a bunch of misc updates to Chapter 5, section 3 (verify-signature-*). To test it, click around https://saving-satoshi-git-fork-satsie-ch-5-js-tip-savingsatoshi.vercel.app/en/chapters/chapter-5/verify-signature-2 through https://saving-satoshi-git-fork-satsie-ch-5-js-tip-savingsatoshi.vercel.app/en/chapters/chapter-5/verify-signature-5

**Here's what's changing:**

- Update a few of the text blocks to look more like the rest of the layout:

![Screenshot from 2024-06-20 22-12-43](https://github.com/saving-satoshi/saving-satoshi/assets/1823216/be4d3157-4e91-4ef5-b6d7-625d99067836)


- verify-signature-2: add a JavaScript hint. I put this in because I know at some point we want to track if spoilers are viewed. In that scenario, I assume we'd want to provide as much help to the user as we can so that viewing the spoiler is a last resort.

I added this specific tip because I initially tried to make an array of bytes instead of a buffer :facepalm: 

![Screenshot from 2024-06-20 23-10-15](https://github.com/saving-satoshi/saving-satoshi/assets/1823216/2a2e73a3-90ee-4e32-a2f8-5e94b94da713)

- First pass at cleaning up the resources pages so they aren't all the same for every challenge. It still needs work, and I did not add anything. Apologies if anyone is currently working on refactoring the chapter 5 resources. I did not intend to make these changes when I started the branch.


