### PR TITLE
fix: Ch4 - Get a P2WPKH address - Python  - Tip 404 URL for bech32.py

### DIFF
--- a/content/lessons/chapter-4/address-3.tsx
+++ b/content/lessons/chapter-4/address-3.tsx
@@ -124,7 +124,7 @@ ${
 
 # Insert checksum and metadata, encode using bech32 and return a string
 # See the library source code for the exact API.
-# https://github.com/saving-satoshi/challenges/blob/master/chapter4/python/lib/bech32.py
+# https://github.com/saving-satoshi/bech32py/blob/main/bech32py/bech32.py
 def hash_to_address(hash):
 `,
     validate: async (answer) => {


### PR DESCRIPTION
## The recommended URL for a Python file doesn't exist.

In Chapter 4,  Get a P2WPKH address, the default Python script recommends the user check a URL to see how to use the `encode` function from the `bech32`library. The link does not exist, however, but I could find the file with the `encode` function in another repository of _saving-satoshi_, with the same file name `bech32.py`, so I took the time to recommend this fix for future users that may be stuck on that part of this awesome adventure.

**Current:** https://github.com/saving-satoshi/challenges/blob/master/chapter4/python/lib/bech32.py
**Correct:** https://github.com/saving-satoshi/bech32py/blob/main/bech32py/bech32.py