### PR TITLE
ch6 in-out-four-normal: add more detail to instructions

### DIFF
--- a/content/lessons/chapter-6/normal/in-out-4.tsx
+++ b/content/lessons/chapter-6/normal/in-out-4.tsx
@@ -166,6 +166,7 @@ class Input:
     setLanguage(language)
   }
 
+  // Tooltip #1
   const [tooltipVisible, setTooltipVisible] = useState(false)
 
   const handleMouseEnter = () => {
@@ -176,6 +177,16 @@ class Input:
     setTooltipVisible(false)
   }
 
+  // Tooltip #2
+  const [tooltipVisible2, setTooltipVisible2] = useState(false)
+
+  const handleMouseEnter2 = () => {
+    setTooltipVisible2(true)
+  }
+
+  const handleMouseLeave2 = () => {
+    setTooltipVisible2(false)
+  }
   return (
     <PlainEditorWrapper
       fixedCode={''}
@@ -188,58 +199,102 @@ class Input:
         <Text className="mt-4 font-nunito text-xl text-white">
           {t('chapter_six.in_out_four.normal.paragraph_one')}
         </Text>
+        <Text className="mt-4 font-nunito text-xl text-white">
+          {t('chapter_six.in_out_four.normal.paragraph_two')}
+        </Text>
         <CodeExample
           className="mt-4 text-wrap font-space-mono"
           code={`from_output(txid: str, vout: int, value: int, scriptcode: bytes)`}
           language="shell"
         />
         <Text className="mt-4 font-nunito text-xl text-white">
-          {t('chapter_six.in_out_four.normal.paragraph_two')}
+          {t('chapter_six.in_out_four.normal.paragraph_three')}
         </Text>
+        <Text className="ml-5 mt-4 font-nunito text-xl text-white">
+          {t('chapter_six.in_out_four.normal.paragraph_four')}
+        </Text>
+        <Text className="ml-5 mt-4 font-nunito text-xl text-white">
+          {t('chapter_six.in_out_four.normal.paragraph_five')}
+        </Text>
+        <Text className="mt-4 font-nunito text-xl text-white">
+          {t('chapter_six.in_out_four.normal.paragraph_six')}
+        </Text>
+        <Text className="mt-4 font-nunito text-xl text-white">
+          {t('chapter_six.in_out_four.normal.paragraph_seven')}
+        </Text>
+        <hr className="my-6 h-[1px] w-full opacity-25" />
 
         <Text className="mt-4 font-nunito text-xl text-white">
-          {t('chapter_six.in_out_four.normal.paragraph_three.a')}
+          {t('chapter_six.in_out_four.normal.paragraph_eight.a')}
           <a
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
-            href={t('chapter_six.in_out_four.normal.paragraph_three.b.href')}
+            href={t('chapter_six.in_out_four.normal.paragraph_eight.b.href')}
             target="_blank"
             className="inline text-lg italic hover:underline md:text-xl"
           >
-            {t('chapter_six.in_out_four.normal.paragraph_three.b.text')}
+            {t('chapter_six.in_out_four.normal.paragraph_eight.b.text')}
             <HolocatQuestion
               theme={chapters['chapter-6'].metadata.theme}
               inline
               id="tx-order"
               question={t(
-                'chapter_six.in_out_four.normal.paragraph_three.b.question'
+                'chapter_six.in_out_four.normal.paragraph_eight.b.question'
               )}
-              href={t('chapter_six.in_out_four.normal.paragraph_three.b.href')}
+              href={t('chapter_six.in_out_four.normal.paragraph_eight.b.href')}
               visible={tooltipVisible}
             />
           </a>
-          {t('chapter_six.in_out_four.normal.paragraph_three.c')}
-        </Text>
-        <Text className="mt-4 font-nunito text-xl text-white">
-          {t('chapter_six.in_out_four.normal.paragraph_four')}
+          {t('chapter_six.in_out_four.normal.paragraph_eight.c')}
         </Text>
 
         <Text className="mt-4 font-nunito text-xl text-white">
-          {t('chapter_six.in_out_four.normal.paragraph_five')}
+          {t('chapter_six.in_out_four.normal.paragraph_nine')}
         </Text>
 
-        <div className="mt-4">
-          <Title>{t('chapter_six.in_out_four.normal.heading_two')}</Title>
-        </div>
-        <Table headings={tableHeading} rows={outputRows} />
+        <hr className="my-6 h-[1px] w-full opacity-25" />
+
+        <Text className="mt-4 font-nunito text-xl text-white">
+          {t('chapter_six.in_out_four.normal.paragraph_ten')}
+        </Text>
 
         <div className="mt-4">
           <Title>{t('chapter_six.in_out_four.normal.heading_three')}</Title>
         </div>
+        <Table headings={tableHeading} rows={outputRows} />
+
+        <div className="mt-4">
+          <Title>{t('chapter_six.in_out_four.normal.heading_four')}</Title>
+        </div>
+
         <Table headings={tableHeading} rows={inputRows} />
-        <Text className="font-nunito text-2xl font-bold text-white">
-          {t('chapter_six.in_out_four.normal.paragraph_six')}
-        </Text>
+
+        <p className="mt-4">
+          <Text className="font-nunito text-xl font-bold italic text-white">
+            {t('chapter_six.in_out_four.normal.paragraph_eleven.a')}
+            <a
+              onMouseEnter={handleMouseEnter2}
+              onMouseLeave={handleMouseLeave2}
+              href={t('chapter_six.in_out_four.normal.paragraph_eleven.b.href')}
+              target="_blank"
+              className="inline font-nunito text-xl font-bold italic hover:underline md:text-xl"
+            >
+              {t('chapter_six.in_out_four.normal.paragraph_eleven.b.text')}
+              <HolocatQuestion
+                theme={chapters['chapter-6'].metadata.theme}
+                inline
+                id="endianness"
+                question={t(
+                  'chapter_six.in_out_four.normal.paragraph_eleven.b.question'
+                )}
+                href={t(
+                  'chapter_six.in_out_four.normal.paragraph_eleven.b.href'
+                )}
+                visible={tooltipVisible2}
+              />
+            </a>
+          </Text>
+        </p>
       </LessonInfo>
     </PlainEditorWrapper>
   )

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1358,22 +1358,30 @@ const translations = {
         nav_title: 'The input class',
         heading: 'Looking at the Input class implementation',
         paragraph_one:
-          'Bitcoin transaction inputs always point to existing, unspent transaction outputs. Therefore, our Input class has a method <span className="text-green"> from_output() </span> which is used to construct an Input by passing in the output description:',
+          'Here we have code for two classes: an <span className="font-bold">Input</span> class and an <span className="font-bold">Outpoint</span> (not "output"!) class.',
         paragraph_two:
-          'The first two arguments are the transaction ID and the index of the output of that transaction you want to spend from. Eventually we will pass in the txid and vout values you got above from listunspent. ',
-        paragraph_three: {
-          a: 'Hashes in bitcoin are ',
+          'Inputs come from unspent transaction outputs. If you provide the description of an output to the <span className="text-green p-1 font-mono bg-[#00000033] m-1 text-base">from_output()</span> method, it will create an instance of the Input class:',
+        paragraph_three: 'The first two arguments are:',
+        paragraph_four:
+          '1. <span className="font-bold">txid: </span>the ID of the transaction that created the output, and',
+        paragraph_five:
+          '2. <span className="font-bold">vout: </span>the index of the output in the transaction\'s entire list of outputs',
+        paragraph_six:
+          'Together, these two pieces of information make up an <span className="font-bold">Outpoint</span>. Eventually we will pass in the txid and vout values that came from executing the <span className="text-green p-1 font-mono bg-[#00000033] m-1 text-base">listunspent</span> command in the previous exercise. ',
+        paragraph_seven:
+          "The second two arguments are the value of the output we want to spend (in satoshis) and something called a scriptcode. That data is not needed until later so let's temporarily use an empty byte array.",
+        paragraph_eight: {
+          a: 'Hashes in bitcoin are',
           b: {
-            text: ' reversed ',
+            text: ' reversed',
             question: 'Why do we reverse hashes in bitcoin?',
             href: 'https://chat.bitcoinsearch.xyz/?author=holocat&question=why%2520are%2520hashes%2520reversed%2520in%2520bitcoin',
           },
-          c: ' when we see them as hexadecimal strings. When we accept hashes as strings from a user we must reverse the byte order before storing or transmitting them as raw bytes. This is why we reverse the byte order of the txid argument that is passed in here.',
+          c: `, but only when presented to or entered by a user. When a hash is provided in hexadecimal format, the byte order must be reversed before storing or transmitting the data as raw bytes.`,
         },
-        paragraph_four:
-          "The second two arguments are the value of the output we want to spend (in satoshis) and something called a scriptcode. For now, we will just store that data as an empty byte array, we won't need it until later.",
-        paragraph_five: `We also need a <span className="text-green"> serialize() </span> method that returns a byte array according to the specification. This is how the transaction is actually sent between nodes on the network, and how it is expressed in a block:`,
-        heading_two: 'Outpoint',
+        paragraph_nine: `You can see an example of this in the <span className="text-green p-1 font-mono bg-[#00000033] m-1 text-base">from_output()</span> method where it handles the txid argument.`,
+        paragraph_ten: `We also need a <span className="text-green p-1 font-mono bg-[#00000033] m-1 text-base">serialize()</span> method that returns a byte array according to the specification. This is how the transaction is actually sent between nodes on the network, and how it is expressed in a block:`,
+        heading_three: 'Outpoint',
         table_one: {
           heading: {
             one: 'Description',
@@ -1398,7 +1406,7 @@ const translations = {
             },
           },
         },
-        heading_three: 'Input',
+        heading_four: 'Input',
         table_two: {
           row_one: {
             column: {
@@ -1433,8 +1441,14 @@ const translations = {
             },
           },
         },
-        paragraph_six:
-          'And remember: integers in bitcoin are serialized little-endian!',
+        paragraph_eleven: {
+          a: 'Remember: integers in bitcoin are serialized ',
+          b: {
+            text: 'little-endian',
+            question: 'What is endianness?',
+            href: 'https://chat.bitcoinsearch.xyz/?author=holocat&question=What%2520is%2520endianness%253F',
+          },
+        },
         success: 'The Input class looks good. Great Work!',
       },
       hard: {


### PR DESCRIPTION
In this PR I've fleshed out some of the instructions for chapter 6's in-out-four-normal challenge. I'd like to copy some of these updates over to the hard version of the challenge, but will do so as a separate PR.

Before:

![Screenshot from 2024-08-29 14-54-03](https://github.com/user-attachments/assets/fbc0112b-e61b-46a1-897a-7dca7dbd1147)

After:

![Screenshot from 2024-11-06 21-52-19](https://github.com/user-attachments/assets/502c8501-f44f-4b83-93ee-7ef63b73f9ec)

![Screenshot from 2024-11-06 21-56-41](https://github.com/user-attachments/assets/45f270e3-1e4b-4ed7-83c0-d8a3834ac139)

[Preview](https://saving-satoshi-git-fork-satsie-ch6-challen-611092-savingsatoshi.vercel.app/en/chapters/chapter-6/in-out-4-normal?dev=true)
