### PR TITLE
Display error on closed ws

### DIFF
--- a/ui/lesson/ScriptingChallenge/Runner/index.tsx
+++ b/ui/lesson/ScriptingChallenge/Runner/index.tsx
@@ -160,8 +160,18 @@ export default function Runner({
             break
           }
           case 'debug': {
-            // payload = payload.trim()
-            // sendTerminal('print', payload)
+            const wsRemovedRegex =
+              /\[system\] Image [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12} removed\./
+            payload = payload.trim()
+            if (wsRemovedRegex.test(payload)) {
+              sendTerminal('clear')
+              sendTerminal('print', t('runner.result'))
+              sendTerminal('error', payload)
+              setHasherState(HasherState.Error)
+              setIsRunning(false)
+              setState(State.Error)
+              ws?.close()
+            }
             break
           }
           case 'output': {


### PR DESCRIPTION
This will allow the terminal to display an error on a closed ws so the user knows that there is something wrong with the image and it no longer will hang
