### PR TITLE
scripting validation for chapter 2 and success message

### DIFF
--- a/content/lessons/chapter-2/scripting-2.tsx
+++ b/content/lessons/chapter-2/scripting-2.tsx
@@ -45,12 +45,12 @@ export default function Scripting2({ lang }) {
     },
     defaultCode: `const crypto = require('crypto')
 
-  // Create a program that finds a sha256 hash starting with 5 zeroes.
-  // To submit your answer, return it from the function.
+// Create a program that finds a sha256 hash starting with 5 zeroes.
+// To submit your answer, return it from the function.
 
-  function findHashFromNonce(nonce) {
-    // Type your code here
-  }
+function findHashFromNonce(nonce) {
+  // Type your code here
+}
   `,
     validate: async (answer) => {
       if (answer.startsWith('00000')) {

--- a/content/lessons/chapter-2/scripting-2.tsx
+++ b/content/lessons/chapter-2/scripting-2.tsx
@@ -33,12 +33,12 @@ export default function Scripting2({ lang }) {
 
   const javascript = {
     program: `//BEGIN VALIDATION BLOCK
-  const min = 1;
-  const max = 100000000;
-  const randomNumber = Math.floor(Math.random() * (max - min + 1)) + min;
-  const testHash = findHashFromNonce(randomNumber)
-  console.log(testHash.toString())
-  console.log("KILL")`,
+const min = 1;
+const max = 100000000;
+const randomNumber = Math.floor(Math.random() * (max - min + 1)) + min;
+const testHash = findHashFromNonce(randomNumber)
+console.log(testHash.toString())
+console.log("KILL")`,
     defaultFunction: {
       name: 'findHash',
       args: ['nonce'],

--- a/content/lessons/chapter-2/scripting-2.tsx
+++ b/content/lessons/chapter-2/scripting-2.tsx
@@ -36,7 +36,7 @@ export default function Scripting2({ lang }) {
   const min = 1;
   const max = 100000000;
   const randomNumber = Math.floor(Math.random() * (max - min + 1)) + min;
-  const testHash = findHash(randomNumber)
+  const testHash = findHashFromNonce(randomNumber)
   console.log(testHash.toString())
   console.log("KILL")`,
     defaultFunction: {
@@ -91,7 +91,7 @@ import random
 min_value = 1
 max_value = 100000000
 random_number = random.randint(min_value, max_value)
-test_hash = find_hash(random_number)
+test_hash = find_hash_from_nonce(random_number)
 print(str(test_hash))
 print("KILL")`,
     defaultFunction: {

--- a/content/lessons/chapter-2/scripting-2.tsx
+++ b/content/lessons/chapter-2/scripting-2.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import crypto from 'crypto'
 import HelpSuggestion from 'components/HelpSuggestion'
 import { ScriptingChallenge, LessonInfo } from 'ui'
 import { EditorConfig } from 'types'

--- a/content/lessons/chapter-2/scripting-2.tsx
+++ b/content/lessons/chapter-2/scripting-2.tsx
@@ -16,108 +16,133 @@ export const metadata = {
   key: 'CH2SCR2',
 }
 
-const javascript = {
-  program: `//BEGIN VALIDATION BLOCK
-const min = 1;
-const max = 100000000;
-const randomNumber = Math.floor(Math.random() * (max - min + 1)) + min;
-const testHash = findHash(randomNumber)
-console.log((findHash(1000000) === '000001f8479faf79c1a58152ffc6b027a93f6ae6b27dc19ef986b2c9e7cad3b3' && findHash(0) !== '000001f8479faf79c1a58152ffc6b027a93f6ae6b27dc19ef986b2c9e7cad3b3') ? testHash : 'test-failed')
-console.log("KILL")`,
-  defaultFunction: {
-    name: 'findHash',
-    args: ['nonce'],
-  },
-  defaultCode: `const crypto = require('crypto')
+export default function Scripting2({ lang }) {
+  const t = useTranslations(lang)
+  const [currentLanguage] = useAtom(currentLanguageAtom)
+  const [language, setLanguage] = useState(getLanguageString(currentLanguage))
+  const [displayAnswer, setDisplayAnswer] = useState('')
 
-// Create a program that finds a sha256 hash starting with 5 zeroes.
-// To submit your answer, return it from the function.
+  const handleSelectLanguage = (language: string) => {
+    setLanguage(language)
+  }
 
-function findHash(nonce) {
-  // Type your code here
-}
-`,
-  validate: async (answer) => {
-    if (answer === 'test-failed') {
-      return [
-        false,
-        'Be sure you are using the nonce param in your function as a random starting nonce will be used to test',
-      ]
-    }
+  const validationTest = (nonce) => {
+    return crypto.createHash('sha256').update(nonce.toString()).digest('hex')
+  }
 
-    if (!answer.startsWith('00000')) {
-      return [false, 'Hash must start with 5 zeroes.']
-    }
+  const javascript = {
+    program: `//BEGIN VALIDATION BLOCK
+  const min = 1;
+  const max = 100000000;
+  const randomNumber = Math.floor(Math.random() * (max - min + 1)) + min;
+  const testHash = findHash(randomNumber)
+  console.log(testHash.toString())
+  console.log("KILL")`,
+    defaultFunction: {
+      name: 'findHash',
+      args: ['nonce'],
+    },
+    defaultCode: `const crypto = require('crypto')
 
-    if (answer.length !== 64) {
-      return [false, 'Hash must be 64 characters long']
-    }
+  // Create a program that finds a sha256 hash starting with 5 zeroes.
+  // To submit your answer, return it from the function.
 
-    return [true, undefined]
-  },
-}
+  function findHashFromNonce(nonce) {
+    // Type your code here
+  }
+  `,
+    validate: async (answer) => {
+      if (answer.startsWith('00000')) {
+        return [
+          false,
+          'Be sure you are returning the nonce and not the hash from your function.',
+        ]
+      }
 
-const python = {
-  program: `# BEGIN VALIDATION BLOCK
+      if (
+        !validationTest(answer).startsWith('00000') &&
+        (validationTest(answer - 1).startsWith('00000') ||
+          validationTest(answer + 1).startsWith('00000'))
+      ) {
+        return [
+          false,
+          'Make sure that you are returning your nonce before you increment it again.',
+        ]
+      }
+
+      if (!validationTest(answer).startsWith('00000')) {
+        return [false, 'Hash must start with 5 zeroes.']
+      }
+
+      if (validationTest(answer).length !== 64) {
+        return [false, 'Hash must be 64 characters long.']
+      }
+
+      setDisplayAnswer(validationTest(answer))
+      return [true, `That's it! Your nonce hashes to ${validationTest(answer)}`]
+    },
+  }
+
+  const python = {
+    program: `# BEGIN VALIDATION BLOCK
 import random
 
 min_value = 1
 max_value = 100000000
 random_number = random.randint(min_value, max_value)
 test_hash = find_hash(random_number)
-if find_hash(1000000) != '000001f8479faf79c1a58152ffc6b027a93f6ae6b27dc19ef986b2c9e7cad3b3':
-    print('test-failed')
-elif find_hash(1000000) == '000001f8479faf79c1a58152ffc6b027a93f6ae6b27dc19ef986b2c9e7cad3b3' and find_hash(0) != '000001f8479faf79c1a58152ffc6b027a93f6ae6b27dc19ef986b2c9e7cad3b3':
-    print(test_hash)
-else:
-    print('error')
+print(str(test_hash))
 print("KILL")`,
-  defaultFunction: {
-    name: 'find_hash',
-    args: ['nonce'],
-  },
-  defaultCode: `from hashlib import sha256
+    defaultFunction: {
+      name: 'find_hash',
+      args: ['nonce'],
+    },
+    defaultCode: `from hashlib import sha256
 
 # Create a program that finds a sha256 hash starting with 5 zeroes.
 # To submit your answer, return it from the function.
 
-def find_hash(nonce):
+def find_hash_from_nonce(nonce):
     # Type your code here
 `,
-  validate: async (answer) => {
-    if (answer === 'test-failed' || answer === 'error') {
-      return [
-        false,
-        'Be sure you are using the nonce param in your function as a random starting nonce will be used to test',
-      ]
-    }
-    if (!answer.startsWith('00000')) {
-      return [false, 'Hash must start with 5 zeroes.']
-    }
+    validate: async (answer) => {
+      if (answer.startsWith('00000')) {
+        return [
+          false,
+          'Be sure you are returning the nonce and not the hash from your function.',
+        ]
+      }
 
-    if (answer.length !== 64) {
-      return [false, 'Hash must be 64 characters long']
-    }
+      if (
+        !validationTest(answer).startsWith('00000') &&
+        (validationTest(answer - 1).startsWith('00000') ||
+          validationTest(answer + 1).startsWith('00000'))
+      ) {
+        return [
+          false,
+          'Make sure that you are returning your nonce before you increment it again.',
+        ]
+      }
 
-    return [true, undefined]
-  },
-}
+      if (!validationTest(answer).startsWith('00000')) {
+        return [false, 'Hash must start with 5 zeroes.']
+      }
 
-const config: EditorConfig = {
-  defaultLanguage: 'javascript',
-  languages: {
-    javascript,
-    python,
-  },
-}
+      if (validationTest(answer).length !== 64) {
+        return [false, 'Hash must be 64 characters long.']
+      }
 
-export default function Scripting2({ lang }) {
-  const t = useTranslations(lang)
-  const [currentLanguage] = useAtom(currentLanguageAtom)
-  const [language, setLanguage] = useState(getLanguageString(currentLanguage))
+      setDisplayAnswer(validationTest(answer))
+      return [true, `That's it! Your nonce hashes to ${validationTest(answer)}`]
+    },
+  }
 
-  const handleSelectLanguage = (language: string) => {
-    setLanguage(language)
+  const config: EditorConfig = {
+    defaultLanguage: 'javascript',
+    languages: {
+      javascript,
+      python,
+    },
   }
 
   return (
@@ -125,7 +150,6 @@ export default function Scripting2({ lang }) {
       lang={lang}
       config={config}
       lessonKey={metadata.key}
-      successMessage={t('chapter_two.scripting_two.success')}
       onSelectLanguage={handleSelectLanguage}
     >
       <LessonInfo>

--- a/content/lessons/chapter-4/address-2.tsx
+++ b/content/lessons/chapter-4/address-2.tsx
@@ -81,7 +81,7 @@ function hashCompressed(compressedPublicKey) {
           'Ensure you are using the correct compressed key and it is being decoded',
         ]
       }
-      return [true, undefined]
+      return [true, t('chapter_four.address_two.success')]
     },
   }
 
@@ -127,7 +127,7 @@ def hash_compressed(compressed_public_key):
           'Ensure you are using the correct compressed key and it is being decoded',
         ]
       }
