### PR TITLE
Chapter 10 copy: encourage player to revisit previous solutions

### DIFF
--- a/content/lessons/chapter-10/making-a-payment-2.tsx
+++ b/content/lessons/chapter-10/making-a-payment-2.tsx
@@ -76,11 +76,14 @@ export default function MakingAPayment2({ lang }) {
             {t('chapter_ten.making_a_payment_two.heading_three')}
           </Text>
           <Text className="mt-4 text-lg md:text-xl">
+            {t('chapter_ten.making_a_payment_two.hint_one')}
+          </Text>
+          <Text className="mt-4 text-lg md:text-xl">
             {t('chapter_ten.making_a_payment_two.paragraph_three')}
           </Text>
           <ul className="ml-4 mt-4 list-disc  font-nunito text-xl">
-            <li>{t('chapter_ten.making_a_payment_two.hint_one')}</li>
             <li>{t('chapter_ten.making_a_payment_two.hint_two')}</li>
+            <li>{t('chapter_ten.making_a_payment_two.hint_three')}</li>
           </ul>
           <Text className="mt-4 text-lg md:text-xl">
             {t('chapter_ten.making_a_payment_two.paragraph_four')}

--- a/content/lessons/chapter-10/making-a-payment-5.tsx
+++ b/content/lessons/chapter-10/making-a-payment-5.tsx
@@ -75,14 +75,17 @@ export default function MakingAPayment5({ lang }) {
           <Text className="mt-4 text-lg font-bold md:text-xl">
             {t('chapter_ten.making_a_payment_five.heading_three')}
           </Text>
+          <Text className="mt-4 text-lg md:text-xl">
+            {t('chapter_ten.making_a_payment_five.hint_one')}
+          </Text>
 
           <Text className="mt-4 text-lg md:text-xl">
             {t('chapter_ten.making_a_payment_five.paragraph_three')}
           </Text>
 
           <ul className="ml-4 mt-4 list-decimal font-nunito text-xl">
-            <li>{t('chapter_ten.making_a_payment_five.hint_one')}</li>
             <li>{t('chapter_ten.making_a_payment_five.hint_two')}</li>
+            <li>{t('chapter_ten.making_a_payment_five.hint_three')}</li>
           </ul>
           <Text className="mt-4 text-lg md:text-xl">
             {t('chapter_ten.making_a_payment_five.paragraph_four')}

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -2896,9 +2896,10 @@ Stack Hint: To spend before the secret is revealed, Vanderpoole uses his signatu
       list_four: `Don't sign it yourself yet!`,
       heading_three: `Hints`,
       paragraph_three: `Output 0 is spent by either:`,
-      hint_one:
+      hint_one: `The 'Refund' tab is now known as 'Initial Commitment'. You can use it to see the script you wrote for the previous state.`,
+      hint_two:
         'You, after 700 blocks: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base whitespace-nowrap">SIG(YOU) 1 </span>',
-      hint_two: `Laszlo: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base whitespace-nowrap"> 0 SIG(REVOCATION_YOU_2) SIG(LASZLO) 0 </span>`,
+      hint_three: `Laszlo: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base whitespace-nowrap"> 0 SIG(REVOCATION_YOU_2) SIG(LASZLO) 0 </span>`,
       paragraph_four: `Output 1 is spent by Laszlo: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base whitespace-nowrap"> SIG(LASZLO) </span>`,
     },
     making_a_payment_three: {
@@ -2924,10 +2925,11 @@ Stack Hint: To spend before the secret is revealed, Vanderpoole uses his signatu
       list_one: `Fill in the amounts and output scripts for Laszlo's commitment transaction`,
       list_two: `Sign it and send it to Laszlo, who will then sign your commitment transaction and send that back to you`,
       heading_three: 'Hints',
+      hint_one: `You can switch to the 'Commitment_you' tab to see the script you wrote for your commitment transaction.`,
       paragraph_three: 'Output 0 is spent by either:',
-      hint_one:
+      hint_two:
         'Laszlo, after 700 blocks: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base whitespace-nowrap">SIG(LASZLO) 1 </span>',
-      hint_two: `You <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base whitespace-nowrap"> 0 SIG(REVOCATION_LASZLO_1) SIG(YOU) 0 </span>`,
+      hint_three: `You <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base whitespace-nowrap"> 0 SIG(REVOCATION_LASZLO_1) SIG(YOU) 0 </span>`,
       paragraph_four: `Output 1 is spent by You: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base whitespace-nowrap"> SIG(YOU) </span>`,
     },
     making_a_payment_six: {

--- a/ui/lesson/TransactionsChallenge/index.tsx
+++ b/ui/lesson/TransactionsChallenge/index.tsx
@@ -200,6 +200,18 @@ const TransactionChallenge: FC<ITransactionProps> = ({
         return { id: tab, text: 'commitment' }
       }
 
+      // Start calling the refund tab "initial commitment" now that the player
+      // has learned about commitment transactions
+      const postCommitmentLessons = new Set([
+        'CH10MAP2',
+        'CH10MAP5',
+        'CH10MAP6',
+        'CH10MAP8',
+      ])
+      if (postCommitmentLessons.has(progressKey) && tab === 'refund_2') {
+        return { id: tab, text: 'initial commitment' }
+      }
+
       return { id: tab, text: tab.includes('refund') ? 'refund' : tab }
     })
   const returnSuccess = (): SuccessNumbers => {


### PR DESCRIPTION
This PR addresses issue https://github.com/saving-satoshi/saving-satoshi/issues/1240

I added copy to encourage users to look at their previous solutions since we don't do any kind of pre-filling here for the code. I also renamed the 'Refund' tab to 'Initial Commitment' every time the user sees it after learning about the term "commitment transactions" in making-a-payment-1. Probably makes more sense to call this the "Initial commitment" from the start, and rename it to "Refund" for updating-the-state-5 but that doesn't seem like it's worth the effort.

@benalleng hoping I implemented things properly based on your comment here: https://github.com/saving-satoshi/saving-satoshi/issues/1138#issuecomment-2523946416 Have a look at it and LMK.

Test links: