### PR TITLE
Preload images

### DIFF
--- a/hooks/useProceed.ts
+++ b/hooks/useProceed.ts
@@ -1,5 +1,6 @@
 'use client'
 
+import React from 'react'
 import { useRouter, usePathname } from 'next/navigation'
 import { useLocalizedRoutes, usePathData } from 'hooks'
 import useEnvironment from './useEnvironment'
@@ -32,21 +33,51 @@ export default function useProceed() {
   const markLessonAsComplete = useSetAtom(markLessonAsCompleteAtom)
   const currentLesson = getLessonById(currentLessonId, courseProgress)
 
-  const Proceed = () => {
-    let route
+  const route = React.useMemo(() => {
     if (
       (isDevelopment || currentLesson?.completed) &&
       nextLessonUsingCurrentRoute
     ) {
-      route =
+      return (
         routes.chaptersUrl + nextLessonUsingCurrentRoute?.path + queryParams
+      )
+    } else {
+      return routes.chaptersUrl + nextLessonPath + queryParams
+    }
+  }, [
+    isDevelopment,
+    currentLesson,
+    nextLessonUsingCurrentRoute,
+    routes.chaptersUrl,
+    nextLessonPath,
+    queryParams,
+  ])
+
+  React.useEffect(() => {
+    console.log('prefetching', route)
+    router.prefetch(route)
+  }, [route, router])
+
+  const Proceed = React.useCallback(() => {
+    if (
+      (isDevelopment || currentLesson?.completed) &&
+      nextLessonUsingCurrentRoute
+    ) {
       markLessonAsComplete(currentLessonId)
     } else {
-      route = routes.chaptersUrl + nextLessonPath + queryParams
       progressToNextLesson()
     }
     router.push(route, { scroll: true })
-  }
+  }, [
+    isDevelopment,
+    currentLesson,
+    nextLessonUsingCurrentRoute,
+    markLessonAsComplete,
+    currentLessonId,
+    progressToNextLesson,
+    router,
+    route,
+  ])
 
   return Proceed
 }

--- a/shared/Button.tsx
+++ b/shared/Button.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 
 export default function Button({
   href,
@@ -26,7 +25,6 @@ export default function Button({
   full?: boolean
   round?: boolean
 }) {
-  const router = useRouter()
   const isLink = href !== undefined
   let className = `inline-block justify-center px-12 text-center font-nunito font-bold transition duration-150 ease-in-out ${
     full ? 'w-full' : 'md:w-auto'
@@ -103,10 +101,6 @@ export default function Button({
 
   if (round) {
     className += ' rounded'
-  }
-  // Prefetch the URL when the component loads
-  if (href && !disabled && !external) {
-    router.prefetch(href)
   }
 
   if (isLink) {

--- a/shared/Button.tsx
+++ b/shared/Button.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 
 export default function Button({
   href,
@@ -25,6 +26,7 @@ export default function Button({
   full?: boolean
   round?: boolean
 }) {
+  const router = useRouter()
   const isLink = href !== undefined
   let className = `inline-block justify-center px-12 text-center font-nunito font-bold transition duration-150 ease-in-out ${
     full ? 'w-full' : 'md:w-auto'
@@ -102,6 +104,10 @@ export default function Button({
   if (round) {
     className += ' rounded'
   }
+  // Prefetch the URL when the component loads
+  if (href && !disabled && !external) {
+    router.prefetch(href)
+  }
 
   if (isLink) {
     // Render as link
@@ -112,6 +118,7 @@ export default function Button({
         title={title}
         rel={external ? 'noreferrer nofollow' : undefined}
         target={external ? '_blank' : undefined}
+        prefetch={!external}
       >
         {children}
       </Link>

--- a/ui/chapter/Chapter.tsx
+++ b/ui/chapter/Chapter.tsx
@@ -220,10 +220,7 @@ export default function Chapter({ children, metadata, lang }) {
                         chapter.metadata.lessons.length === 0 ||
                         isLoading ||
                         !display ||
-                        (!isLoading &&
-                          position !== 1 &&
-                          !account &&
-                          !isAccountLoading)
+                        (!account && position !== 1)
                       }
                       classes={clsx('w-full', {
                         hidden:


### PR DESCRIPTION
This preloads the images in the intro pages when on the chapters selection page.  I've attempted to prefetch the route from inside the `useProceed` hook so that it preloads the images when progressing through a chapter but it's not working at the moment.