-      return [true, undefined]
+      return [true, t('chapter_four.address_two.success')]
     },
   }
 
@@ -152,7 +152,6 @@ def hash_compressed(compressed_public_key):
         config={config}
         saveData
         lessonKey={metadata.key}
-        successMessage={t('chapter_four.address_two.success')}
         onSelectLanguage={handleSelectLanguage}
       >
         <LessonInfo>

--- a/content/lessons/chapter-4/address-3.tsx
+++ b/content/lessons/chapter-4/address-3.tsx
@@ -97,7 +97,7 @@ function hashToAddress(hash) {
         ]
       }
 
-      return [true, undefined]
+      return [true, t('chapter_four.address_three.success')]
     },
   }
 
@@ -141,7 +141,7 @@ def hash_to_address(hash):
         ]
       }
 
-      return [true, undefined]
+      return [true, t('chapter_four.address_three.success')]
     },
   }
 
@@ -166,7 +166,6 @@ def hash_to_address(hash):
         config={config}
         saveData
         lessonKey={metadata.key}
-        successMessage={t('chapter_four.address_three.success')}
         onSelectLanguage={handleSelectLanguage}
       >
         <LessonInfo>

--- a/content/lessons/chapter-4/public-key-3.tsx
+++ b/content/lessons/chapter-4/public-key-3.tsx
@@ -61,7 +61,7 @@ function privateKeyToPublicKey(privateKey) {
 
         // Check if both hashes match the correct pattern
         if (hash1.match(correctPattern) && hash2.match(correctPattern)) {
-          return [true, 'Nicely Done ']
+          return [true, t('chapter_four.public_key_three.success')]
         } else {
           return [false, 'Try multiplying with the G constant']
         }
@@ -105,7 +105,7 @@ def privatekey_to_publickey(private_key):
 
         // Check if both hashes match the correct pattern
         if (hash1.match(correctPattern) && hash2.match(correctPattern)) {
-          return [true, 'Nicely Done']
+          return [true, t('chapter_four.public_key_three.success')]
         } else {
           return [false, 'Try multiplying with the G constant']
         }
@@ -134,7 +134,6 @@ def privatekey_to_publickey(private_key):
       config={config}
       saveData
       lessonKey={metadata.key}
-      successMessage={t('chapter_four.public_key_three.success')}
       onSelectLanguage={handleSelectLanguage}
     >
       <LessonInfo>

--- a/content/lessons/chapter-4/public-key-4.tsx
+++ b/content/lessons/chapter-4/public-key-4.tsx
@@ -92,7 +92,7 @@ function compressPublicKey(publicKey) {
       if (answer !== compressPublicKey(dataObject)) {
         return [false, 'Ensure you are using your own key object']
       }
-      return [true, undefined]
+      return [true, t('chapter_four.public_key_four.success')]
     },
   }
 
@@ -131,7 +131,7 @@ def compress_publickey(public_key):
       if (answer !== compressPublicKey(dataObject)) {
         return [false, 'Ensure you are using your own key object']
       }
-      return [true, undefined]
+      return [true, t('chapter_four.public_key_four.success')]
     },
   }
 
@@ -152,7 +152,6 @@ def compress_publickey(public_key):
         config={config}
         lessonKey={metadata.key}
         saveData
-        successMessage={t('chapter_four.public_key_four.success')}
         onSelectLanguage={handleSelectLanguage}
       >
         <LessonInfo>

--- a/content/lessons/chapter-5/derive-message-7.tsx
+++ b/content/lessons/chapter-5/derive-message-7.tsx
@@ -16,16 +16,22 @@ export const metadata = {
   key: 'CH5DRM7',
 }
 
-const javascript = {
-  program: `
+export default function DeriveMessage7({ lang }) {
+  const t = useTranslations(lang)
+  const [currentLanguage] = useAtom(currentLanguageAtom)
+  const [language, setLanguage] = useState(getLanguageString(currentLanguage))
+  const [tooltipVisible, setTooltipVisible] = useState(false)
+
+  const javascript = {
+    program: `
 console.log(createTxMessage())
 console.log("KILL")
 `,
-  defaultFunction: {
-    name: 'createTxMessage',
-    args: [],
-  },
-  defaultCode: `function createTxMessage() {
+    defaultFunction: {
+      name: 'createTxMessage',
+      args: [],
+    },
+    defaultCode: `function createTxMessage() {
   let msg = ""
 
   // version:
@@ -74,28 +80,31 @@ console.log("KILL")
   return msg
 }
 `,
-  validate: async (answer) => {
-    if (
-      answer !==
-      '0100000001c997a5e56e104102fa209c6a852dd90660a20b2d9c352423edce25857fcd37040000000043410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3acffffffff0200ca9a3b00000000434104ae1a62fe09c5f51b13905f07f06b99a2f7159b2225f374cd378d71302fa28414e7aab37397f554a7df5f142c21c1b7303b8a0626f1baded5c72a704f7e6cd84cac00286bee0000000043410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac0000000001000000'
-    ) {
-      return [false, 'Be sure you filled in both the output and sig hash flag.']
-    }
+    validate: async (answer) => {
+      if (
+        answer !==
+        '0100000001c997a5e56e104102fa209c6a852dd90660a20b2d9c352423edce25857fcd37040000000043410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3acffffffff0200ca9a3b00000000434104ae1a62fe09c5f51b13905f07f06b99a2f7159b2225f374cd378d71302fa28414e7aab37397f554a7df5f142c21c1b7303b8a0626f1baded5c72a704f7e6cd84cac00286bee0000000043410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac0000000001000000'
+      ) {
+        return [
+          false,
+          'Be sure you filled in both the output and sig hash flag.',
+        ]
+      }
 
-    return [true, undefined]
-  },
-}
+      return [true, t('chapter_five.derive_message_seven.success')]
+    },
+  }
 
-const python = {
-  program: `
+  const python = {
+    program: `
 print(create_tx_message())
 print("KILL")
 `,
-  defaultFunction: {
-    name: 'create_tx_message',
-    args: [],
-  },
-  defaultCode: `def create_tx_message():
+    defaultFunction: {
+      name: 'create_tx_message',
+      args: [],
+    },
+    defaultCode: `def create_tx_message():
     msg = ""
 
     # version:
@@ -143,31 +152,28 @@ print("KILL")
 
     return msg
 `,
-  validate: async (answer) => {
-    if (
-      answer !==
-      '0100000001c997a5e56e104102fa209c6a852dd90660a20b2d9c352423edce25857fcd37040000000043410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3acffffffff0200ca9a3b00000000434104ae1a62fe09c5f51b13905f07f06b99a2f7159b2225f374cd378d71302fa28414e7aab37397f554a7df5f142c21c1b7303b8a0626f1baded5c72a704f7e6cd84cac00286bee0000000043410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac0000000001000000'
-    ) {
-      return [false, 'Be sure you filled in both the output and sig hash flag.']
-    }
+    validate: async (answer) => {
+      if (
+        answer !==
+        '0100000001c997a5e56e104102fa209c6a852dd90660a20b2d9c352423edce25857fcd37040000000043410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3acffffffff0200ca9a3b00000000434104ae1a62fe09c5f51b13905f07f06b99a2f7159b2225f374cd378d71302fa28414e7aab37397f554a7df5f142c21c1b7303b8a0626f1baded5c72a704f7e6cd84cac00286bee0000000043410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac0000000001000000'
+      ) {
+        return [
+          false,
+          'Be sure you filled in both the output and sig hash flag.',
+        ]
+      }
 
-    return [true, undefined]
-  },
-}
+      return [true, t('chapter_five.derive_message_seven.success')]
+    },
+  }
 
