### PR TITLE
Chapter 6, put-it-together-2-normal: fix bug with curly brace

### DIFF
--- a/content/lessons/chapter-6/normal/put-it-together-2.tsx
+++ b/content/lessons/chapter-6/normal/put-it-together-2.tsx
@@ -183,8 +183,8 @@ console.log("KILL")`,
     },
     defaultCode: `const secp256k1 = require('@savingsatoshi/secp256k1js');
 const {randomBytes} = require('crypto');
-${combinedCode.slice(0, -2)}
-// YOUR CODE HERE
+${combinedCode.slice(0, -3)}
+  // YOUR CODE HERE
   compute_input_signature(index, key) {
     assert(typeof key === 'bigint');
     assert(Number.isInteger(index));

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1428,7 +1428,7 @@ const translations = {
         heading: 'Finish the implementation of Class Input',
         paragraph_one: 'It should have the following method:',
         paragraph_two:
-          'The First two arguments are the transaction ID and the index of the output of that transaction you want to spend from.',
+          'The first two arguments are the transaction ID and the index of the output of that transaction you want to spend from.',
         paragraph_three:
           'Eventually we will pass in the txid and vout values you got above from listunspent. Note that hashes in Bitcoin are little-endian, which means that you will need to reverse the byte order of the txid string!',
         paragraph_four:


### PR DESCRIPTION
In the Chapter 6 put-it-together-2-normal exercise, the default code that is loaded has an extra curly brace, causing a syntax error in the text editor. It puts the `compute_input_signature` method outside of the `Transaction` class, which I don't think is correct.

I believe the extra curly brace is coming over from the `combinedCode` variable, so I adjusted the slice parameter to not bring it in.

Before: offending curly brace on line 85
![Screenshot from 2024-08-26 15-05-46](https://github.com/user-attachments/assets/3aaed5ee-39c2-4148-9f0d-d235943a7145)

After: (the `constructor()` and `digest()` methods were collapsed in the Before screenshot)
![Screenshot from 2024-08-26 15-16-01](https://github.com/user-attachments/assets/38d801c2-6770-4456-8894-2d94e0612e4c)
