### PR TITLE
fix: Fixed race condition for local storage write on signup

### DIFF
--- a/api/auth/login.ts
+++ b/api/auth/login.ts
@@ -1,5 +1,5 @@
 import { SAVING_SATOSHI_TOKEN } from 'config/keys'
-import { post } from 'utils'
+import { post, setAndVerifyLocalStorage } from 'utils'
 
 export default async function login(privateKey) {
   try {
@@ -9,8 +9,7 @@ export default async function login(privateKey) {
         private_key: privateKey,
       },
     })
-
-    window.localStorage.setItem(SAVING_SATOSHI_TOKEN, token)
+    setAndVerifyLocalStorage(SAVING_SATOSHI_TOKEN, token)
 
     return true
   } catch (errors) {

--- a/state/progressState.ts
+++ b/state/progressState.ts
@@ -794,7 +794,7 @@ export const loadProgressAtom = atom(null, async (get, set) => {
 
   set(isLoadingProgressAtom, true)
 
-  let progress = null
+  let progress = defaultProgressState
   if (account) {
     progress = await getProgress()
   }

--- a/state/progressState.ts
+++ b/state/progressState.ts
@@ -789,21 +789,24 @@ function mergeProgressState(
 export const loadProgressAtom = atom(null, async (get, set) => {
   const account = get(accountAtom)
   const isLoadingAccount = get(isAuthLoadingAtom)
+
   if (isLoadingAccount) return
+
+  set(isLoadingProgressAtom, true)
+
+  let progress = null
   if (account) {
-    set(isLoadingProgressAtom, true)
-    const progressFromServer = await getProgress()
-    set(
-      syncedCourseProgressAtom,
-      mergeProgressState(defaultProgressState, progressFromServer)
-    )
-  } else {
-    const progressFromLocalStorage = await getProgressLocal()
-    set(
-      syncedCourseProgressAtom,
-      mergeProgressState(defaultProgressState, progressFromLocalStorage)
-    )
+    progress = await getProgress()
   }
+
+  if (!progress || !account) {
+    progress = await getProgressLocal()
+  }
+
+  set(
+    syncedCourseProgressAtom,
+    mergeProgressState(defaultProgressState, progress)
+  )
   set(isProgressLoadedAtom, true)
   set(isLoadingProgressAtom, false)
 })

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -34,3 +34,34 @@ export const sleep = (time: number): Promise<void> => {
     setTimeout(resolve, time)
   })
 }
+
+export function setAndVerifyLocalStorage(
+  key,
+  value,
+  maxAttempts = 10,
+  interval = 50
+) {
+  return new Promise((resolve, reject) => {
+    localStorage.setItem(key, value)
+
+    let attempts = 0
+    const checkValue = () => {
+      attempts++
+      const storedValue = localStorage.getItem(key)
+
+      if (storedValue === value) {
+        resolve(storedValue)
+      } else if (attempts >= maxAttempts) {
+        reject(
+          new Error(
+            `Failed to verify localStorage value after ${maxAttempts} attempts`
+          )
+        )
+      } else {
+        setTimeout(checkValue, interval)
+      }
+    }
+
+    checkValue()
+  })
+}


### PR DESCRIPTION
There was a race condition when writing the session token on signup so occasionally the signup modal would fail to close.