-const config: EditorConfig = {
-  defaultLanguage: 'javascript',
-  languages: {
-    javascript,
-    python,
-  },
-}
-
-export default function DeriveMessage7({ lang }) {
-  const t = useTranslations(lang)
-  const [currentLanguage] = useAtom(currentLanguageAtom)
-  const [language, setLanguage] = useState(getLanguageString(currentLanguage))
-  const [tooltipVisible, setTooltipVisible] = useState(false)
+  const config: EditorConfig = {
+    defaultLanguage: 'javascript',
+    languages: {
+      javascript,
+      python,
+    },
+  }
 
   const handleMouseEnter = () => {
     setTooltipVisible(true)
@@ -186,7 +192,6 @@ export default function DeriveMessage7({ lang }) {
       lang={lang}
       config={config}
       lessonKey={metadata.key}
-      successMessage={t('chapter_five.derive_message_seven.success')}
       onSelectLanguage={handleSelectLanguage}
     >
       <LessonInfo>

--- a/content/lessons/chapter-5/validate-signature-1.tsx
+++ b/content/lessons/chapter-5/validate-signature-1.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ScriptingChallenge, LessonInfo, CodeExample, Tooltip } from 'ui'
+import { ScriptingChallenge, LessonInfo, CodeExample } from 'ui'
 import { EditorConfig } from 'types'
 import { useTranslations } from 'hooks'
 import { Text } from 'ui'
@@ -16,15 +16,20 @@ export const metadata = {
   navigation_title: 'chapter_five.validate_signature_one.nav_title',
   key: 'CH5VLS1',
 }
-const javascript = {
-  program: `
+export default function PublicKey3({ lang }) {
+  const t = useTranslations(lang)
+  const [currentLanguage] = useAtom(currentLanguageAtom)
+  const [language, setLanguage] = useState(getLanguageString(currentLanguage))
+
+  const javascript = {
+    program: `
   console.log(encode_message(text))
   console.log("KILL")`,
-  defaultFunction: {
-    name: 'encode_message',
-    args: ['text'],
-  },
-  defaultCode: `const { Hash } = require('crypto');
+    defaultFunction: {
+      name: 'encode_message',
+      args: ['text'],
+    },
+    defaultCode: `const { Hash } = require('crypto');
 // Provided by Vanderpoole
 let text = "I am Vanderpoole and I have control of the private key Satoshi\\n"
 text += "used to sign the first-ever Bitcoin transaction confirmed in block #170.\\n"
@@ -39,28 +44,28 @@ function encode_message(text){
 
 }
 `,
-  validate: async (answer: string) => {
-    const correctAnswer =
-      '73a16290e005b119b9ce0ceea52949f0bd4f925e808b5a54c631702d3fea1242'
-    if (answer) {
-      if (answer == correctAnswer) {
-        return [true, 'Nicely Done ']
+    validate: async (answer: string) => {
+      const correctAnswer =
+        '73a16290e005b119b9ce0ceea52949f0bd4f925e808b5a54c631702d3fea1242'
+      if (answer) {
+        if (answer == correctAnswer) {
+          return [true, t('chapter_five.validate_signature_one.success')]
+        }
+        return [false, 'Not a valid hex value']
       }
-      return [false, 'Not a valid hex value']
-    }
-    return [false, 'Return a value']
-  },
-}
+      return [false, 'Return a value']
+    },
+  }
 
-const python = {
-  program: `
+  const python = {
+    program: `
 print(encode_message(text))
 print("KILL")`,
-  defaultFunction: {
-    name: 'encode_message',
-    args: ['text'],
-  },
-  defaultCode: `import hashlib
+    defaultFunction: {
+      name: 'encode_message',
+      args: ['text'],
+    },
+    defaultCode: `import hashlib
 # Defined by Bitcoin message signing protocol
 # Provided by Vanderpoole
 text = "I am Vanderpoole and I have control of the private key Satoshi\\n"
@@ -74,31 +79,27 @@ def encode_message(text):
     # Returns a 32-byte hex value.
     prefix = "Bitcoin Signed Message:\\n"
 `,
-  validate: async (answer: string) => {
-    const correctAnswer =
-      '73a16290e005b119b9ce0ceea52949f0bd4f925e808b5a54c631702d3fea1242'
-    if (answer) {
-      if (answer === correctAnswer) {
-        return [true, 'Nicely Done ']
+    validate: async (answer: string) => {
+      const correctAnswer =
+        '73a16290e005b119b9ce0ceea52949f0bd4f925e808b5a54c631702d3fea1242'
+      if (answer) {
+        if (answer === correctAnswer) {
+          return [true, t('chapter_five.validate_signature_one.success')]
+        }
+        return [false, 'Not a valid hex value']
       }
-      return [false, 'Not a valid hex value']
-    }
-    return [false, 'Return a value']
-  },
-}
+      return [false, 'Return a value']
+    },
+  }
 
-const config: EditorConfig = {
-  defaultLanguage: 'javascript',
-  languages: {
-    javascript,
-    python,
-  },
-}
+  const config: EditorConfig = {
+    defaultLanguage: 'javascript',
+    languages: {
+      javascript,
+      python,
+    },
+  }
 
-export default function PublicKey3({ lang }) {
-  const t = useTranslations(lang)
-  const [currentLanguage] = useAtom(currentLanguageAtom)
-  const [language, setLanguage] = useState(getLanguageString(currentLanguage))
   const handleSelectLanguage = (language: string) => {
     setLanguage(language)
   }
@@ -117,7 +118,6 @@ export default function PublicKey3({ lang }) {
       config={config}
       saveData
       lessonKey={metadata.key}
-      successMessage={''}
       onSelectLanguage={handleSelectLanguage}
     >
       <LessonInfo>

--- a/content/lessons/chapter-5/validate-signature-2.tsx
+++ b/content/lessons/chapter-5/validate-signature-2.tsx
@@ -18,16 +18,21 @@ export const metadata = {
 const vpSig =
   'H4vQbVD0pLK7pkzPto8BHourzsBrHMB3Qf5oYVmr741pPwdU2m6FaZZmxh4ScHxFoDelFC9qG0PnAUl5qMFth8k='
 
-const javascript = {
-  program: `
+export default function Scripting2({ lang }) {
+  const t = useTranslations(lang)
+  const [currentLanguage] = useAtom(currentLanguageAtom)
+  const [language, setLanguage] = useState(getLanguageString(currentLanguage))
+
+  const javascript = {
+    program: `
 console.log(decode_sig("${vpSig}").toString());
 console.log("KILL");
 `,
-  defaultFunction: {
-    name: 'decodeSig',
-    args: [],
-  },
-  defaultCode: `// Vanderpoole's signature
+    defaultFunction: {
+      name: 'decodeSig',
+      args: [],
+    },
+    defaultCode: `// Vanderpoole's signature
 const vpSig = "H4vQbVD0pLK7pkzPto8BHourzsBrHMB3Qf5oYVmr741pPwdU2m6FaZZmxh4ScHxFoDelFC9qG0PnAUl5qMFth8k="
 
 function decode_sig(vpSig) {
@@ -36,31 +41,31 @@ function decode_sig(vpSig) {
 
 }
 `,
-  validate: async (answer) => {
-    if (
-      answer !==
-      '63239744615459417534795088953002824328865520877888079618399827727977035042153,28508663025799969786676261677335521233963265910413171955666154169583931328457'
-    ) {
-      return [
-        false,
-        'Be sure to return the r and s values in the correct order.',
-      ]
-    }
+    validate: async (answer) => {
+      if (
+        answer !==
+        '63239744615459417534795088953002824328865520877888079618399827727977035042153,28508663025799969786676261677335521233963265910413171955666154169583931328457'
+      ) {
+        return [
+          false,
+          'Be sure to return the r and s values in the correct order.',
+        ]
+      }
 
-    return [true, undefined]
-  },
-}
+      return [true, t('chapter_five.validate_signature_two.success')]
+    },
+  }
 
-const python = {
-  program: `
+  const python = {
+    program: `
 print(decode_sig("${vpSig}"))
 print("KILL")
 `,
-  defaultFunction: {
-    name: 'decode_sig',
-    args: [],
-  },
-  defaultCode: `import base64
+    defaultFunction: {
+      name: 'decode_sig',
+      args: [],
+    },
+    defaultCode: `import base64
 
 # Vanderpoole's signature
 vp_sig = "H4vQbVD0pLK7pkzPto8BHourzsBrHMB3Qf5oYVmr741pPwdU2m6FaZZmxh4ScHxFoDelFC9qG0PnAUl5qMFth8k="
@@ -69,33 +74,28 @@ def decode_sig(vp_sig):
     # Decode a base64-encoded signature string into its ECDSA signature elements r and s, returned as a tuple of integers.
     # Remember to throw away the first byte of metadata from the signature string!
 `,
-  validate: async (answer) => {
-    if (
-      answer !==
-      '(63239744615459417534795088953002824328865520877888079618399827727977035042153, 28508663025799969786676261677335521233963265910413171955666154169583931328457)'
-    ) {
-      return [
-        false,
-        'Be sure to return the r and s values in the correct order.',
-      ]
-    }
+    validate: async (answer) => {
+      if (
+        answer !==
+        '(63239744615459417534795088953002824328865520877888079618399827727977035042153, 28508663025799969786676261677335521233963265910413171955666154169583931328457)'
+      ) {
+        return [
+          false,
+          'Be sure to return the r and s values in the correct order.',
+        ]
+      }
 
-    return [true, undefined]
-  },
-}
+      return [true, t('chapter_five.validate_signature_two.success')]
+    },
+  }
 
-const config: EditorConfig = {
-  defaultLanguage: 'javascript',
-  languages: {
-    javascript,
-    python,
-  },
-}
-
-export default function Scripting2({ lang }) {
-  const t = useTranslations(lang)
-  const [currentLanguage] = useAtom(currentLanguageAtom)
-  const [language, setLanguage] = useState(getLanguageString(currentLanguage))
+  const config: EditorConfig = {
+    defaultLanguage: 'javascript',
+    languages: {
+      javascript,
+      python,
+    },
+  }
 
   const handleSelectLanguage = (language: string) => {
     setLanguage(language)
@@ -106,7 +106,6 @@ export default function Scripting2({ lang }) {
       lang={lang}
       config={config}
       lessonKey={metadata.key}
-      successMessage=""
       onSelectLanguage={handleSelectLanguage}
     >
       <LessonInfo>

--- a/content/lessons/chapter-5/validate-signature-3.tsx
+++ b/content/lessons/chapter-5/validate-signature-3.tsx
@@ -14,21 +14,26 @@ export const metadata = {
   key: 'CH5VLS3',
 }
 
-const javascript = {
-  program: `console.log(verify(r, s, keyGE, msg).toString());
+export default function ValidateSignature3({ lang }) {
+  const t = useTranslations(lang)
+  const [currentLanguage] = useAtom(currentLanguageAtom)
+  const [language, setLanguage] = useState(getLanguageString(currentLanguage))
+
+  const javascript = {
+    program: `console.log(verify(r, s, keyGE, msg).toString());
 console.log("KILL")
 `,
-  defaultFunction: {
-    name: 'verify',
-    args: [],
-  },
-  rangesToCollapse: [
-    {
-      start: 90,
-      end: 95,
+    defaultFunction: {
+      name: 'verify',
+      args: [],
     },
-  ],
-  defaultCode: `const { Hash } = require('crypto')
+    rangesToCollapse: [
+      {
+        start: 90,
+        end: 95,
+      },
+    ],
+    defaultCode: `const { Hash } = require('crypto')
 const secp256k1 = require('@savingsatoshi/secp256k1js')
 // View the library source code
 // https://github.com/saving-satoshi/secp256k1js/blob/main/secp256k1.js
@@ -123,29 +128,29 @@ const [r, s] =
 const msg =
 const keyGE =
 `,
-  validate: async (answer) => {
-    if (answer === 'false') {
-      return [true, 'The signature is invalid']
-    }
-    return [false, 'Check your methods']
-  },
-}
+    validate: async (answer) => {
+      if (answer === 'false') {
+        return [true, t('chapter_five.validate_signature_three.success')]
+      }
+      return [false, 'Check your methods']
+    },
+  }
 
-const python = {
-  program: `print(verify(r, s, key_ge, msg))
+  const python = {
+    program: `print(verify(r, s, key_ge, msg))
 print("KILL")
 `,
-  defaultFunction: {
-    name: 'verify',
-    args: [],
-  },
-  rangesToCollapse: [
-    {
-      start: 68,
-      end: 73,
+    defaultFunction: {
+      name: 'verify',
+      args: [],
     },
-  ],
-  defaultCode: `import base64
+    rangesToCollapse: [
+      {
+        start: 68,
+        end: 73,
+      },
+    ],
+    defaultCode: `import base64
 import hashlib
 import secp256k1py.secp256k1 as SECP256K1
 # View the library source code
@@ -218,26 +223,21 @@ r, s =
 msg =
 key_ge =
 `,
-  validate: async (answer) => {
-    if (answer === 'False') {
-      return [true, 'The signature is invalid']
-    }
-    return [false, 'Check your methods']
-  },
-}
+    validate: async (answer) => {
+      if (answer === 'False') {
+        return [true, t('chapter_five.validate_signature_three.success')]
+      }
+      return [false, 'Check your methods']
+    },
+  }
 
-const config: EditorConfig = {
-  defaultLanguage: 'javascript',
-  languages: {
-    javascript,
-    python,
-  },
-}
-
-export default function ValidateSignature3({ lang }) {
-  const t = useTranslations(lang)
-  const [currentLanguage] = useAtom(currentLanguageAtom)
-  const [language, setLanguage] = useState(getLanguageString(currentLanguage))
+  const config: EditorConfig = {
+    defaultLanguage: 'javascript',
+    languages: {
+      javascript,
+      python,
+    },
+  }
 
   const handleSelectLanguage = (language: string) => {
     setLanguage(language)
@@ -248,7 +248,6 @@ export default function ValidateSignature3({ lang }) {
       lang={lang}
       config={config}
       lessonKey={metadata.key}
-      successMessage={t('chapter_five.validate_signature_three.success')}
       onSelectLanguage={handleSelectLanguage}
     >
       <LessonInfo>

--- a/content/lessons/chapter-5/validate-signature-4.tsx
+++ b/content/lessons/chapter-5/validate-signature-4.tsx
@@ -14,21 +14,26 @@ export const metadata = {
   key: 'CH5VLS4',
 }
 
-const javascript = {
-  program: `console.log(verify_keys(keys).toString());
+export default function ValidateSignature4({ lang }) {
+  const t = useTranslations(lang)
+  const [currentLanguage] = useAtom(currentLanguageAtom)
+  const [language, setLanguage] = useState(getLanguageString(currentLanguage))
+
+  const javascript = {
+    program: `console.log(verify_keys(keys).toString());
 console.log("KILL")
 `,
-  defaultFunction: {
-    name: 'verify',
-    args: [],
-  },
-  rangeToNotCollapse: [
-    {
-      start: 70,
-      end: 72,
+    defaultFunction: {
+      name: 'verify',
+      args: [],
     },
-  ],
-  defaultCode: `const secp256k1 = require('@savingsatoshi/secp256k1js')
+    rangeToNotCollapse: [
+      {
+        start: 70,
+        end: 72,
+      },
+    ],
+    defaultCode: `const secp256k1 = require('@savingsatoshi/secp256k1js')
 // View the library source code
 // https://github.com/saving-satoshi/secp256k1js/blob/main/secp256k1.js
 
@@ -101,42 +106,39 @@ function verify_keys(keys) {
   // YOUR CODE HERE
 }
 `,
-  validate: async (answer) => {
-    if (
-      answer ===
-      '049d57ded01d3a7652a957cf86fd4c3d2a76e76e83d3c965e1dca45f1ee06630636b8bcbc3df3fbc9669efa2ccd5d7fa5a89fe1c0045684189f01ea915b8a746a6'
-    ) {
-      return [
-        true,
-        'The signature is valid for this public key Vanderpoole used this public key, this was not Satoshi!',
-      ]
-    }
-    if (answer === 'true') {
-      return [
-        false,
-        'Make sure you are returning the public key Vanderpoole used and not a boolean value',
-      ]
-    }
-    return [false, 'That is not quite right, try again.']
-  },
-}
+    validate: async (answer) => {
+      if (
+        answer ===
+        '049d57ded01d3a7652a957cf86fd4c3d2a76e76e83d3c965e1dca45f1ee06630636b8bcbc3df3fbc9669efa2ccd5d7fa5a89fe1c0045684189f01ea915b8a746a6'
+      ) {
+        return [true, t('chapter_five.validate_signature_four.success')]
+      }
+      if (answer === 'true') {
+        return [
+          false,
+          'Make sure you are returning the public key Vanderpoole used and not a boolean value',
+        ]
+      }
+      return [false, 'That is not quite right, try again.']
+    },
+  }
 
-const python = {
-  program: `
+  const python = {
+    program: `
 print(verify_keys(keys));
 print("KILL")
 `,
-  defaultFunction: {
-    name: 'verify',
-    args: [],
-  },
-  rangeToNotCollapse: [
-    {
-      start: 49,
-      end: 51,
+    defaultFunction: {
+      name: 'verify',
+      args: [],
     },
-  ],
-  defaultCode: `import secp256k1py.secp256k1 as SECP256K1
+    rangeToNotCollapse: [
+      {
+        start: 49,
+        end: 51,
+      },
+    ],
+    defaultCode: `import secp256k1py.secp256k1 as SECP256K1
 # View the library source code
 # https://github.com/saving-satoshi/secp256k1py/blob/main/secp256k1py/secp256k1.py
 
@@ -187,38 +189,30 @@ def verify(r, s, key, msg):
 def verify_keys(keys):
     # YOUR CODE HERE
 `,
-  validate: async (answer) => {
-    if (
-      answer ===
-      '049d57ded01d3a7652a957cf86fd4c3d2a76e76e83d3c965e1dca45f1ee06630636b8bcbc3df3fbc9669efa2ccd5d7fa5a89fe1c0045684189f01ea915b8a746a6'
-    ) {
-      return [
-        true,
-        'The signature is valid for this public key Vanderpoole used this public key, this was not Satoshi!',
-      ]
-    }
-    if (answer === 'True') {
-      return [
-        false,
-        'Make sure you are returning the public key Vanderpoole used and not a boolean value',
-      ]
-    }
-    return [false, 'That is not quite right, try again.']
-  },
-}
+    validate: async (answer) => {
+      if (
+        answer ===
+        '049d57ded01d3a7652a957cf86fd4c3d2a76e76e83d3c965e1dca45f1ee06630636b8bcbc3df3fbc9669efa2ccd5d7fa5a89fe1c0045684189f01ea915b8a746a6'
+      ) {
+        return [true, t('chapter_five.validate_signature_four.success')]
+      }
+      if (answer === 'True') {
+        return [
+          false,
+          'Make sure you are returning the public key Vanderpoole used and not a boolean value',
+        ]
+      }
+      return [false, 'That is not quite right, try again.']
+    },
+  }
 
-const config: EditorConfig = {
-  defaultLanguage: 'javascript',
-  languages: {
-    javascript,
-    python,
-  },
-}
-
-export default function ValidateSignature4({ lang }) {
-  const t = useTranslations(lang)
-  const [currentLanguage] = useAtom(currentLanguageAtom)
-  const [language, setLanguage] = useState(getLanguageString(currentLanguage))
+  const config: EditorConfig = {
+    defaultLanguage: 'javascript',
+    languages: {
+      javascript,
+      python,
+    },
+  }
 
   const handleSelectLanguage = (language: string) => {
     setLanguage(language)
@@ -229,7 +223,6 @@ export default function ValidateSignature4({ lang }) {
       lang={lang}
       config={config}
       lessonKey={metadata.key}
-      successMessage={t('chapter_five.validate_signature_four.success')}
       onSelectLanguage={handleSelectLanguage}
     >
       <LessonInfo>

--- a/content/lessons/chapter-5/verify-signature-2.tsx
+++ b/content/lessons/chapter-5/verify-signature-2.tsx
@@ -26,18 +26,25 @@ const satoshiTransactionMessage =
 const correctAnswer =
   '55192368857469264807759274836848938481238746809645363588732068292162212317977'
 
-// for some reason the answer is coming through with a lot of ansi characters included
-// so we will need to strip them via .toString() before doing the comparison.
-const javascript = {
-  program: `
+export default function VerifySignature2({ lang }) {
+  const t = useTranslations(lang)
+  const [currentLanguage] = useAtom(currentLanguageAtom)
+  const [objectPosition, setObjectPosition] = useState<string | undefined>()
+  const [language, setLanguage] = useState(getLanguageString(currentLanguage))
+  const [tooltipVisible, setTooltipVisible] = useState(false)
+
+  // for some reason the answer is coming through with a lot of ansi characters included
+  // so we will need to strip them via .toString() before doing the comparison.
+  const javascript = {
+    program: `
 console.log(msg_to_integer("${satoshiTransactionMessage}").toString());
 console.log("KILL")
 `,
-  defaultFunction: {
-    name: 'msg_to_integer',
-    args: [],
-  },
-  defaultCode: `const {Hash} = require('crypto');
+    defaultFunction: {
+      name: 'msg_to_integer',
+      args: [],
+    },
+    defaultCode: `const {Hash} = require('crypto');
 
 function msg_to_integer(msg) {
   // Given a hex string to sign, convert that string to a Buffer of bytes,
@@ -45,57 +52,50 @@ function msg_to_integer(msg) {
 
 }
 `,
-  validate: async (answer) => {
-    if (answer !== correctAnswer) {
-      return [false, 'Hash is not valid']
-    }
+    validate: async (answer) => {
+      if (answer !== correctAnswer) {
+        return [false, 'Hash is not valid']
+      }
 
-    return [true, undefined]
-  },
-}
+      return [true, t('chapter_five.verify_signature_two.success')]
+    },
+  }
 
-const python = {
-  program: `
+  const python = {
+    program: `
 print(msg_to_integer("${satoshiTransactionMessage}"))
 print("KILL")
 `,
-  defaultFunction: {
-    name: 'msg_to_integer',
-    args: [],
-  },
-  defaultCode: `# Import from python standard libraries
+    defaultFunction: {
+      name: 'msg_to_integer',
+      args: [],
+    },
+    defaultCode: `# Import from python standard libraries
 import hashlib
 
 def msg_to_integer(msg):
     # Given a hex string to sign, convert that string to bytes,
     # double-SHA256 the bytes and then return an integer from the 32-byte digest.
 `,
-  validate: async (answer) => {
-    // for some reason the answer is coming through with a lot of ansi characters included
-    // so we will need to strip them before doing the comparison.
-    const cleanedAnswer = answer.replace(/\u001b\[[0-9;]*m/g, '')
-    if (cleanedAnswer !== correctAnswer) {
-      return [false, 'Hash is not valid']
-    }
+    validate: async (answer) => {
+      // for some reason the answer is coming through with a lot of ansi characters included
+      // so we will need to strip them before doing the comparison.
+      const cleanedAnswer = answer.replace(/\u001b\[[0-9;]*m/g, '')
+      if (cleanedAnswer !== correctAnswer) {
+        return [false, 'Hash is not valid']
+      }
 
-    return [true, undefined]
-  },
-}
+      return [true, t('chapter_five.verify_signature_two.success')]
+    },
+  }
 
-const config: EditorConfig = {
-  defaultLanguage: 'javascript',
-  languages: {
-    javascript,
-    python,
-  },
-}
-
-export default function VerifySignature2({ lang }) {
-  const t = useTranslations(lang)
-  const [currentLanguage] = useAtom(currentLanguageAtom)
-  const [objectPosition, setObjectPosition] = useState<string | undefined>()
-  const [language, setLanguage] = useState(getLanguageString(currentLanguage))
-  const [tooltipVisible, setTooltipVisible] = useState(false)
+  const config: EditorConfig = {
+    defaultLanguage: 'javascript',
+    languages: {
+      javascript,
+      python,
+    },
+  }
 
   const handleMouseEnter = () => {
     setTooltipVisible(true)
@@ -123,7 +123,6 @@ export default function VerifySignature2({ lang }) {
       lang={lang}
       config={config}
       lessonKey={metadata.key}
-      successMessage={t('chapter_five.verify_signature_two.success')}
       onSelectLanguage={handleSelectLanguage}
     >
       <LessonInfo>

--- a/content/lessons/chapter-5/verify-signature-5.tsx
+++ b/content/lessons/chapter-5/verify-signature-5.tsx
@@ -14,15 +14,21 @@ export const metadata = {
   key: 'CH5VFS5',
 }
 
-const javascript = {
-  program: `console.log(verify(sig_r, sig_s, pubkey_x, pubkey_y, msg));
+export default function VerifySignature5({ lang }) {
+  const t = useTranslations(lang)
+  const [currentLanguage] = useAtom(currentLanguageAtom)
+  const [objectPosition, setObjectPosition] = useState<string | undefined>()
+  const [language, setLanguage] = useState(getLanguageString(currentLanguage))
+
+  const javascript = {
+    program: `console.log(verify(sig_r, sig_s, pubkey_x, pubkey_y, msg));
 console.log("KILL")
 `,
-  defaultFunction: {
-    name: 'verify',
-    args: [],
-  },
-  defaultCode: `const secp256k1 = require('@savingsatoshi/secp256k1js')
+    defaultFunction: {
+      name: 'verify',
+      args: [],
+    },
+    defaultCode: `const secp256k1 = require('@savingsatoshi/secp256k1js')
 // View the library source code
 // https://github.com/saving-satoshi/secp256k1js/blob/main/secp256k1.js
 
@@ -97,28 +103,28 @@ function verify(sig_r, sig_s, pubkey_x, pubkey_y, msg) {
 
 }
 `,
-  validate: async (answer) => {
-    // for some reason the answer is coming through with a lot of ansi characters included
-    // so we will need to strip them before doing the comparison.
-    const cleanedAnswer = answer.replace(/\u001b\[[0-9;]*m/g, '')
-    if (cleanedAnswer !== 'true') {
-      return [false, 'Signature is not valid']
-    }
+    validate: async (answer) => {
+      // for some reason the answer is coming through with a lot of ansi characters included
+      // so we will need to strip them before doing the comparison.
+      const cleanedAnswer = answer.replace(/\u001b\[[0-9;]*m/g, '')
+      if (cleanedAnswer !== 'true') {
+        return [false, 'Signature is not valid']
+      }
 
-    return [true, undefined]
-  },
-}
+      return [true, t('chapter_five.verify_signature_five.success')]
+    },
+  }
 
-const python = {
-  program: `
+  const python = {
+    program: `
 print(verify(sig_r, sig_s, pubkey_x, pubkey_y, msg));
 print("KILL")
 `,
-  defaultFunction: {
-    name: 'verify',
-    args: [],
-  },
-  defaultCode: `import secp256k1py.secp256k1 as SECP256K1
+    defaultFunction: {
+      name: 'verify',
+      args: [],
+    },
+    defaultCode: `import secp256k1py.secp256k1 as SECP256K1
 # View the library source code
 # https://github.com/saving-satoshi/secp256k1py/blob/main/secp256k1py/secp256k1.py
 
@@ -165,28 +171,22 @@ def verify(sig_r, sig_s, pubkey_x, pubkey_y, msg):
     #   Use the python's built-in pow() function to invert s and turn division into multiplication!
     # YOUR CODE HERE!
 `,
-  validate: async (answer) => {
-    if (answer !== 'True') {
-      return [false, 'Signature is not valid']
-    }
+    validate: async (answer) => {
+      if (answer !== 'True') {
+        return [false, 'Signature is not valid']
+      }
 
-    return [true, undefined]
-  },
-}
+      return [true, t('chapter_five.verify_signature_five.success')]
+    },
+  }
 
-const config: EditorConfig = {
-  defaultLanguage: 'javascript',
-  languages: {
-    javascript,
-    python,
-  },
-}
-
-export default function VerifySignature5({ lang }) {
-  const t = useTranslations(lang)
-  const [currentLanguage] = useAtom(currentLanguageAtom)
-  const [objectPosition, setObjectPosition] = useState<string | undefined>()
-  const [language, setLanguage] = useState(getLanguageString(currentLanguage))
+  const config: EditorConfig = {
+    defaultLanguage: 'javascript',
+    languages: {
+      javascript,
+      python,
+    },
+  }
 
   const handleSelectLanguage = (language: string) => {
     setLanguage(language)
@@ -207,7 +207,6 @@ export default function VerifySignature5({ lang }) {
       lang={lang}
       config={config}
       lessonKey={metadata.key}
-      successMessage={t('chapter_five.verify_signature_five.success')}
       onSelectLanguage={handleSelectLanguage}
     >
       <LessonInfo>

--- a/content/lessons/chapter-6/hard/in-out-4.tsx
+++ b/content/lessons/chapter-6/hard/in-out-4.tsx
@@ -121,7 +121,7 @@ class Input {
     validate: async (answer: string) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, '']
+          return [true, t('chapter_six.in_out_four.hard.success')]
         } else {
           return [false, 'recheck your methods']
         }
@@ -186,7 +186,7 @@ class Input:
     validate: async (answer) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, '']
+          return [true, t('chapter_six.in_out_four.hard.success')]
         } else {
           return [false, 'recheck your methods']
         }
@@ -220,7 +220,6 @@ class Input:
       lang={lang}
       config={config}
       lessonKey={metadata.key}
-      successMessage={t('chapter_six.in_out_four.hard.success')}
       onSelectLanguage={handleSelectLanguage}
       saveData
     >

--- a/content/lessons/chapter-6/hard/put-it-together-1.tsx
+++ b/content/lessons/chapter-6/hard/put-it-together-1.tsx
@@ -59,7 +59,7 @@ export default function PutItTogetherOneHard({ lang }) {
     validate: async (answer: string) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, 'Nicely Done']
+          return [true, t('chapter_six.put_it_together_one.hard.success')]
         }
         return [
           false,
@@ -96,7 +96,7 @@ class Witness:
     validate: async (answer: string) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, 'Nicely Done ']
+          return [true, t('chapter_six.put_it_together_one.hard.success')]
         }
         return [false, 'Not a valid hex value']
       }
@@ -121,7 +121,6 @@ class Witness:
         config={config}
         saveData
         lessonKey={metadata.key}
-        successMessage={t('chapter_six.put_it_together_one.hard.success')}
       >
         <LessonInfo>
           <Text className="font-nunito text-2xl font-bold text-white">

--- a/content/lessons/chapter-6/hard/put-it-together-2.tsx
+++ b/content/lessons/chapter-6/hard/put-it-together-2.tsx
@@ -163,7 +163,7 @@ console.log(tx_dluitpjd.serialize().toString('hex')==='020000000001018e74531c451
     validate: async (answer: string) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, 'Nicely done']
+          return [true, t('chapter_six.put_it_together_two.hard.success')]
         }
         return [false, 'Not a valid hex value']
       }
@@ -291,7 +291,7 @@ class Transaction:
     validate: async (answer: string) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, 'Nicely Done ']
+          return [true, t('chapter_six.put_it_together_two.hard.success')]
         }
         return [false, 'Not a valid hex value']
       }
@@ -316,7 +316,6 @@ class Transaction:
         config={config}
         saveData
         lessonKey={metadata.key}
-        successMessage={t('chapter_six.put_it_together_two.hard.success')}
       >
         <LessonInfo className="overflow-y-scroll  sm:max-h-[calc(100vh-70px)]">
           <Text className="font-nunito text-2xl font-bold text-white">

--- a/content/lessons/chapter-6/hard/put-it-together-3.tsx
+++ b/content/lessons/chapter-6/hard/put-it-together-3.tsx
@@ -169,7 +169,7 @@ ${prevData.data.slice(0, -2)}
     validate: async (answer: string) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, 'Nicely done']
+          return [true, t('chapter_six.put_it_together_three.hard.success')]
         }
         return [false, 'Not a valid hex value']
       }
