### PR TITLE
fix: correct elliptic curve equation s/x^2/x^3/ in chapter 4

### DIFF
--- a/content/lessons/chapter-4/public-key-2.tsx
+++ b/content/lessons/chapter-4/public-key-2.tsx
@@ -132,7 +132,7 @@ export default function PublicKey2({ lang }) {
             </span>
           </div>
           <span className="mb-4 font-space-mono text-xl text-white xl:text-3xl">
-            y^2 = x^2 + 7
+            y^2 = x^3 + 7
           </span>
         </div>
       }


### PR DESCRIPTION
Adapt the curve equation to match secp256k1: $y^2 = x^3 + 7$
Note that the curve $y^2 = x^2 + 7$ would look very different, see e.g. https://www.desmos.com/calculator/ for trying out.