### PR TITLE
Script case

### DIFF
--- a/ui/lesson/OpRunner/OPFunctions.ts
+++ b/ui/lesson/OpRunner/OPFunctions.ts
@@ -66,7 +66,6 @@ export const opFunctions: { [key: string]: Function } = {
     }
   },
   OP_PUSH: (stack: StackType, tokens: T, index: number) => {
-    console.log(stack, 'op_push')
     if (!stack) return null
     if (!tokens[index + 1]?.value) {
       return {

--- a/ui/lesson/OpRunner/OPFunctions.ts
+++ b/ui/lesson/OpRunner/OPFunctions.ts
@@ -313,11 +313,17 @@ export const opFunctions: { [key: string]: Function } = {
     }
     const a = stack.pop()
     const b = stack.pop()
+
     if (a != b) {
       return {
         value: null,
         error: 'OP_EQUALVERIFY: top two stack elements are not equal',
       }
+    }
+
+    return {
+      value: null,
+      error: null,
     }
   },
   OP_DUP: (stack: StackType) => {

--- a/ui/lesson/OpRunner/OpRunner.tsx
+++ b/ui/lesson/OpRunner/OpRunner.tsx
@@ -67,7 +67,7 @@ const OpRunner = ({
 
   const handleInitialStackChange = (event) => {
     handleReset()
-    setInitialStack(event.target.value)
+    setInitialStack(event.target.value.toUpperCase())
     setStartedTyping(true)
   }
 
@@ -112,7 +112,7 @@ const OpRunner = ({
           </p>
           <textarea
             title="Add OP_CODES seperated by spaces."
-            className="overflow-wrap-normal w-full resize-none break-all border-none bg-transparent font-space-mono text-lg text-white focus:outline-none"
+            className="overflow-wrap-normal w-full resize-none break-all border-none bg-transparent font-space-mono text-lg uppercase text-white focus:outline-none"
             onChange={handleScriptChange}
             autoComplete="off"
             value={script}
@@ -132,7 +132,7 @@ const OpRunner = ({
             <input
               title="Add text or numbers seperated by spaces."
               onChange={handleInitialStackChange}
-              className="flex-grow border-none bg-transparent font-space-mono text-lg focus:outline-none"
+              className="flex-grow border-none bg-transparent font-space-mono text-lg uppercase focus:outline-none"
               type="text"
               placeholder="0xA 10..."
             />

--- a/ui/lesson/OpRunner/OpRunner.tsx
+++ b/ui/lesson/OpRunner/OpRunner.tsx
@@ -27,6 +27,7 @@ const OpRunner = ({
   React.useEffect(() => {
     if (startedTyping) {
       const timeoutId = setTimeout(() => {
+        handleReset()
         handleRun()
       }, 1000)
 
@@ -61,19 +62,17 @@ const OpRunner = ({
 
   const handleScriptChange = (event) => {
     setScript(event.target.value.toUpperCase())
-    handleReset()
     setStartedTyping(true)
   }
 
   const handleInitialStackChange = (event) => {
-    handleReset()
     setInitialStack(event.target.value.toUpperCase())
     setStartedTyping(true)
   }
 
   const handleHeightChange = (event) => {
-    handleReset()
     setHeight(parseInt(event.target.value))
+    setStartedTyping(true)
   }
 
   const checkSuccessState = (tokens: T, stack: StackType) => {

--- a/ui/lesson/OpRunner/OpRunner.tsx
+++ b/ui/lesson/OpRunner/OpRunner.tsx
@@ -27,7 +27,6 @@ const OpRunner = ({
   React.useEffect(() => {
     if (startedTyping) {
       const timeoutId = setTimeout(() => {
-        handleReset()
         handleRun()
       }, 1000)
 
@@ -62,15 +61,18 @@ const OpRunner = ({
 
   const handleScriptChange = (event) => {
     setScript(event.target.value.toUpperCase())
+    handleReset()
     setStartedTyping(true)
   }
 
   const handleInitialStackChange = (event) => {
+    handleReset()
     setInitialStack(event.target.value.toUpperCase())
     setStartedTyping(true)
   }
 
   const handleHeightChange = (event) => {
+    handleReset()
     setHeight(parseInt(event.target.value))
     setStartedTyping(true)
   }


### PR DESCRIPTION
This makes all text inputs in the OPRunner upper case and fixes an error in `OP_EQUALVERIFY` not returning anything