@@ -296,7 +296,7 @@ ${prevData.data}
     validate: async (answer: string) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, 'Nicely Done ']
+          return [true, t('chapter_six.put_it_together_three.hard.success')]
         }
         return [false, 'Not a valid hex value']
       }
@@ -322,7 +322,6 @@ ${prevData.data}
         config={config}
         saveData
         lessonKey={metadata.key}
-        successMessage={t('chapter_six.put_it_together_three.hard.success')}
       >
         <LessonInfo className="overflow-y-scroll  sm:max-h-[calc(100vh-70px)]">
           <Text className="font-nunito text-2xl font-bold text-white">

--- a/content/lessons/chapter-6/hard/put-it-together-4.tsx
+++ b/content/lessons/chapter-6/hard/put-it-together-4.tsx
@@ -197,7 +197,7 @@ ${prevData.data.slice(0, -2)}
     validate: async (answer: string) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, '']
+          return [true, t('chapter_six.put_it_together_four.hard.success')]
         } else {
           return [false, 'recheck your methods']
         }
@@ -342,7 +342,7 @@ ${prevData.data}
     validate: async (answer) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, '']
+          return [true, t('chapter_six.put_it_together_four.hard.success')]
         } else {
           return [false, 'recheck your methods']
         }
@@ -370,7 +370,6 @@ ${prevData.data}
         config={config}
         saveData
         lessonKey={metadata.key}
