### PR TITLE
Chapters page chapter tabs consistency

### DIFF
--- a/ui/chapter/Chapter.tsx
+++ b/ui/chapter/Chapter.tsx
@@ -161,9 +161,9 @@ export default function Chapter({ children, metadata, lang }) {
             <div className="flex grow py-2 lg:grow-0">
               <div
                 aria-hidden={activeTab !== 'info'}
-                className={clsx('-mr-[100%] block w-full', {
-                  visible: activeTab === 'info',
-                  invisible: activeTab !== 'info',
+                className={clsx('-mr-[100%] w-full', {
+                  block: activeTab === 'info',
+                  hidden: activeTab !== 'info',
                 })}
               >
                 <div className="font-nunito md:mt-6">
@@ -260,9 +260,9 @@ export default function Chapter({ children, metadata, lang }) {
               </div>
               <div
                 aria-hidden={activeTab !== 'challenges'}
-                className={clsx('-mr-[100%] block w-full', {
-                  visible: activeTab === 'challenges',
-                  invisible: activeTab !== 'challenges',
+                className={clsx('-mr-[100%] w-full', {
+                  block: activeTab === 'challenges',
+                  hidden: activeTab !== 'challenges',
                 })}
               >
                 <ChallengeList

--- a/ui/chapter/Chapter.tsx
+++ b/ui/chapter/Chapter.tsx
@@ -133,7 +133,7 @@ export default function Chapter({ children, metadata, lang }) {
           { 'lg:order-1': isEven, 'lg:order-2': !isEven }
         )}
       >
-        <div className="ml-3.5 mr-3.5 w-full content-center justify-items-start px-1">
+        <div className="ml-3.5 mr-3.5 w-full content-start px-1">
           <h2 className="mt-6 text-left font-nunito text-xl font-bold text-white text-opacity-75 md:text-3xl">
             {t('shared.chapter')} {position}
           </h2>


### PR DESCRIPTION
Fixes a bug where the info and challenges tabs were using visibility classes instead of display css

Closes #1099 

[Preview](https://saving-satoshi-git-fork-benalleng-chapter-4c7b3f-savingsatoshi.vercel.app/en/chapters?dev=true)