### PR TITLE
Fixed broken links and Python syntax

### DIFF
--- a/content/lessons/chapter-5/validate-signature-3.tsx
+++ b/content/lessons/chapter-5/validate-signature-3.tsx
@@ -31,7 +31,7 @@ console.log("KILL")
   defaultCode: `const { Hash } = require('crypto')
 const secp256k1 = require('@savingsatoshi/secp256k1js')
 // View the library source code
-// https://github.com/saving-satoshi/challenges/blob/master/chapter4/javascript/lib/secp256k1.js
+// https://github.com/saving-satoshi/secp256k1js/blob/main/secp256k1.js
 
 const GE = secp256k1.GE
 const FE = secp256k1.FE
@@ -149,7 +149,7 @@ print("KILL")
 import hashlib
 import secp256k1py.secp256k1 as SECP256K1
 # View the library source code
-# https://github.com/saving-satoshi/challenges/blob/master/chapter4/python/lib/secp256k1.py
+# https://github.com/saving-satoshi/secp256k1py/blob/main/secp256k1py/secp256k1.py
 
 GE = SECP256K1.GE
 G = SECP256K1.G
@@ -191,11 +191,11 @@ def decode_sig(base64_sig):
 def verify(sig_r, sig_s, key, msg):
   if r == 0 or r >= GE.ORDER:
     print("FALSE - invalid r value")
-    return false
+    return False
 
   if s == 0 or s >= GE.ORDER:
     print("FALSE - invalid s value")
-    return false
+    return False
   # Calculate the inverse of sig_s modulo ORDER
   sig_s_inverted = pow(sig_s, -1, GE.ORDER)
 

--- a/content/lessons/chapter-5/validate-signature-4.tsx
+++ b/content/lessons/chapter-5/validate-signature-4.tsx
@@ -30,7 +30,7 @@ console.log("KILL")
   ],
   defaultCode: `const secp256k1 = require('@savingsatoshi/secp256k1js')
 // View the library source code
-// https://github.com/saving-satoshi/challenges/blob/master/chapter4/javascript/lib/secp256k1.js
+// https://github.com/saving-satoshi/secp256k1js/blob/main/secp256k1.js
 
 const GE = secp256k1.GE
 const FE = secp256k1.FE
@@ -138,7 +138,7 @@ print("KILL")
   ],
   defaultCode: `import secp256k1py.secp256k1 as SECP256K1
 # View the library source code
-# https://github.com/saving-satoshi/challenges/blob/master/chapter4/python/lib/secp256k1.py
+# https://github.com/saving-satoshi/secp256k1py/blob/main/secp256k1py/secp256k1.py
 
 GE = SECP256K1.GE
 G = SECP256K1.G
@@ -163,11 +163,11 @@ keys = [
 def verify(r, s, key, msg):
     if r == 0 or r >= GE.ORDER:
         print("FALSE - invalid r value")
-        return false
+        return False
 
     if s == 0 or s >= GE.ORDER:
         print("FALSE - invalid s value")
-        return false
+        return False
     # Calculate the inverse of sig_s modulo ORDER
     sig_s_inverted = pow(sig_s, -1, GE.ORDER)
 

--- a/content/lessons/chapter-5/verify-signature-5.tsx
+++ b/content/lessons/chapter-5/verify-signature-5.tsx
@@ -24,7 +24,7 @@ console.log("KILL")
   },
   defaultCode: `const secp256k1 = require('@savingsatoshi/secp256k1js')
 // View the library source code
-// https://github.com/saving-satoshi/challenges/blob/master/chapter4/javascript/lib/secp256k1.js
+// https://github.com/saving-satoshi/secp256k1js/blob/main/secp256k1.js
 
 const GE = secp256k1.GE
 const FE = secp256k1.FE
@@ -120,7 +120,7 @@ print("KILL")
   },
   defaultCode: `import secp256k1py.secp256k1 as SECP256K1
 # View the library source code
-# https://github.com/saving-satoshi/challenges/blob/master/chapter4/python/lib/secp256k1.py
+# https://github.com/saving-satoshi/secp256k1py/blob/main/secp256k1py/secp256k1.py
 
 GE = SECP256K1.GE
 G = SECP256K1.G

--- a/content/lessons/chapter-6/in-out-1.tsx
+++ b/content/lessons/chapter-6/in-out-1.tsx
@@ -29,7 +29,7 @@ export default function InOut1({ lang }) {
 // Return that curve point (also known as a group element)
 // which will be an instance of secp256k1.GE
 // See the library source code for the exact definition
-// https://github.com/saving-satoshi/challenges/blob/master/chapter4/javascript/lib/secp256k1.js
+// https://github.com/saving-satoshi/secp256k1js/blob/main/secp256k1.js
 const G = secp256k1.G
 
 function privateKeyToPublicKey(privateKey) {
@@ -45,7 +45,7 @@ function privateKeyToPublicKey(privateKey) {
 # Return that curve point (also known as a group element)
 # which will be an instance of secp256k1.GE
 # See the library source code for the exact definition
-# https://github.com/saving-satoshi/challenges/blob/master/chapter4/python/lib/secp256k1.py
+# https://github.com/saving-satoshi/secp256k1py/blob/main/secp256k1py/secp256k1.py
 G = SECP256K1.FAST_G
 
 def privatekey_to_publickey(private_key):

--- a/content/lessons/chapter-8/building-blocks-7.tsx
+++ b/content/lessons/chapter-8/building-blocks-7.tsx
@@ -126,7 +126,7 @@ candidates = Bitcoin.rpc("getblocksbyheight", HEIGHT)
 
 for bhash in candidates:
   block = Bitcoin.rpc("getblock", bhash)
-  if no state["blocks_by_hash"][bhash]["valid"] and validate_block(block):
+  if not state["blocks_by_hash"][bhash]["valid"] and validate_block(block):
     print("Looks like some invalid blocks are getting through. Try again!")
     print("KILL")
   if state["blocks_by_hash"][bhash]["valid"] and validate_block(block):


### PR DESCRIPTION
Hey, I'm running through the challenges again to find these broken links. I hope this can help.

## Broken Links
### JS:
**Currently broken link:** https://github.com/saving-satoshi/challenges/blob/master/chapter4/javascript/lib/secp256k1.js
**Live-link:** https://github.com/saving-satoshi/secp256k1js/blob/main/secp256k1.js
Chapter 5, Verify the signature - Test the signature
Chapter 5, Validate the signature - See if Vanderpoole was lying
Chapter 5, Validate the signature - Find the correct key

### Python:
**Currently broken link:** https://github.com/saving-satoshi/challenges/blob/master/chapter4/python/lib/secp256k1.py
**Live-link:** https://github.com/saving-satoshi/secp256k1py/blob/main/secp256k1py/secp256k1.py
Chapter 5, Verify the signature - Test the signature
Chapter 5, Validate the signature - See if Vanderpoole was lying
Chapter 5, Validate the signature - Find the correct key

## Python Syntax
validate-signature-3.tsx
ch_5_4_see_if_Vanderpoole_was_lying
lines 47, 51 from 'false' to 'False'

validate-signature-4.tsx
ch_5_4_find_the_correct_key
lines 28, 32 from 'false' to 'False'

Getting an error of syntax even with the correct solution. I found out that the test is missing a letter.
Chapter 8 - 7-Get a valid block
line 129: https://github.com/saving-satoshi/saving-satoshi/blob/dev/content/lessons/chapter-8/building-blocks-7.tsx
![image](https://github.com/user-attachments/assets/9515823e-743c-48dc-b712-b0240b1a6128)