-        successMessage={t('chapter_six.put_it_together_four.hard.success')}
       >
         <LessonInfo className="overflow-y-scroll  sm:max-h-[calc(100vh-70px)]">
           <Title>{t('chapter_six.put_it_together_four.hard.heading')}</Title>

--- a/content/lessons/chapter-6/hard/put-it-together-5.tsx
+++ b/content/lessons/chapter-6/hard/put-it-together-5.tsx
@@ -188,7 +188,7 @@ console.log("KILL")
     validate: async (answer: string) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, '']
+          return [true, t('chapter_six.put_it_together_five.hard.success')]
         } else {
           return [false, 'recheck your methods']
         }
@@ -329,7 +329,7 @@ print("KILL")
     validate: async (answer: string) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, '']
+          return [true, t('chapter_six.put_it_together_five.hard.success')]
         } else {
           return [false, 'recheck your methods']
         }
@@ -356,7 +356,6 @@ print("KILL")
         lang={lang}
         config={config}
         lessonKey={metadata.key}
-        successMessage={t('chapter_six.put_it_together_five.hard.success')}
         saveData
       >
         <LessonInfo>

--- a/content/lessons/chapter-6/hard/put-it-together-6.tsx
+++ b/content/lessons/chapter-6/hard/put-it-together-6.tsx
@@ -119,7 +119,7 @@ console.log(tx.serialize().toString('hex'));`,
       if (answer.slice(-8) !== '00000000') {
         return [false, 'Nope! Try again.']
       }
-      return [true, 'Nicely Done']
+      return [true, t('chapter_six.put_it_together_six.hard.success')]
     },
   }
 
@@ -172,7 +172,7 @@ print(tx.serialize().hex())`,
       if (answer.slice(-8) !== '00000000') {
         return [false, 'Nope! Try again.']
       }
