### PR TITLE
chore: Removed unused python import

### DIFF
--- a/content/lessons/chapter-5/verify-signature-2.tsx
+++ b/content/lessons/chapter-5/verify-signature-2.tsx
@@ -58,7 +58,6 @@ print("KILL")
   },
   defaultCode: `# Import from python standard libraries
 import hashlib
-import base64
 
 def msg_to_integer(msg):
     # Given a hex string to sign, convert that string to bytes,


### PR DESCRIPTION
in chapter-5/verify-signature-2 we don't need to import base64 in python since this challenge is just hashing not a string decoding.
