### PR TITLE
Repl code base64 encoded

### DIFF
--- a/ui/lesson/ScriptingChallenge/Runner/index.tsx
+++ b/ui/lesson/ScriptingChallenge/Runner/index.tsx
@@ -135,7 +135,11 @@ export default function Runner({
       }
 
       ws = new WebSocket(wsEndpoint)
-      ws.onopen = () => send('repl', { code: `${code}\n${program}`, language })
+      ws.onopen = () =>
+        send('repl', {
+          code: Buffer.from(`${code}\n${program}`).toString('base64'),
+          language,
+        })
       ws.onmessage = async (e) => {
         let { type, payload } = JSON.parse(e.data)
         switch (type) {


### PR DESCRIPTION
Now encodes the repl stream code to base64 to remove the `\n` and other whitespace in the `JSON.stringify()` pairs with https://github.com/saving-satoshi/saving-satoshi-backend/pull/54