-      return [true, 'Nicely Done']
+      return [true, t('chapter_six.put_it_together_six.hard.success')]
     },
   }
 
@@ -195,7 +195,6 @@ print(tx.serialize().hex())`,
         config={config}
         saveData
         lessonKey={metadata.key}
-        successMessage={t('chapter_six.put_it_together_six.hard.success')}
         loadingSavedCode={isLoading}
       >
         <LessonInfo>

--- a/content/lessons/chapter-6/in-out-5.tsx
+++ b/content/lessons/chapter-6/in-out-5.tsx
@@ -95,7 +95,7 @@ class Output {
     validate: async (answer: string) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, '']
+          return [true, t('chapter_six.in_out_five.success')]
         } else {
           return [false, 'recheck your methods']
         }
@@ -142,7 +142,7 @@ class Output:
     validate: async (answer) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, '']
+          return [true, t('chapter_six.in_out_five.success')]
         } else {
           return [false, 'recheck your methods']
         }
@@ -171,7 +171,6 @@ class Output:
       config={config}
       saveData
       lessonKey={metadata.key}
-      successMessage={t('chapter_six.in_out_five.success')}
       onSelectLanguage={handleSelectLanguage}
     >
       <LessonInfo>

--- a/content/lessons/chapter-6/normal/put-it-together-1.tsx
+++ b/content/lessons/chapter-6/normal/put-it-together-1.tsx
@@ -197,7 +197,7 @@ class Transaction {
     validate: async (answer: string) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, 'Nicely done']
+          return [true, t('chapter_six.put_it_together_one.normal.success')]
         }
         return [false, 'Not a valid hex value']
       }
@@ -358,7 +358,7 @@ class Transaction:
     validate: async (answer: string) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, 'Nicely Done ']
+          return [true, t('chapter_six.put_it_together_one.normal.success')]
         }
         return [false, 'Not a valid hex value']
       }
@@ -383,7 +383,6 @@ class Transaction:
         config={config}
         saveData
         lessonKey={metadata.key}
-        successMessage={t('chapter_six.put_it_together_one.normal.success')}
       >
         <LessonInfo>
           <Text className="font-nunito text-2xl font-bold text-white">

--- a/content/lessons/chapter-6/normal/put-it-together-2.tsx
+++ b/content/lessons/chapter-6/normal/put-it-together-2.tsx
@@ -255,7 +255,7 @@ ${combinedCode.slice(0, -2)}
     validate: async (answer: string) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, '']
+          return [true, t('chapter_six.put_it_together_two.normal.success')]
         } else {
           return [false, 'recheck your methods']
         }
@@ -405,7 +405,7 @@ ${combinedCode}
     validate: async (answer) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, '']
+          return [true, t('chapter_six.put_it_together_two.normal.success')]
         } else {
           return [false, 'recheck your methods']
         }
@@ -433,7 +433,6 @@ ${combinedCode}
         config={config}
         saveData
         lessonKey={metadata.key}
-        successMessage={t('chapter_six.put_it_together_two.normal.success')}
         loadingSavedCode={isLoading}
       >
         <LessonInfo>

--- a/content/lessons/chapter-6/normal/put-it-together-3.tsx
+++ b/content/lessons/chapter-6/normal/put-it-together-3.tsx
@@ -226,7 +226,7 @@ console.log(tx.serialize().toString('hex'));`,
       if (answer.slice(-8) !== '00000000') {
         return [false, 'Nope! Try again....']
       }
