### PR TITLE
Script Highlighting

### DIFF
--- a/ui/lesson/OpCodeChallenge/OpRunner.tsx
+++ b/ui/lesson/OpCodeChallenge/OpRunner.tsx
@@ -544,6 +544,8 @@ const OpRunner = ({
                                       {
                                         'bg-red/35':
                                           stack.error.message !== null ||
+                                          (stack.stack[0] !== 1 &&
+                                            stack.stack[0] !== true) ||
                                           (opCodeIndex === isFinalToken() - 1 &&
                                             (stack.stack.length !== 1 ||
                                               stack.stack[0] === false ||


### PR DESCRIPTION
Fixes a bug where opcodes weren't being highlighted on values !== `1` or `true`