-      return [true, 'Nicely Done']
+      return [true, t('chapter_six.put_it_together_three.normal.success')]
     },
   }
 
@@ -285,7 +285,7 @@ print(tx.serialize().hex())`,
       if (answer.slice(-8) !== '00000000') {
         return [false, 'Nope! Try again.']
       }
-      return [true, 'Nicely Done']
+      return [true, t('chapter_six.put_it_together_three.normal.success')]
     },
   }
 
@@ -307,7 +307,6 @@ print(tx.serialize().hex())`,
         config={config}
         saveData
         lessonKey={metadata.key}
-        successMessage={t('chapter_six.put_it_together_three.normal.success')}
         loadingSavedCode={isLoading}
       >
         <LessonInfo>

--- a/content/lessons/chapter-7/mempool-transaction-1.tsx
+++ b/content/lessons/chapter-7/mempool-transaction-1.tsx
@@ -210,7 +210,7 @@ function run() {
           answer.startsWith('Total fees:') &&
           Number(answer.split(' ')[2]) >= 65000001
         ) {
-          return [5, '']
+          return [5, t('chapter_seven.mempool_transaction_one.success')]
         } else {
           return [false, 'Invalid block, keep working!']
         }
@@ -322,7 +322,7 @@ def run():
           answer.startsWith('Total fees:') &&
           Number(answer.split(' ')[2]) >= 65000001
         ) {
-          return [5, '']
+          return [5, t('chapter_seven.mempool_transaction_one.success')]
         } else {
           return [false, 'Invalid block, keep working!']
         }
@@ -370,7 +370,6 @@ def run():
       lessonKey={metadata.key}
       poorMessage={t('chapter_seven.mempool_transaction_one.poor')}
       goodMessage={t('chapter_seven.mempool_transaction_one.good')}
-      successMessage={t('chapter_seven.mempool_transaction_one.success')}
       onSelectLanguage={handleSelectLanguage}
       saveData
     >

--- a/content/lessons/chapter-8/building-blocks-3.tsx
+++ b/content/lessons/chapter-8/building-blocks-3.tsx
@@ -31,7 +31,7 @@ console.log(Bitcoin.rpc());
     validate: async (answer: string) => {
       if (answer) {
         if (answer === '3007592928481984.23') {
-          return [true, '']
+          return [true, t('chapter_eight.building_blocks_three.success')]
         } else {
           return [null, '']
         }
@@ -57,7 +57,7 @@ print(Bitcoin.rpc())
     validate: async (answer) => {
       if (answer) {
         if (answer === '3007592928481984.23') {
-          return [true, '']
+          return [true, t('chapter_eight.building_blocks_three.success')]
         } else {
           return [null, '']
         }
@@ -86,7 +86,6 @@ print(Bitcoin.rpc())
       config={config}
       saveData
       lessonKey={metadata.key}
-      successMessage={t('chapter_eight.building_blocks_three.success')}
       onSelectLanguage={handleSelectLanguage}
     >
       <LessonInfo>

--- a/content/lessons/chapter-8/building-blocks-4.tsx
+++ b/content/lessons/chapter-8/building-blocks-4.tsx
@@ -49,7 +49,7 @@ const getBlockHeight = (height) => {
         answer ===
         'b09090d61e5eea3e23e9b428de2d9660c8b5e345ec3bb39eea8df9bc80813171'
       ) {
-        return [true, 'Nicely Done ']
+        return [true, t('chapter_eight.building_blocks_four.success')]
       } else {
         return [false, 'Incorrect']
       }
@@ -79,7 +79,7 @@ def get_block_height(height):
         answer ===
         'b09090d61e5eea3e23e9b428de2d9660c8b5e345ec3bb39eea8df9bc80813171'
       ) {
-        return [true, 'Nicely Done ']
+        return [true, t('chapter_eight.building_blocks_four.success')]
       } else {
         return [false, 'Incorrect']
       }
@@ -105,7 +105,6 @@ def get_block_height(height):
       config={config}
       saveData
       lessonKey={metadata.key}
-      successMessage={t('chapter_eight.building_blocks_four.success')}
       onSelectLanguage={handleSelectLanguage}
     >
       <LessonInfo>

--- a/content/lessons/chapter-8/building-blocks-5.tsx
+++ b/content/lessons/chapter-8/building-blocks-5.tsx
@@ -53,7 +53,7 @@ const getTxFee = (tx) => {
 `,
     validate: async (answer) => {
       if (answer === '700') {
-        return [true, 'Nicely Done']
+        return [true, t('chapter_eight.building_blocks_five.success')]
       } else {
         return [false, 'Incorrect']
       }
@@ -91,7 +91,7 @@ def get_tx_fee(tx):
 `,
     validate: async (answer: string) => {
       if (answer === '700') {
-        return [true, 'Nicely Done ']
+        return [true, t('chapter_eight.building_blocks_five.success')]
       } else {
         return [false, 'Incorrect']
       }
@@ -117,7 +117,6 @@ def get_tx_fee(tx):
       config={config}
       saveData
       lessonKey={metadata.key}
-      successMessage={t('chapter_eight.building_blocks_five.success')}
       onSelectLanguage={handleSelectLanguage}
     >
       <LessonInfo className="overflow-y-scroll sm:max-h-[calc(100vh-70px)]">

--- a/content/lessons/chapter-8/building-blocks-6.tsx
+++ b/content/lessons/chapter-8/building-blocks-6.tsx
@@ -41,7 +41,7 @@ console.log("KILL")`,
     validate: async (answer: string) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, '']
+          return [true, t('chapter_eight.building_blocks_six.success')]
         } else {
           return [false, 'recheck your methods']
         }
@@ -65,7 +65,7 @@ print("KILL")`,
     validate: async (answer) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, '']
+          return [true, t('chapter_eight.building_blocks_six.success')]
         } else {
           return [false, 'recheck your methods']
         }
@@ -94,7 +94,6 @@ print("KILL")`,
       config={config}
       saveData
       lessonKey={metadata.key}
-      successMessage={t('chapter_eight.building_blocks_six.success')}
       onSelectLanguage={handleSelectLanguage}
     >
       <LessonInfo>

--- a/content/lessons/chapter-8/building-blocks-7.tsx
+++ b/content/lessons/chapter-8/building-blocks-7.tsx
@@ -105,7 +105,7 @@ function validateBlock(block) {
           answer ===
           '88fd124d747cde1d8494d589ec6b82ce11356dd869823dfec8e84b111a72bc87'
         ) {
-          return [true, '']
+          return [true, t('chapter_eight.building_blocks_seven.success')]
         } else {
           return [false, 'recheck your methods']
         }
@@ -157,7 +157,7 @@ def validate_block(block):
           answer ===
           '88fd124d747cde1d8494d589ec6b82ce11356dd869823dfec8e84b111a72bc87'
         ) {
-          return [true, '']
+          return [true, t('chapter_eight.building_blocks_seven.success')]
         } else {
           return [false, 'recheck your methods']
         }
@@ -209,7 +209,6 @@ for (const bhash of candidates) {
         config={config}
         saveData
         lessonKey={metadata.key}
-        successMessage={t('chapter_eight.building_blocks_seven.success')}
         onSelectLanguage={handleSelectLanguage}
       >
         <LessonInfo>

--- a/content/lessons/chapter-8/building-blocks-8.tsx
+++ b/content/lessons/chapter-8/building-blocks-8.tsx
@@ -90,7 +90,7 @@ const showtime = () => {
     validate: async (answer: string) => {
       if (answer) {
         if (answer === 'true') {
-          return [true, '']
+          return [true, t('chapter_eight.building_blocks_eight.success')]
         } else {
           return [false, 'recheck your methods']
         }
@@ -131,7 +131,7 @@ def showtime():
     validate: async (answer) => {
       if (answer) {
         if (answer === 'True') {
-          return [true, '']
+          return [true, t('chapter_eight.building_blocks_eight.success')]
         } else {
           return [false, 'Recheck your methods']
         }
@@ -169,7 +169,6 @@ def showtime():
         config={config}
         saveData
         lessonKey={metadata.key}
-        successMessage={t('chapter_eight.building_blocks_eight.success')}
         onSelectLanguage={handleSelectLanguage}
       >
         <LessonInfo>

--- a/content/resources/chapter-2/scripting-2.tsx
+++ b/content/resources/chapter-2/scripting-2.tsx
@@ -21,7 +21,7 @@ const javascript = {
     args: ['nonce'],
   },
   defaultCode: [
-    `function findHash(nonce) {
+    `function findHashFromNonce(nonce) {
   let hash = '';
 
   // while the hash does not start with 5 zeroes we want the prgram to repeat
@@ -48,7 +48,7 @@ const python = {
     args: ['nonce'],
   },
   defaultCode: [
-    `def find_hash(nonce):
+    `def find_hash_from_nonce(nonce):
     # Lets initialize the hash here as an empty string
     hash = ''
 

--- a/content/resources/chapter-2/scripting-2.tsx
+++ b/content/resources/chapter-2/scripting-2.tsx
@@ -28,13 +28,14 @@ const javascript = {
   while (hash.substring(0, 5) !== '00000') {
     // Hash the nonce using the crypto library and then increment the nonce
     hash = crypto.createHash('sha256').update(nonce.toString()).digest('hex');
-
+    if(hash.startsWith('00000')) {
+      return nonce
+    }
     nonce++;
   }
-  return hash
 }`,
   ],
-  validate: async (answer) => {
+  validate: async () => {
     return [true, undefined]
   },
   constraints: [],
@@ -55,10 +56,12 @@ const python = {
     while hash[0:5] != '00000':
         # Hash the nonce using the crypto library and then increment the nonce
         hash = sha256(str(nonce).encode()).digest().hex()
+        if (hash[0:5] == '00000'):
+            return nonce
         nonce += 1
-    return hash`,
+`,
   ],
-  validate: async (answer) => {
+  validate: async () => {
     return [true, undefined]
   },
   constraints: [],
@@ -156,7 +159,7 @@ export default function ScriptingResourcesTwo({ lang }) {
               <div className="relative grow bg-[#00000026] font-mono text-sm text-white">
                 <MonacoEditor
                   loading={<Loader className="h-10 w-10 text-white" />}
-                  height={`235px`}
+                  height={`250px`}
                   value={code}
                   beforeMount={handleBeforeMount}
                   onMount={handleMount}

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1169,6 +1169,7 @@ const translations = {
           return: 'It should return a tuple with the (r, s) values.',
         },
       },
+      success: 'Nicely Done',
     },
     validate_signature_three: {
       title: 'Validate the signature',

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -410,7 +410,7 @@ const translations = {
         'Alright, time to write and run your own code. Write a script that generates a sha256 hash that begins with five zeroes ("00000..."). Your code should repeatedly call the sha256 function with different input until the output satisfies this requirement. You should try incrementing an integer inside a loop to get different inputs. In cryptography this number may referred to as a "nonce" or "number used once".',
       python: {
         paragraph_two:
-          'When you find a nonce with a hash that begins with five zeroes, return the hash to the console. We are using the hashlib library in python to help you along in creating this function, you can use the following external resources to help you write this function if needed:',
+          'When you find a nonce with a hash that begins with five zeroes, return the nonce from the function. We are using the hashlib library in python to help you along in creating this function, you can use the following external resources to help you write this function if needed:',
         list_one:
           '<Link href="https://docs.python.org/3/library/hashlib.html" target="_blank" className="underline">hashlib documentation</Link>',
         list_two:
@@ -418,13 +418,12 @@ const translations = {
       },
       javascript: {
         paragraph_two:
-          'When you find a nonce with a hash that begins with five zeroes, return the hash to the console. We are using the crypto library in JavaScript to help you along in creating this function, you can use the following external resources to help you write this function if needed:',
+          'When you find a nonce with a hash that begins with five zeroes, return the nonce from the function. We are using the crypto library in JavaScript to help you along in creating this function, you can use the following external resources to help you write this function if needed:',
         list_one:
           '<Link href="https://www.geeksforgeeks.org/node-js-crypto-createhash-method/" target="_blank" className="underline">crypto documentation</Link>',
         list_two:
           '<Link href="https://www.educative.io/answers/what-is-node-cryptocreatehashalgorithm-options" target="_blank" className="underline">Tutorial JavaScript function</Link>',
       },
-      success: 'Five zeroes! That’s it!',
     },
 
     mining_one: {

--- a/ui/lesson/ScriptingChallenge/LanguageTabs.tsx
+++ b/ui/lesson/ScriptingChallenge/LanguageTabs.tsx
@@ -27,6 +27,10 @@ export default function LanguageTabs({
   const isActive = activeView === LessonView.Code
   const pathData = usePathData()
 
+  const handleClick = (value) => {
+    onChange(value)
+  }
+
   return (
     <div
       className={clsx(
@@ -45,7 +49,7 @@ export default function LanguageTabs({
             (languageLocked && meta.value !== value && (
               <button
                 key={i}
-                onClick={() => onChange(meta.value)}
+                onMouseDown={() => handleClick(meta.value)}
                 className={clsx(
                   'flex h-full items-center justify-center border-r border-white border-opacity-30',
                   {
@@ -80,7 +84,7 @@ export default function LanguageTabs({
             )) || (
               <button
                 key={i}
-                onClick={() => onChange(meta.value)}
+                onMouseDown={() => handleClick(meta.value)}
                 className={clsx(
                   'flex h-full items-center justify-center border-r border-white border-opacity-30',
                   {

--- a/ui/lesson/ScriptingChallenge/Runner/Hasher.tsx
+++ b/ui/lesson/ScriptingChallenge/Runner/Hasher.tsx
@@ -17,7 +17,6 @@ export default function Hasher({
   language,
   state,
   config,
-  successMessage,
   validationError,
   value,
 }: {
@@ -25,7 +24,6 @@ export default function Hasher({
   language: string
   state: HasherState
   config: EditorConfig
-  successMessage: string
   validationError?: string
   value: any
 }) {
@@ -112,9 +110,6 @@ export default function Hasher({
             <span className="text-sm">
               Check the Console tab for more information
             </span>
-          )}
-          {state === HasherState.Success && (
-            <span className="text-sm">{successMessage}</span>
           )}
           {state !== HasherState.Error &&
             state !== HasherState.Success &&

--- a/ui/lesson/ScriptingChallenge/Runner/index.tsx
+++ b/ui/lesson/ScriptingChallenge/Runner/index.tsx
@@ -58,7 +58,6 @@ export default function Runner({
   lang,
   poorMessage,
   goodMessage,
-  successMessage,
   setErrors,
 }: {
   language: string
@@ -71,7 +70,6 @@ export default function Runner({
   lang: string
   poorMessage: string
   goodMessage: string
-  successMessage: string
   setErrors: (errors: string[]) => void
 }) {
   const t = useTranslations(lang)
@@ -184,15 +182,15 @@ export default function Runner({
             }
             sendTerminal('print', payload)
 
-            const [res, err] = await onValidate({
+            const [res, msg] = await onValidate({
               code: new Base64String(`${code}\n${program}`),
               answer: payload,
             })
             if (!res || res === 2) {
               setIsRunning(false)
               setHasherState(HasherState.Error)
-              if (err) {
-                sendTerminal('error', err)
+              if (msg) {
+                sendTerminal('error', msg)
               }
               break
             }
@@ -217,7 +215,7 @@ export default function Runner({
             setIsRunning(false)
             setHasherState(HasherState.Success)
             sendTerminal('success', t('runner.evaluation'))
-            sendTerminal('success', successMessage)
+            sendTerminal('success', msg)
             ws?.close()
             break
           }

--- a/ui/lesson/ScriptingChallenge/index.tsx
+++ b/ui/lesson/ScriptingChallenge/index.tsx
@@ -52,7 +52,6 @@ export default function ScriptingChallenge({
   editorOptions,
   poorMessage,
   goodMessage,
-  successMessage,
   saveData,
   onSelectLanguage,
   loadingSavedCode,
@@ -64,7 +63,6 @@ export default function ScriptingChallenge({
   config: EditorConfig
   poorMessage?: string
   goodMessage?: string
-  successMessage: string
   saveData?: boolean
   onSelectLanguage?: (language: string) => void
   loadingSavedCode?: boolean

--- a/ui/lesson/ScriptingChallenge/index.tsx
+++ b/ui/lesson/ScriptingChallenge/index.tsx
@@ -255,7 +255,6 @@ export default function ScriptingChallenge({
             handleTryAgain={handleTryAgain}
             poorMessage={poorMessage ?? ''}
             goodMessage={goodMessage ?? ''}
-            successMessage={successMessage}
           />
         </div>
       </Lesson>


### PR DESCRIPTION
This moves the scripting challenge success messages into the content page instead of as a parameter that drills down to the ui component.

Also changes the validation of chapter 2 scripting 2 to see if there is a better flow to requiring the nonce value to prevent users from console.logging a string with all zeroes

[Preview chapter 2 validation change](https://saving-satoshi-git-fork-benalleng-chapter-162acc-savingsatoshi.vercel.app/en/chapters/chapter-2/scripting-2?dev=true)

[Preview translation success message moved](https://saving-satoshi-git-fork-benalleng-chapter-162acc-savingsatoshi.vercel.app/en/chapters/chapter-8/building-blocks-3?dev=true)