### PR TITLE
German translation

### DIFF
--- a/i18n/locales/de.ts
+++ b/i18n/locales/de.ts
@@ -25,7 +25,7 @@ const translations = {
     subtitle:
       'Wir schreiben das Jahr 2139. In zwei Wochen wird der letzte Bitcoin geschürft. Seit Monaten tickt auf dem Satoshi Square eine Uhr herunter.',
     intro:
-      'Die Welt wartet auf den letzten Block. Dann kommt das Netzwerk plötzlich zum Stillstand.<br><br>Sie erhalten ein Holocat von jemandem mit dem Namen Satoshi Nakamoto. (Es ist wie jedes andere E-Hologramm, aber dieses hat die Form einer Katze). Sie öffnen das Holocat, indem Sie neugierig auf seine Nase klopfen, um zu hören, was es zu sagen hat ...',
+      'Die Welt wartet auf den letzten Block. Dann kommt das Netzwerk plötzlich zum Stillstand.<br><br>Sie erhalten ein Holokatze von jemandem mit dem Namen Satoshi Nakamoto. (Es ist wie jedes andere E-Hologramm, aber dieses hat die Form einer Katze). Sie öffnen das Holokatze, indem Sie neugierig auf seine Nase klopfen, um zu hören, was es zu sagen hat ...',
     project: {
       title: 'Mit Spaß gebaut',
       paragraph_one:
@@ -97,16 +97,16 @@ const translations = {
     },
     intro_two: {
       title: 'Genesis',
-      nav_title: 'Satoshis Holocaust',
+      nav_title: 'Satoshis Holokatze',
       paragraph_one:
-        'Auf Ihrer Everything Watch erhalten Sie einen Holocat der Marke WhiskerWare von jemandem mit dem Namen Satoshi Nakamoto. (Er ist wie jedes andere E-Hologramm, aber dieses hat die Form einer Katze.) Sie öffnen den Holocat, indem Sie auf seine Nase stupsen.',
+        'Auf Ihrer Everything Watch erhalten Sie einen Holokatze der Marke WhiskerWare von jemandem mit dem Namen Satoshi Nakamoto. (Er ist wie jedes andere E-Hologramm, aber dieses hat die Form einer Katze.) Sie öffnen den —Holokatze, indem Sie auf seine Nase stupsen.',
       paragraph_two:
         '— „Bitcoin stirbt nicht, aber es braucht Ihre Hilfe. Vergessen Sie die Katze nicht.“ – Satoshi Nakamoto',
       paragraph_three:
         '—Satoshi? Die Satoshi? Aus dem Whitepaper? Nein, das kann nicht sein. Sie gelten seit über einem Jahrhundert als tot.',
       paragraph_four: 'Haben sie nicht?',
       paragraph_five:
-        'Holocat: „Mach dich lieber an die Arbeit. Ich kann helfen, aber du musst anfangen zu miauen.“',
+        'Holokatze: „Mach dich lieber an die Arbeit. Ich kann helfen, aber du musst anfangen zu miauen.“',
     },
     genesis_one: {
       title: 'Genesis',
@@ -202,7 +202,7 @@ const translations = {
       paragraph_one:
         'Sie rennen hinunter zu Ihrer Garage, steigen in den alten Budgetcopter Ihres Vaters, geben die Koordinaten ein und machen sich auf den Weg zu Distrikt 21.',
       paragraph_two:
-        'Trotz Katzenallergien, die so stark sind, dass sie sogar auf Hologramme zutreffen, kommt der Holocat. Sie wenden ein, aber Katzen sind eben Katzen.',
+        'Trotz Katzenallergien, die so stark sind, dass sie sogar auf Hologramme zutreffen, kommt der Holokatze. Sie wenden ein, aber Katzen sind eben Katzen.',
       button_text: 'Schließe Kapitel 1 ab.',
     },
     outro_two: {
@@ -259,11 +259,11 @@ const translations = {
       title: 'Einleitung',
       nav_title: 'Das Lager',
       paragraph_one:
-        '—HOLOCAT: „Junge, was für ein Drecksloch. Hier sollte es besser irgendwo ein paar E-Sardellen geben. Ich würde mich sogar mit etwas CyberKibble zufrieden geben.“',
+        '—HOLOKATZE: „Junge, was für ein Drecksloch. Hier sollte es besser irgendwo ein paar E-Sardellen geben. Ich würde mich sogar mit etwas CyberKibble zufrieden geben.“',
       paragraph_two:
         'Sie landen, halten sich fest und suchen nach einem Einstiegspunkt. Das zerbrochene Fenster sollte den Zweck erfüllen. Sie schlagen mit einem Ziegelstein die Überreste des Fensters heraus und springen hinein. Das Gebäude ist mit Tausenden staubiger, gut erhaltener Bitcoin-Miner gefüllt.',
       paragraph_three: {
-        a: '—HOLOCAT: „Das ist kein Lagerhaus, das ist ein Museum. Ich glaube, das sind alte Mining-Geräte der Familie Vanderpoole. In den frühen Tagen von Bitcoin nutzten die Miner Allzweckcomputer, um Bitcoin zu minen. Aber nach ein paar Jahren erkannten die Miner, dass sie Maschinen mit einem speziellen Chip, einem sogenannten anwendungsspezifischen integrierten Schaltkreis, verwenden konnten, oder',
+        a: '—HOLOKATZE: „Das ist kein Lagerhaus, das ist ein Museum. Ich glaube, das sind alte Mining-Geräte der Familie Vanderpoole. In den frühen Tagen von Bitcoin nutzten die Miner Allzweckcomputer, um Bitcoin zu minen. Aber nach ein paar Jahren erkannten die Miner, dass sie Maschinen mit einem speziellen Chip, einem sogenannten anwendungsspezifischen integrierten Schaltkreis, verwenden konnten, oder',
         b: 'kurz gesagt. Diese Chips machen nur eines: Bitcoin schürfen. Ihr enger Fokus erhöht ihre Effizienz und ermöglicht es den Minern, weniger Energie für das Schürfen aufzuwenden, was ihnen einen Vorteil verschafft. Können Sie glauben, dass die Leute irgendwann einmal mit ihren Laptops geschürft haben?"',
       },
       paragraph_four:
@@ -280,22 +280,22 @@ const translations = {
       paragraph_one:
         'In der Ecke blinkt ein dunkler, kaum funktionierender Computermonitor, an dem eine Notiz klebt. Auf der Notiz steht: „Mach sie an, Dummkopf.“',
       paragraph_two:
-        '—HOLOCAT: „Wie unhöflich. Wow, eine mechanische Tastatur. Ich habe von diesen Dingern gehört. Angeblich waren sie so laut, dass sie den Benutzern ihr Gehör kosteten, und wurden deshalb verboten.“',
+        '—HOLOKATZE: „Wie unhöflich. Wow, eine mechanische Tastatur. Ich habe von diesen Dingern gehört. Angeblich waren sie so laut, dass sie den Benutzern ihr Gehör kosteten, und wurden deshalb verboten.“',
       paragraph_three:
-        'Holocat springt auf die Tastatur, läuft darüber und zeigt Ihnen, welche Tasten Sie drücken müssen.',
+        'Holokatze springt auf die Tastatur, läuft darüber und zeigt Ihnen, welche Tasten Sie drücken müssen.',
     },
     hashing_one: {
       title: 'Nullen',
       nav_title: 'Der Computer erwacht zum Leben',
       paragraph_one:
-        'Entweder durch Zufall oder weil Holocat wirklich wusste, was sie tat, verwandelten sich die zufälligen Buchstaben und Zahlen, auf die sie trat, in ... noch mehr zufällige Buchstaben und Zahlen?',
+        'Entweder durch Zufall oder weil Holokatze wirklich wusste, was sie tat, verwandelten sich die zufälligen Buchstaben und Zahlen, auf die sie trat, in ... noch mehr zufällige Buchstaben und Zahlen?',
       list_one: '> QX23Y6VGECTUKSNIEUTUB[P[pihof',
       list_two:
         '> 1c31d1d9fb848a505fc0cdbea848ff1bdd46a9ed4d639d413d3a93035194eedf',
       paragraph_two:
         'Auf dem Monitor wird „FALSCHES HASH. VERSUCHEN SIE ES ERNEUT.“ angezeigt.',
       paragraph_three:
-        'Natürlich war das Kauderwelsch, das Holocat eingetippt hat, falsch. Sie ist nur eine freche holografische Katze!',
+        'Natürlich war das Kauderwelsch, das Holokatze eingetippt hat, falsch. Sie ist nur eine freche holografische Katze!',
       paragraph_four: 'Was passiert, wenn Sie etwas anderes eingeben?',
     },
     hashing_two: {
@@ -453,7 +453,7 @@ const translations = {
       heading: 'Gut gemacht!',
       paragraph_one:
         'Die Maschinen erwachen zum Leben. Alles scheint zu funktionieren. Auf dem alten Monitor erscheint eine Karte, die die Standorte anderer Lagerhäuser zeigt, die mit alten Bergbaugeräten der Familie Vanderpoole gefüllt sind, die weltweit online gegangen sind. Sieht so aus, als wären sie aktiviert worden, als Sie die Bergbau-Herausforderung abgeschlossen haben!',
-      paragraph_two: '—HOLOCAT: „Schau, da ist eine Nachricht.“',
+      paragraph_two: '—HOLOKATZE: „Schau, da ist eine Nachricht.“',
       paragraph_three:
         '„Gute Arbeit. Dies wird Bitcoin helfen, wieder alle zehn Minuten einen Block zu erreichen.“ – Satoshi Nakamoto',
       paragraph_four: 'Er schon wieder?',
@@ -510,10 +510,10 @@ const translations = {
   chapter_three: {
     title: 'Der 51%-Angriff',
     paragraph_one:
-      'Sie geben die Adresse eines Block-Explorers ein und sehen, dass die Blöcke wieder im Zehn-Minuten-Takt vorliegen. Irgendwie schläft Holocat trotz des Lärms aller ASICs.',
+      'Sie geben die Adresse eines Block-Explorers ein und sehen, dass die Blöcke wieder im Zehn-Minuten-Takt vorliegen. Irgendwie schläft Holokatze trotz des Lärms aller ASICs.',
     paragraph_two: 'Katzen. Was kann man tun?',
     paragraph_three:
-      'Allerdings stimmt etwas nicht. Die Blöcke sind leer und Transaktionen werden nicht verarbeitet. Haben Sie einen Fehler gemacht? Könnte das ein Zufall sein? Eine weitere Meldung erscheint auf dem Computerbildschirm und weckt Holocat.',
+      'Allerdings stimmt etwas nicht. Die Blöcke sind leer und Transaktionen werden nicht verarbeitet. Haben Sie einen Fehler gemacht? Könnte das ein Zufall sein? Eine weitere Meldung erscheint auf dem Computerbildschirm und weckt Holokatze.',
     paragraph_four: 'Das ist kein Zufall.',
     intro_one: {
       title: 'Einleitung',
@@ -523,7 +523,7 @@ const translations = {
       paragraph_two:
         'Der alte Computer stößt eine Staubwolke aus und produziert dann einen Datenhaufen, eine sogenannte „Tabelle“, die Kontaktinformationen einiger der größten Bitcoin-Miner sowie einen Patch für den Virus enthält. Je schneller Sie den Patch an andere Miner weitergeben können, desto schneller können diese die Kontrolle über ihre Maschinen zurückerlangen und sich Ihrem Kampf gegen BitRey anschließen.',
       paragraph_three:
-        '—HOLOCAT: „Wir haben noch mehr zu tun. Also, du hast noch mehr zu tun. Ich werde durch Wände rennen und Mäuse erschrecken.“',
+        '—HOLOKATZE: „Wir haben noch mehr zu tun. Also, du hast noch mehr zu tun. Ich werde durch Wände rennen und Mäuse erschrecken.“',
     },
     solo_one: {
       title: 'Sie gegen BitRey',
@@ -695,7 +695,7 @@ const translations = {
       title: 'Einleitung',
       nav_title: 'Sichern der Tasche',
       paragraph_one:
-        '—HOLOCAT: „Einer von uns sollte besser schlafen. Du musst anfangen, den Rest der Bergleute zu kontaktieren. Sie werden noch mehr wissen wollen als die ganze Welt.“',
+        '—HOLOKATZE: „Einer von uns sollte besser schlafen. Du musst anfangen, den Rest der Bergleute zu kontaktieren. Sie werden noch mehr wissen wollen als die ganze Welt.“',
       paragraph_two:
         'Während Sie sich an Ihrem ButtLift Hover Desk niederlassen, gehen Sie die Ereignisse des Tages noch einmal durch. Vanderpoole. BitRey. Die Enthüllung, dass die Bergleute nie einer Protestschließung zugestimmt haben. Könnte das alles wahr sein? War das alles inszeniert? Und wie lange sollen Sie sich noch um diese Katze kümmern? (In der Ferne miaut etwas.)',
       paragraph_three:
@@ -921,7 +921,7 @@ const translations = {
       nav_title: 'Eine Nachricht von Satoshi',
       paragraph_one:
         'Ihr TXM4H-A Hover-Bildschirm erwacht zum Leben. Sie haben eine neue Nachricht.',
-      paragraph_two: '—HOLOCAT: Vergiss nicht, mir auf die Nase zu hauen.',
+      paragraph_two: '—HOLOKATZE: Vergiss nicht, mir auf die Nase zu hauen.',
       paragraph_three: 'Du schnippst ihr auf die Nase',
       paragraph_four:
         '—SATOSHI NAKAMOTO: „Vanderpoole ist nicht der, für den er sich ausgibt. Sie können ihn entlarven. Fordern Sie ihn auf, den Besitz von Satoshis Bitcoin zu beweisen, indem er eine Nachricht mit den privaten Schlüsseln dieser Wallet signiert.“',
@@ -1155,7 +1155,7 @@ const translations = {
       nav_title: 'Den richtigen Schlüssel finden',
       heading: 'Wie hat Vanderpoole diese Signatur überhaupt erstellt?',
       paragraph_one:
-        'Holocat mischt sich ein und sagt, ein Überläufer von BitRey habe uns eine Liste mit öffentlichen Schlüsseln geschickt, die Vanderpoole häufig verwendet. Vielleicht habe er einen dieser Schlüssel zum Signieren der Nachricht verwendet.',
+        'Holokatze mischt sich ein und sagt, ein Überläufer von BitRey habe uns eine Liste mit öffentlichen Schlüsseln geschickt, die Vanderpoole häufig verwendet. Vielleicht habe er einen dieser Schlüssel zum Signieren der Nachricht verwendet.',
       paragraph_two:
         'Bitte geben Sie den Schlüssel ein, der den Überprüfungsprozess erfolgreich abschließt und es uns ermöglicht, den öffentlichen Schlüssel zu identifizieren, den Vanderpoole zum Signieren dieser Nachricht verwendet hat.',
       paragraph_three:
@@ -1271,7 +1271,7 @@ const translations = {
   chapter_six: {
     title: 'Der Schlüsselhalter',
     paragraph_one:
-      'Ahhh! Vanderpoole hat es auf Sie abgesehen, weil Sie seine betrügerischen Behauptungen aufgedeckt haben. Doch obwohl der Holocaust nun aus dem Sack ist, halten viele verängstigte Menschen weiterhin an dem Mythos fest, den Vanderpoole um sich selbst, seine Familie und ihre angebliche Abstammung geschaffen hat. Die Zeiten sind beängstigend und die Menschen brauchen einen Helden. Leider ist er für viele der Beste, den sie haben.',
+      'Ahhh! Vanderpoole hat es auf Sie abgesehen, weil Sie seine betrügerischen Behauptungen aufgedeckt haben. Doch obwohl der Holokatze nun aus dem Sack ist, halten viele verängstigte Menschen weiterhin an dem Mythos fest, den Vanderpoole um sich selbst, seine Familie und ihre angebliche Abstammung geschaffen hat. Die Zeiten sind beängstigend und die Menschen brauchen einen Helden. Leider ist er für viele der Beste, den sie haben.',
     intro_one: {
       title: 'Einleitung',
       nav_title: 'War das wirklich Satoshi',
@@ -1286,12 +1286,12 @@ const translations = {
       title: 'Einleitung',
       nav_title: 'Mika 3000 bezahlen',
       paragraph_one:
-        '—HOLOCAT: „Das ist kaum das Einzige, was dich in letzter Zeit dumm klingen lässt.“',
+        '—HOLOKATZE: „Das ist kaum das Einzige, was dich in letzter Zeit dumm klingen lässt.“',
       paragraph_two:
         '—SATOSHI NAKAMOTO: „Bitcoin hat sich vor vielen Jahren der Kontrolle seines Schöpfers entzogen. Es wäre egal, ob Vanderpoole oder ich Satoshi oder einer ihrer Nachkommen wären. Bitcoin wird von seiner Community definiert und kann nicht von einer einzelnen Person oder Entität – einschließlich Satoshi – vereinnahmt werden. Dies zu beweisen, ist der wahre Kampf. Ich hoffe, es macht Ihnen nichts aus, aber ich habe Ihren exzentrischen Freund, den freiberuflichen Reporter, gebeten, sich bei mir zu melden.“',
       paragraph_three: '—Er was?',
       paragraph_four: '—Ding.',
-      paragraph_five: '—HOLOCAT: Vergiss nicht, mich anzustupsen.',
+      paragraph_five: '—HOLOKATZE: Vergiss nicht, mich anzustupsen.',
       paragraph_six:
         '—MIKA 3000: „Du hast Mumm, aber Mumm allein reicht nicht. Was du entdeckt hast, ist nur der Anfang. Es steckt noch mehr hinter dieser Geschichte, aber wir müssen Vanderpooles Privatinsel besuchen, um sicher zu wissen, was „mehr“ bedeutet. Das wird viel kosten, also könnte ich deine Hilfe gebrauchen, um Geld von der Multisig-Wallet abzuheben, die du mir beim Einrichten geholfen hast. Du hast noch einen meiner Schlüssel, oder?“',
     },
@@ -2059,9 +2059,9 @@ const translations = {
       paragraph_one:
         'Sie fragen Ihre Landsleute, ob sie über Vanderpooles Armee von Sicherheitsdrohnen besorgt sind.',
       paragraph_two:
-        '—HOLOCAT: „Geben Sie mir 15 Minuten. Im Grunde sind sie Vögel und ich bin eine Katze. Sie haben keine Chance.“',
+        '—HOLOKATZE: „Geben Sie mir 15 Minuten. Im Grunde sind sie Vögel und ich bin eine Katze. Sie haben keine Chance.“',
       paragraph_three:
-        'Holocat fährt ihre Krallen aus und erledigt Vanderpooles Drohnenarmee Schlag für Schlag. Mika 3000 reicht Ihnen einen schwarzen Rollkragenpullover, Handschuhe und eine Nachtsichtbrille.',
+        'Holokatze fährt ihre Krallen aus und erledigt Vanderpooles Drohnenarmee Schlag für Schlag. Mika 3000 reicht Ihnen einen schwarzen Rollkragenpullover, Handschuhe und eine Nachtsichtbrille.',
       paragraph_four:
         '—MIKA 3000: „In einem Hawaiihemd kann man keine Spionage betreiben. Was hast du dir dabei gedacht? Das ist kein weiteres verlassenes Lagerhaus, das ist eine Festung. Hier, das hätte ich fast vergessen. Nimm diesen Enterhaken.“',
       paragraph_five:
@@ -2074,12 +2074,12 @@ const translations = {
       paragraph_two:
         'Der Virus ersetzt einen Teil des Codes, der von allen Minern verwendet wird, unabhängig davon, ob sie Teil eines Pools sind oder nicht. Es handelt sich dabei um die Blockaufbaulogik, den Algorithmus, der Transaktionen in einer Blockvorlage zusammenfügt. Die Vorlage wird weiterhin an legitimen Hashing-Code zum Nachweis der Arbeit weitergegeben. Auf der Suche nach einem gültigen Hash werden Vorlagen mit Abermillionen verschiedener Nonces kombiniert, aber bis einer gefunden wird, ist der Schaden – das Fehlen jeglicher Transaktionen in der Blockvorlage – bereits angerichtet.',
       paragraph_three:
-        '—HOLOCAT: „Was für ein Verlust. Seine Familie war einst großartig. Es ist so traurig, dass es mit den Vanderpooles so weit gekommen ist.“',
+        '—HOLOKATZE: „Was für ein Verlust. Seine Familie war einst großartig. Es ist so traurig, dass es mit den Vanderpooles so weit gekommen ist.“',
     },
     intro_three: {
       nav_title: 'Korrektur der Software',
       paragraph_one:
-        'Aber Sie können den beschädigten Mining-Code nicht einfach auf Vanderpooles Server belassen. Er wird weiterhin Miner infizieren. Sie müssen ihn reparieren! Während Sie den Code durchlesen, zeigt Ihnen Holocat eine Mempool-Anzeige, die sich mit unbestätigten Transaktionen füllt. Je schneller dieser Code repariert wird, desto besser.',
+        'Aber Sie können den beschädigten Mining-Code nicht einfach auf Vanderpooles Server belassen. Er wird weiterhin Miner infizieren. Sie müssen ihn reparieren! Während Sie den Code durchlesen, zeigt Ihnen Holokatze eine Mempool-Anzeige, die sich mit unbestätigten Transaktionen füllt. Je schneller dieser Code repariert wird, desto besser.',
     },
     mempool_transaction_one: {
       title: 'Bausteine',
@@ -2162,14 +2162,14 @@ const translations = {
   chapter_eight: {
     title: 'Einundzwanzig Millionen',
     paragraph_one:
-      'Dank Ihrer Recherchen wollen die Leute unbedingt etwas von Ihnen hören. Sie schnippst Holocat an die Nase und enthüllen eine Einladung von Deborah Chunk, die Sie einlädt, persönlich in den Büros von LARGE BIG NEWS Studios zu erscheinen. Die Story muss an die Öffentlichkeit gelangen, also steigen Sie erneut in Ihren Budgetcopter.',
+      'Dank Ihrer Recherchen wollen die Leute unbedingt etwas von Ihnen hören. Sie schnippst Holokatze an die Nase und enthüllen eine Einladung von Deborah Chunk, die Sie einlädt, persönlich in den Büros von LARGE BIG NEWS Studios zu erscheinen. Die Story muss an die Öffentlichkeit gelangen, also steigen Sie erneut in Ihren Budgetcopter.',
     intro_one: {
       title: 'Einleitung',
       nav_title: 'Vanderpooles Täuschung',
       paragraph_one:
         '—DEBORAH CHUNK: „Diese Dokumente enthüllen die angeblichen Lügen von Thomas Vanderpoole auf eine Weise, die sicherlich historisch, ja sogar skandalös ist. Das Erste, was die Leute wissen wollen, ist, ob Sie allein gehandelt haben. Das Zweite ist, woher Sie Ihre Informationen haben.“',
       paragraph_two:
-        'Sie erzählen ihr von Holocat und nur von Holocat. Sie sagen, die Informationen seien direkt an Sie und Mika 3000 von jemandem übermittelt worden, der behauptet, Satoshi Nakamoto zu sein, und von dem Sie vermuten, dass es sich in Wirklichkeit um ein Hackerkollektiv handelt. Dieser letzte Punkt veranlasst Thomas Vanderpoole, direkt in der Show anzurufen.',
+        'Sie erzählen ihr von Holokatze und nur von Holokatze. Sie sagen, die Informationen seien direkt an Sie und Mika 3000 von jemandem übermittelt worden, der behauptet, Satoshi Nakamoto zu sein, und von dem Sie vermuten, dass es sich in Wirklichkeit um ein Hackerkollektiv handelt. Dieser letzte Punkt veranlasst Thomas Vanderpoole, direkt in der Show anzurufen.',
     },
     intro_two: {
       title: 'Einleitung',
@@ -2183,7 +2183,7 @@ const translations = {
       intro: 'Einleitung',
       nav_title: 'Vorwürfe gegen Vanderpoole',
       paragraph_one:
-        '—DEBORAH CHUNK: „Mr. Vanderpoole, wenn ich darf. Die Leute sind verwirrt und unsicher, ob die Bitcoin-Versorgung manipuliert wurde. Können Sie beweisen, dass Sie an der angeblichen Manipulation nicht beteiligt waren? Mysteriöser Hacker und sein Holocat, können Sie beweisen, dass Vanderpoole dieses Verbrechen gegen Bitcoin versucht hat?“',
+        '—DEBORAH CHUNK: „Mr. Vanderpoole, wenn ich darf. Die Leute sind verwirrt und unsicher, ob die Bitcoin-Versorgung manipuliert wurde. Können Sie beweisen, dass Sie an der angeblichen Manipulation nicht beteiligt waren? Mysteriöser Hacker und sein Holokatze, können Sie beweisen, dass Vanderpoole dieses Verbrechen gegen Bitcoin versucht hat?“',
     },
     building_blocks_one: {
       title: 'Bausteine',
@@ -2292,7 +2292,7 @@ const translations = {
       nav_title: 'Show Time!',
       heading_one: 'Show Time!',
       paragraph_one:
-        'Die Kameras laufen, zwei Milliarden Menschen weltweit verfolgen den Livestream. Nur noch wenige Minuten bis zur nächsten Werbepause. Deborah Chunk schwitzt. Irgendwie schwitzt auch Holocat. Irgendwo am anderen Ende der Leitung muss auch Vanderpoole schwitzen. Das ist Ihr Moment.',
+        'Die Kameras laufen, zwei Milliarden Menschen weltweit verfolgen den Livestream. Nur noch wenige Minuten bis zur nächsten Werbepause. Deborah Chunk schwitzt. Irgendwie schwitzt auch Holokatze. Irgendwo am anderen Ende der Leitung muss auch Vanderpoole schwitzen. Das ist Ihr Moment.',
       paragraph_two:
         'Suchen Sie, beginnend mit dem gültigen Block direkt vor dem, den Sie auf Höhe 6929851 gefunden haben, die längste Kette gültiger Blöcke, die Sie finden können. Speichern Sie die Kette als Array von Block-Hashes. Pflegen Sie, wenn Sie schon dabei sind, auch ein Array aller ungültigen Blöcke, die Sie finden, nur um der Welt zu zeigen, wie sehr Vanderpoole versucht hat, Bitcoin zu knacken. Die Reihenfolge dieser ungültigen Block-Hashes ist egal, aber Ihre gültige Kette MUSS mit dem Hash von Block 6929850 beginnen, gefolgt von einem Block-Hash auf jeder Höhe bis hinauf zur Kettenspitze.',
       paragraph_three:
@@ -2525,7 +2525,7 @@ const translations = {
       paragraph_one:
         'Richtlinien für mehrere Signaturen stellen eine Liste öffentlicher Schlüssel und eine Anzahl von Signaturen bereit, die für eine gültige Ausgabe erforderlich sind. Sie können als „m-von-n“ beschrieben werden, was bedeutet, dass „m Signaturen aus dieser Liste von n öffentlichen Schlüsseln erforderlich sind“. Die öffentlichen Schlüssel und die m- und n-Werte sind normalerweise im Sperrskript enthalten und der Ausgeber muss nur die richtige Anzahl von Signaturen bereitstellen.',
       paragraph_two:
-        'Holocat erscheint mit einer aufgezeichneten Nachricht von Satoshi Nakamoto!',
+        'Holokatze erscheint mit einer aufgezeichneten Nachricht von Satoshi Nakamoto!',
       paragraph_three:
         'Hallo. Ich habe versehentlich einen Fehler geschrieben, als ich <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_CHECKMULTISIG</span> implementiert habe. Es entfernt ein zusätzliches Element vom Stapel, das überhaupt nicht verwendet wird. Also, äh, ups. Entschuldigung. Dieser Code ist konsenskritisch, daher wird jede <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_CHECKMULTISIG</span>-Operation in der Vergangenheit, Gegenwart und Zukunft von Bitcoin gezwungen sein, ein „Dummy“-Element einzuschließen. Vergessen Sie es nicht, sonst können Sie Ihre Multisig-Münzen nicht ausgeben!',
     },
@@ -2957,12 +2957,12 @@ const translations = {
         '—LASZLO: „Warte. Wenn du diese Transaktion nicht unterschreibst, habe ich nichts. Du könntest mit diesem Bier verschwinden und ich könnte nichts in der Kette bestätigen. Vielleicht solltest du es zuerst unterschreiben und es mir dann schicken, damit wir beide eine Kopie haben?“',
     },
     making_a_payment_four: {
-      title: 'Holocats Warnung vor Vertrauenslosigkeit',
-      nav_title: 'Holocats Warnung vor Vertrauenslosigkeit',
+      title: 'Holokatze Warnung vor Vertrauenslosigkeit',
+      nav_title: 'Holokatze Warnung vor Vertrauenslosigkeit',
       paragraph_one:
-        'In diesem Moment materialisiert Holocat auf dem Tisch, stellt sich mit ausgestreckten Vorderpfoten auf die Hinterbeine und miaut.',
+        'In diesem Moment materialisiert Holokatze auf dem Tisch, stellt sich mit ausgestreckten Vorderpfoten auf die Hinterbeine und miaut.',
       paragraph_two:
-        '—HOLOCAT: „Moment mal, du kannst Laszlo deine Unterschrift für diese Transaktion nicht geben! Wenn du das nächste Mal eine Zahlung tätigst, gibst du ihm den Widerrufsschlüssel revocation_you_2. Dann hat er alles, was er braucht, um alle 100.000 Satoshis zu stehlen!“',
+        '—HOLOKATZE: „Moment mal, du kannst Laszlo deine Unterschrift für diese Transaktion nicht geben! Wenn du das nächste Mal eine Zahlung tätigst, gibst du ihm den Widerrufsschlüssel revocation_you_2. Dann hat er alles, was er braucht, um alle 100.000 Satoshis zu stehlen!“',
       paragraph_three:
         'Jetzt wird es etwas komplizierter. Laszlo braucht etwas, bevor er Ihnen ein Bier geben kann und sicher sein kann, dass er dafür bezahlt wird. Aber er kann Ihre Transaktion nicht haben, weil er dann auf Ihr gesamtes Geld zugreifen würde! Laszlo ist ein toller Typ und seine Bar ist eine der besten der Stadt, aber es wäre trotzdem schön, wenn wir ihm nicht vertrauen müssten.',
     },
@@ -3064,7 +3064,7 @@ const translations = {
       title: 'Andere',
       nav_title: 'Auf dem Weg nach Hause',
       paragraph_one:
-        'Nach einem langen und seltsamen Tag bezahlen Sie Ihre Getränke und machen sich auf den Heimweg. Doch als Sie die Tür zu Ihrem 3D-gedruckten Bungalow öffnen, stellen Sie fest: oh Mist! Schon wieder Vanderpoole! Passiert das wirklich oder haben Sie eine Mempool-Margarita zu viel getrunken? Obwohl ihn von allen Seiten eine kleine Gruppe von Holocats flankiert, ist er nicht auf Streit aus.',
+        'Nach einem langen und seltsamen Tag bezahlen Sie Ihre Getränke und machen sich auf den Heimweg. Doch als Sie die Tür zu Ihrem 3D-gedruckten Bungalow öffnen, stellen Sie fest: oh Mist! Schon wieder Vanderpoole! Passiert das wirklich oder haben Sie eine Mempool-Margarita zu viel getrunken? Obwohl ihn von allen Seiten eine kleine Gruppe von Holokatze flankiert, ist er nicht auf Streit aus.',
       paragraph_two:
         '—VANDERPOOLE: „Wir kennen uns nicht wirklich, obwohl, wie mein Großvater immer sagte, die Schicksale von Fremden oft miteinander verflochten sind. Du musst mir zuhören. Bei all dem Satoshi Nakamoto-Zeug habe ich versucht, das Geschäft meiner Familie zu retten. Du kannst dir nicht vorstellen, wie viel uns das Mining bedeutet hat. Ich schätze, ich war nicht bereit für Veränderungen und wollte, dass alles mehr oder weniger so bleibt, wie es ist.“',
     },
@@ -3084,7 +3084,7 @@ const translations = {
       paragraph_one:
         'Vanderpoole nimmt deine Holokatze in die Hand und sie beginnt zu schnurren. Menschen sind kompliziert und niemand weiß das besser als Katzen, ob Holo oder nicht.',
       paragraph_two:
-        '—HOLOCAT: „Sie sind kein Bösewicht, Mr. Vanderpoole. Aber vielleicht, nur vielleicht, haben Sie sich zu viele Gedanken darüber gemacht.“',
+        '—HOLOKATZE: „Sie sind kein Bösewicht, Mr. Vanderpoole. Aber vielleicht, nur vielleicht, haben Sie sich zu viele Gedanken darüber gemacht.“',
       paragraph_three: '—VANDERPOOLE: Das ist die Wahrheit.',
     },
     outro_five: {
@@ -3240,7 +3240,7 @@ const translations = {
   error: {
     first: 'Irgendwas stimmt nicht!',
     second:
-      'Holocat hat vielleicht wieder an einigen Kabeln gekaut. Böse Katze!',
+      'Holokatze hat vielleicht wieder an einigen Kabeln gekaut. Böse Katze!',
     reload: 'Wiederholen',
   },
   help_page: {

--- a/i18n/locales/de.ts
+++ b/i18n/locales/de.ts
@@ -1,1265 +1,3266 @@
 const translations = {
   shared: {
-    next: 'Weiter',
+    next: 'Weitermachen',
     start: 'Start',
-    copy: 'Kopieren',
+    copy: 'Kopie',
     info: 'Info',
     copy_acknowledged: 'Kopiert!',
-    about: 'Info',
+    about: 'Über',
     chapter: 'Kapitel',
     chapters: 'Kapitel',
     challenge: 'Herausforderung',
     challenges: 'Herausforderungen',
-    coming_soon: 'Bald verfügbar',
-    start_chapter: 'Beginne Kapitel',
+    coming_soon: 'Demnächst verfügbar',
+    start_chapter: 'Kapitel beginnen',
     back: 'Zurück',
+    end: 'Ende',
+    close: 'Schließen',
     poweroff: 'Zurück zur Kapitelauswahl',
-    loading: 'Lädt',
+    loading: 'Laden',
+    bitcoin_dev_project: 'Bitcoin Dev Project',
   },
-  status_bar: {
-    begin_message: 'Beende die Challange, um fortzufahren...',
-    error_message: 'Hm... das stimmt noch nicht so ganz...',
-    in_progress_message: 'Sieht ganz gut aus soweit...',
-    success_message: 'Sehr gut gemacht!',
-    next: 'Weiter',
-  },
-  ///ABOUT PAGE
   about: {
-    title: 'Über das Projekt',
-    mobile_title: 'Um was es geht',
+    title: 'Über Saving Satoshi',
+    mobile_title: 'Worum es geht',
     subtitle:
-      'Wir schreiben das Jahr 2139. Der letzte Bitcoin wird erst in zwei Wochen geschürft werden. Seit Monaten tickt auf dem Satoshi-Platz eine eigens hierführ eingerichtet Uhr herunter.',
+      'Wir schreiben das Jahr 2139. In zwei Wochen wird der letzte Bitcoin geschürft. Seit Monaten tickt auf dem Satoshi Square eine Uhr herunter.',
     intro:
-      'Die Welt wartet gespannt auf den letzen Block. Dann, plötzlich, kommt das Netzwerk zum Stillstand.<br><br>Du erhälst eine Holokatze von jemandem, der sich Satoshi Nakamoto nennt. (Sie ist wie jedes andere E-Hologram, jedoch in der Form einer Katze). Du öffnest die Nachricht der Holokatze, indem du auf ihre Nase drückst, um zu hören, was sie zu sagen hat.',
-
+      'Die Welt wartet auf den letzten Block. Dann kommt das Netzwerk plötzlich zum Stillstand.<br><br>Sie erhalten ein Holocat von jemandem mit dem Namen Satoshi Nakamoto. (Es ist wie jedes andere E-Hologramm, aber dieses hat die Form einer Katze). Sie öffnen das Holocat, indem Sie neugierig auf seine Nase klopfen, um zu hören, was es zu sagen hat ...',
     project: {
       title: 'Mit Spaß gebaut',
       paragraph_one:
-        'Saving Satoshi ist eine unbeschwerte erste Anlaufstelle für Programmierer, die neugierig auf die Bitcoin-Entwicklung sind. Saving Satoshi bietet eine Mischung aus technischen Text- und Code-basierten Herausforderungen, die aber für jeden mit grundlegenden Programmierkenntnissen machbar sein sollten. Das Projekt ist frei und quelloffen (FOSS) und alle Grafiken wurde mit Text-zu-Bild-Tools wie Midjourney erstellt.',
+        'Saving Satoshi ist eine unterhaltsame erste Anlaufstelle für Programmierer, die sich für die Entwicklung von Bitcoins interessieren. Saving Satoshi bietet eine Mischung aus technischen Text- und Code-basierten Herausforderungen, die jedoch für jeden mit grundlegenden Programmierkenntnissen machbar sein sollten. Das Projekt ist kostenlos und Open Source (FOSS) und die gesamte Grafik wurde mit Text-zu-Bild-Tools wie Midjourney erstellt.',
       paragraph_two:
-        'Dieses Projekt befindet sich in ständiger Entwicklung und verfolgt einen iterativen Ansatz, um Feddback zu berücksichtigen, wenn wir neue Kapitel veröffentlichen. Derzeit sind zehn Kapitel geplant. Es können jedoch noch weitere hinzugefügt werden, wenn das Projekt weiter wächst.',
+        'Dieses Projekt wird kontinuierlich weiterentwickelt und verfolgt einen iterativen Ansatz, um Feedback zu berücksichtigen, wenn wir neue Kapitel veröffentlichen. Derzeit sind zehn Kapitel geplant. Es können jedoch weitere hinzugefügt werden, wenn das Projekt weiter wächst.',
     },
-
     contributing: {
-      title: 'Wie kann man mitmachen',
+      title: 'So können Sie beitragen',
       paragraph_one:
-        'Wir sind ein Open-Source-Projekt - Dir stehen alle Türen offen mitzugestalten.',
-
+        'Da es sich bei uns um ein Open-Source-Projekt handelt, stehen Ihnen alle Türen zur Mitgestaltung offen.',
       feedback: {
-        title: 'Feedback',
+        title: 'Rückmeldung',
         paragraph_one:
-          'Eine gute Möglichkeit, einen Beitrag zu leisten, besteht darin, Kapitel 1 durchzuarbeiten und uns Feedback zu Deiner Erfahrung zu geben. Diese kannst Du <a href="https://docs.google.com/forms/d/e/1FAIpQLSf1xpNqUYJyvYL5IZDnxy78273pkqzfYW2Hf91H4Do4KHgy9g/viewform" target="_blank" rel="noreferrer">hier</a> teilen.',
+          'Eine gute Möglichkeit, einen Beitrag zu leisten, besteht darin, Kapitel 1 durchzugehen und uns Feedback zu Ihren allgemeinen Erfahrungen bei der Verwendung von <a href="https://docs.google.com/forms/d/e/1FAIpQLSf1xpNqUYJyvYL5IZDnxy78273pkqzfYW2Hf91H4Do4KHgy9g/viewform" target="_blank" rel="noreferrer">diesem Formular</a> zu geben.',
       },
-
       contribute: {
-        title: 'Mitmachen',
+        title: 'Beitragen',
         paragraph_one:
-          'Alle Vorschläge sind willkommen, einschließlich inhaltlicher Änderungen, oder Änderungen an der Spielmechaniken - wirklich alles. Wir suchen ebenfalls nach Hilfe um Code-Verschläge zu begutachten oder <a href="https://leaf-singer-0fc.notion.site/How-to-QA-5177e63f65a4406da01bc57d886b5ac2" target="_blank" rel="noreferrer">Fragen zu Code-Änderungen zu beantworten </a>. Für Code-Verbesserungen kannst Du direkt ein "Issue" eröffnen oder einen "Pull-Request" auf GitHub einreichen.',
+          'Alle Vorschläge sind willkommen, einschließlich Inhaltsänderungen, Spielmechaniken – wirklich alles. Wir sind auch immer auf der Suche nach Hilfe beim Überprüfen und <a href="https://leaf-singer-0fc.notion.site/How-to-QA-5177e63f65a4406da01bc57d886b5ac2" target="_blank" rel="noreferrer">QA-Durchführen von Codeänderungen</a>. Für Codeverbesserungen können Sie direkt ein Problem melden oder eine Pull-Anfrage auf GitHub senden.',
         paragraph_two:
-          'Wenn du dich an der Gestaltung, der Geschichte oder etwas anderem beteiligen möchtest, mach mit im Kanal #saving-satoshi in unserem <a href="https://discord.gg/DC8Dys4G3h" target="_blank" rel="noreferrer">Bitcoin Design Discord Kanal</a>. Teile uns mit, wie Du einen Beitrag leisten möchtest, und wir helfen Dir, die richtige Richtung einzuschlagen.',
+          'Wenn Sie sich an Design, Story oder etwas anderem beteiligen möchten, besuchen Sie uns im Kanal #saving-satoshi im <a href="https://discord.gg/DC8Dys4G3h" target="_blank" rel="noreferrer">Bitcoin Design Discord</a>. Erwähnen Sie, wie Sie beitragen möchten, und wir helfen Ihnen, in die richtige Richtung zu gehen.',
       },
     },
-
     contributors: {
-      title: 'Viel Spaß!',
-      contributions_by: 'Mitarbeit von',
+      title: 'Genießen!',
+      contributions_by: 'Beiträge von',
       many_more:
-        'und <a href="https://github.com/saving-satoshi/saving-satoshi/graphs/contributors" target="_blank" rel="noreferrer">vielen mehr</a>.',
+        'und <a href="https://github.com/saving-satoshi/saving-satoshi/graphs/contributors" target="_blank" rel="noreferrer">viele mehr</a>.',
     },
-
-    satoshi_needs_you: 'Jetzt sei schnell, Satoshi braucht dich.',
+    satoshi_needs_you: 'Jetzt beeil dich, Satoshi braucht dich.',
     privacy: {
-      title: 'Unser Engagement für Deinen Datenschutz',
+      title: 'Unsere Verpflichtung zum Datenschutz',
       paragraph_one:
-        'Bei Saving Satoshi sind wir sehr darauf bedacht, die Privatsphäre und Sicherheit unserer Nutzer zu gewährleisten. Wir glauben an Transparenz und möchten, dass Du verstehst, wie und warum wir die App-Nutzung verfolgen. Um dies zu erreichen, nutzen wir ein vielseitiges Werkzeug namens <Link href="https://umami.is/" className="underline" target="_blank">Umami</Link>.',
+        'Bei Saving Satoshi legen wir großen Wert darauf, die Privatsphäre und Sicherheit unserer Benutzer zu gewährleisten. Wir glauben an Transparenz und möchten, dass Sie verstehen, wie und warum wir die App-Nutzung verfolgen. Um dies zu erreichen, verwenden wir ein leistungsstarkes Tool namens <Link href="https://umami.is/" className="underline" target="_blank">Umami</Link>.',
       sub_heading_one: 'Was ist Umami?',
       paragraph_two:
-        'Umami ist eine quelloffene (open-source) Analyseplattform, die uns hilft, wichtige Erkenntnisse darüber zu gewinnen, wie Du unsere App nutzt. So können wir datengestützte Entscheidungen treffen und unser Produkt kontinuierlich verbessern, um Deine Bedürfnisse besser zu erfüllen.  Du kannst dir die Umami-Statistiken zu Besuchen auf savingsatoshi.com <Link className="underline" href="https://visits.bitcoindevs.xyz/share/zFmD5WIus09mDxEf/Saving%20Satoshi" target="_blank">hier</Link> anschauen.',
-      sub_heading_two: 'Welche Daten sammeln wir?',
+        'Umami ist eine Open-Source-Analyseplattform, die uns hilft, wichtige Erkenntnisse darüber zu gewinnen, wie Sie unsere App nutzen. Sie ermöglicht es uns, datenbasierte Entscheidungen zu treffen und unser Produkt kontinuierlich zu verbessern, um Ihren Anforderungen besser gerecht zu werden. Sie können das Umami-Dashboard <Link className="underline" href="https://visits.bitcoindevs.xyz/share/zFmD5WIus09mDxEf/Saving%20Satoshi" target="_blank">hier</Link> anzeigen.',
+      sub_heading_two: 'Welche Daten erheben wir?',
       paragraph_three:
-        'Keine Sorge, wir sammeln nur nicht-persönliche Daten und annonymisieren diese. Zum Beispiel:',
-      list_item_one_title: 'Produktverbesserungen:',
+        'Seien Sie versichert, wir sammeln nur nicht-personenbezogene und anonymisierte Daten, wie zum Beispiel:',
+      list_item_one_title: 'Produktverbesserung:',
       list_item_one_text:
-        'Wir verwenden die Daten, um Bereiche zu identifizieren, in denen unsere App verbessert werden kann. Indem wir verstehen, wie Du unsere App nutzt, können wir sie effizienter, benutzerfreundlicher und sicherer machen.',
+        'Wir verwenden die Daten, um Bereiche zu identifizieren, in denen unsere App verbessert werden kann. Indem wir verstehen, wie Sie unsere App verwenden, können wir sie effizienter, benutzerfreundlicher und sicherer machen.',
       list_item_two_title: 'Kompatibilität:',
       list_item_two_text:
-        'Die von Dir verwendeten Geräte und Plattformen zu kennen, erlaubt es uns, unsere App für verschiedene Konfigurationen zu optimieren und sicherzustellen, dass sie naht- und reibungslos für Dich funktioniert.',
-      sub_heading_three: 'Deine Privatsphäre ist uns wichtig',
+        'Wenn wir wissen, welche Geräte und Plattformen Sie verwenden, können wir unsere App für verschiedene Konfigurationen optimieren und so sicherstellen, dass sie reibungslos bei Ihnen funktioniert.',
+      sub_heading_three: 'Ihre Privatsphäre ist wichtig',
       paragraph_four:
-        'Wir möchten betonen, dass Deine Privatsphäre für uns von größter Bedeutung ist. Wir sammeln keine persönlich identifizierbaren Informationen, und die Daten, die wir sammeln, werden ausschließlich zur Verbesserung unserer App verwendet. Deine Daten werden niemals an Dritte weitergegeben oder verkauft.',
+        'Wir möchten betonen, dass Ihre Privatsphäre für uns von größter Bedeutung ist. Wir sammeln keine personenbezogenen Daten und die von uns gesammelten Daten werden ausschließlich zum Zweck der Verbesserung unserer App verwendet. Ihre Daten werden niemals an Dritte weitergegeben oder verkauft.',
       paragraph_five:
-        'Wenn Du Bedenken oder Fragen zu unseren Datenerfassungspraktiken oder Datenschutzrichtlinien hast, zögere bitte nicht, uns zu kontaktieren. Wir sind bestrebt, Dir eine transparente und sichere Erfahrung bei der Nutzung unserer App zu bieten.',
+        'Wenn Sie Bedenken oder Fragen zu unseren Datenerfassungspraktiken oder Datenschutzrichtlinien haben, zögern Sie bitte nicht, uns zu kontaktieren. Wir sind bestrebt, Ihnen bei der Nutzung unserer App ein transparentes und sicheres Erlebnis zu bieten.',
     },
   },
-
-  ///CHAPTERS TITLE PAGE
   chapter_one: {
-    title: 'Ein Geheimnis bei Tageslicht',
+    title: 'Geheimnisse auf der ganzen Welt',
     paragraph_one:
-      'Wir schreiben das Jahr 2139. Der letzte Bitcoin wird in zwei Wochen geschürft werden. Seit Monaten tickt die Uhr auf dem Satoshi-Platz herunter. Die Welt wartet auf den letzten Block. Dann, ganz plötzlich, kommt das Netzwerk zum Stillstand.',
-
-    ///CHAPTER 1
+      'Wir schreiben das Jahr 2139. In zwei Wochen wird der letzte Bitcoin geschürft. Monatelang hat die Uhr im Satoshi Square heruntergezählt. Bis zu diesem Zeitpunkt hatte jeder Block eine Art Bitcoin-Belohnung, eine Subvention. Nur so können neue Bitcoins entstehen, aber bald wird sich das ändern. Nach über einhundert Jahren geht der Ausgabeplan für Bitcoin zu Ende. Die Welt wartet darauf, dass der letzte Block mit einer Subvention geschürft wird. Es ist ein historisches Ereignis. Das Ende einer Ära.',
+    paragraph_two: 'Plötzlich kommt das Netzwerk zum Stillstand.',
     intro_one: {
-      title: 'Genesis',
-      paragraph_one: `Momente später, Dein Hover Desk aktiviert sich.`,
-      paragraph_two: `—Deborah Chunk: “Thomas Vanderpoole. Als Geschäftsführer von BitRey betreiben Sie einen der größten Bitcoin-Mining-Pools der Welt. Sie stellen auch Bitcoin-Mining-Maschinen her. Was geschieht hier? Stirbt Bitcoin?”`,
-      paragraph_three: `—Vanderpoole: “Ja, das mache ich, Deborah. Wie mein Vater und sein Vater vor ihm. Die Vanderpools schürfen seit Block #21000. Deshalb kann ich Dir mit Sicherheit sagen, dass die Miner auf der ganzen Welt diese Netzwerk-Verzögerungen verursachen, indem sie ihre Maschinen abschalten. Dies ist ein Protest. Niemand will, dass Bitcoin bei 21 Millionen nicht mehr als Block-Belohnung ausgegeben wird. Wir können nicht allein von den Transaktionsgebühren leben.”`,
-      start: 'Weiter',
+      title: 'Einleitung',
+      nav_title: 'Protest der Bergarbeiter',
+      paragraph_one: 'Augenblicke später wird Ihr Hover-Bildschirm aktiviert.',
+      paragraph_two:
+        '—Deborah Chunk: „Thomas Vanderpoole. Als gut gekleideter CEO von BitRey betreiben Sie den mit Abstand größten Bitcoin-Mining-Pool der Welt. Sie stellen auch Bitcoin-Mining-Maschinen her. Was ist los? Stirbt Bitcoin?“',
+      paragraph_three:
+        '—Vanderpoole: „Lassen Sie uns von vorne beginnen. Ja, das bin ich, Deborah, und ja, das tue ich. Die Vanderpooles – mein gut gekleideter Papa und sein gut gekleideter Papa vor ihm – schürfen seit Block 21.000. Deshalb kann ich mit Sicherheit sagen, dass Miner auf der ganzen Welt diese Verzögerungen verursachen, indem sie ihre Maschinen abschalten. Dies ist ein Protest. Niemand möchte, dass die Ausgabe von Bitcoins bei 21 Millionen eingestellt wird. Miner können nicht allein von Gebühren überleben.“',
+      start: 'Weitermachen',
     },
-
     intro_two: {
       title: 'Genesis',
+      nav_title: 'Satoshis Holocaust',
       paragraph_one:
-        'Du erhälst eine Holokatze von jemandem, der sich Satoshi Nakamoto nennt (sie ist wie jedes andere E-Hologram, jedoch in der Form einer Katze). Du öffnest die Nachricht der Holokatze, indem du auf ihre Nase drückst.',
+        'Auf Ihrer Everything Watch erhalten Sie einen Holocat der Marke WhiskerWare von jemandem mit dem Namen Satoshi Nakamoto. (Er ist wie jedes andere E-Hologramm, aber dieses hat die Form einer Katze.) Sie öffnen den Holocat, indem Sie auf seine Nase stupsen.',
       paragraph_two:
-        '—“Bitcoin ist nicht am sterben, aber er benötigt Deine Hilfe. Vergiss die Katze nicht.” – Satoshi Nakamoto',
+        '— „Bitcoin stirbt nicht, aber es braucht Ihre Hilfe. Vergessen Sie die Katze nicht.“ – Satoshi Nakamoto',
       paragraph_three:
-        '—Satoshi? Der Satoshi? Nein, das kann nicht sein. Er wird seit über einem Jahrhundert für tot gehalten. Oder? Oder!?',
-      paragraph_four: 'Wird er etwa nicht?',
+        '—Satoshi? Die Satoshi? Aus dem Whitepaper? Nein, das kann nicht sein. Sie gelten seit über einem Jahrhundert als tot.',
+      paragraph_four: 'Haben sie nicht?',
       paragraph_five:
-        'Holokatze: “Du gehst besser an die Arbeit. Ich kann Dir helfen, aber Du musst jetzt anfangen meow.”',
+        'Holocat: „Mach dich lieber an die Arbeit. Ich kann helfen, aber du musst anfangen zu miauen.“',
     },
-
     genesis_one: {
       title: 'Genesis',
-      heading: 'Deine erste Herausforderung',
+      nav_title: 'Das Geheimnis der Genesis',
+      heading: 'Ihre erste Herausforderung',
       paragraph_one:
-        'Bitcoin ist zensurresistentes Geld. Jeder kann Geld verschicken, indem er eine Transaktion an das Netzwerk sendet. Nach der Übermittlung werden die Transaktionen von den Minern zu Blöcken zusammengefügt. Die Miner konkurrieren mit anderen Minern um das Privileg, an der Blockchain zu arbeiten. Dadurch bleibt Bitcoin dezentral.',
+        'Bitcoin ist zensurresistentes Geld. Jeder kann Geld senden, indem er eine Transaktion an das Netzwerk sendet. Nach der Übertragung werden die Transaktionen von Minern in Blöcke verpackt. Miner konkurrieren mit anderen Minern um das Privileg, auf der Kette aufzubauen. Dies ist es, was Bitcoin dezentralisiert hält.',
       paragraph_two:
-        'Satoshi Nakamoto, der pseudonyme Erfinder von Bitcoin, hat auch den ersten Bitcoin-Block geschürft. Er hinterließ der Welt eine geheime Nachricht in der allerersten Bitcoin-Transaktion, die jemals durchgeführt wurde. Deine erste Aufgabe ist es, sie zu finden und zu entschlüsseln.',
+        'Satoshi Nakamoto, der pseudonyme Erfinder von Bitcoin, hat auch den ersten Bitcoin-Block geschürft. Er hinterließ der Welt eine geheime Nachricht in der allerersten Bitcoin-Transaktion, die jemals durchgeführt wurde. Ihre erste Herausforderung besteht darin, diese zu finden und zu entschlüsseln.',
     },
-
     genesis_two: {
       title: 'Genesis',
-      heading: 'Finde die geheime Nachricht',
+      nav_title: 'Suche nach der Nachricht',
+      heading: 'Finde die versteckte Nachricht',
       paragraph_one:
-        'Lass uns den allerersten Block in der Bitcoin-Blockchain finden. Klick auf den unten stehenden Button, um einen <Tooltip id="genesis_two_paragraph_one" content="chapter_one.genesis_two.tooltip_block_explorer" theme="bg-[#30435b]">Blockexplorer</Tooltip> genau an Block 0 zu öffnen - dem sogenannte Genesisblock.',
+        'Suchen wir den allerersten Block in der Bitcoin-Blockchain. Klicken Sie auf die Schaltfläche unten, um einen <Tooltip id="genesis_two_paragraph_one" content="chapter_one.genesis_two.tooltip_block_explorer" theme="bg-[#30435b]">Block-Explorer</Tooltip> genau bei Block 0 zu öffnen, der als Genesis-Block bezeichnet wird.',
       paragraph_two:
-        'Scrolle nach unten und erweitere die Details zu der einen Transaktion, die in diesem Block gespeichert ist. Suche die Eingabe mit dem Namen "Coinbase". Jetzt schau nach der Bezeichnung “SCRIPTSIG (<Tooltip id="genesis_two_paragraph_two" content="chapter_one.genesis_two.tooltip_hex" theme="bg-[#30435b]">HEX</Tooltip>)”. Die Zeichenketten daneben ist eine verschlüsselte Nachricht.',
+        'Scrollen Sie nach unten und erweitern Sie die Details der einen Transaktion, die in diesem Block gespeichert ist. Suchen Sie nach der Eingabe „Coinbase“. Suchen Sie nun nach der Bezeichnung „SCRIPTSIG (<Tooltip id="genesis_two_paragraph_two" content="chapter_one.genesis_two.tooltip_hex" theme="bg-[#30435b]">HEX</Tooltip>)“. Der Wert daneben ist eine verschlüsselte Nachricht.',
       paragraph_three:
-        'Kopiere die Zeichenkette und füge sie in das untere Feld ein.',
+        'Kopieren Sie diesen Wert und fügen Sie ihn in den Codeblock ein.',
       tooltip_block_explorer:
-        'Ein <a  href="https://bitcoinops.org/en/topics/block-explorers/" target="_blank" rel="noreferrer">Blockexplorer</a> ist ein nützliches Werkzeug um schnell Informationen über Bitcoin-Transaktionen nachzuschlagen.',
+        'Ein <a  href="https://bitcoinops.org/en/topics/block-explorers/" target="_blank" rel="noreferrer">Block-Explorer</a> ist ein nützliches Tool, um schnell Informationen zu Bitcoin-Transaktionen nachzuschlagen.',
       tooltip_hex:
-        'Kurz für Hexadezimal, ein Zahlensystem das Zahlen mittels der Basis 16 repräsentiert.',
-      view_block_0: 'Begutachte Block 0',
-      placeholder: 'Füge die Zeichenkette, die du gefunden hast, hier ein',
+        'Abkürzung für Hexadezimal, ein Zahlensystem zur Darstellung von Zahlen mit der Basis 16.',
+      view_block_0: 'Block 0 anzeigen',
+      placeholder: 'Fügen Sie den gefundenen Wert hier ein',
     },
-
     genesis_three: {
       title: 'Genesis',
-      heading: 'Entschlüsseln wir die Nachricht',
+      nav_title: 'Entschlüsseln Sie die Nachricht',
+      heading: 'Lassen Sie uns die Nachricht entschlüsseln',
       paragraph_one:
-        'Die Nachricht, die Du gefunden hast, war in einem Format namens HEX kodiert. Jetzt werden wir einen Befehl ausführen, um sie in ASCII umzuwandeln und dann lesen zu können.',
+        'Die von Ihnen gefundene Nachricht wurde in einem Format namens HEX codiert. Jetzt führen wir einen Befehl aus, um sie in ASCII umzuwandeln, das wir lesen können.',
       paragraph_two:
-        'Kopiere den folgenden Befehl und füge Ihn im Terminal in das Codefeld ein und drücke “Enter”.',
-      terminal_challenge_lines: `Gib Deine Befehle hier ein und drücke Enter...\n Die Variable $scriptSigHex ist schon für dich definiert worden.\n\n var $scriptSigHex = '04fff...e6b73'`,
+        'Kopieren Sie den folgenden Befehl, fügen Sie ihn im Codeblock des Terminals ein und drücken Sie die Eingabetaste.',
+      terminal_challenge_lines:
+        "Geben Sie hier Ihre Befehle ein und drücken Sie die Eingabetaste...\nDie Variable $scriptSigHex ist bereits für Sie definiert.\n\nvar $scriptSigHex = '04fff...e6b73'",
       waiting_for_input:
-        'Abwartend, dass Sie das Skript schreiben und ausführen...',
-      success: `Überragende Arbeit! Die entschlüsselte Nachricht verweist auf die Titelseite von <Link href="https://en.bitcoin.it/wiki/Genesis_block" target="_blank" className="underline">The Times</Link> vom 3. Januar 2009, dem gleichen Tag an dem Satoshi den Genesisblock geschürft hat. Wie cool ist das denn?! Diese Nachricht gibt uns auch einen Einblick in seine Motivation für die Entwicklung von Bitcoin.\n\n Lass uns weiter machen.`,
+        'Wartet darauf, dass Sie das Skript schreiben und ausführen ...',
+      success:
+        'Tolle Arbeit! Die entschlüsselte Nachricht verweist auf die Titelseite von <Link href="https://en.bitcoin.it/wiki/Genesis_block" target="_blank" className="underline">The Times</Link> vom 3. Januar 2009, dem Tag, an dem Satoshi den Genesis-Block geschürft hat. Wie cool ist das denn?! Diese Nachricht gibt uns auch einen Einblick in seine Motivation, Bitcoin zu erschaffen.\n\nWeiter geht‘s.',
     },
-
     genesis_four: {
       title: 'Genesis',
+      nav_title: 'Ihr erster Erfolg',
       subtitle: 'Glückwunsch! Du hast die erste Herausforderung gemeistert!',
       paragraph_one:
-        'Du hast die geheime Nachricht gefunden, die Satoshi Nakamoto in den Genesisblock eingebettet hat. Jetzt ist es an der Zeit, das eben Gelernte zu vertiefen. Entschlüssle einen wichtigen Hinweis bezüglich der Geschichte in der nächsten Herausforderung.',
+        'Sie haben die geheime Nachricht von Satoshi Nakamoto im Genesis-Block gefunden. Es ist Zeit, das Gelernte zu vertiefen. Entschlüsseln Sie in der nächsten Herausforderung einen wichtigen Hinweis zur Geschichte.',
     },
-
     transacting_one: {
       title: 'Transaktionen',
-      heading: 'Was ist in einer Transaktion?',
+      nav_title: 'Was ist in einer Transaktion enthalten?',
+      heading: 'Was beinhaltet eine Transaktion?',
       paragraph_one:
-        'Die zwei Hauptkomponenten einer Transaktion sind Eingänge (Inputs) und Ausgänge (Outputs). In der vorigen Übung haben wir eine geheime Nachricht entschlüsselt, die sich in einem Transaktionseingang befand. Dieses Mal werden wir eine Nachricht entschlüsseln, die dem Ausgangsteil angehört.',
+        'Zwei Hauptkomponenten einer Transaktion sind Eingaben und Ausgaben. In der vorherigen Übung haben wir eine geheime Nachricht dekodiert, die in einer Transaktionseingabe gefunden wurde. Dieses Mal dekodieren wir eine Nachricht, die zum Ausgabeteil gehört.',
       paragraph_two:
-        'Für die folgende Transaktion werden wir den Output vom Typ OP_RETURN identifizieren.',
+        'Für die folgende Transaktion identifizieren wir die Ausgabe vom Typ OP_RETURN.',
     },
-
     transacting_two: {
       title: 'Transaktionen',
+      nav_title: 'Suchen Sie nach OP_RETURN',
       heading: 'OP_RETURN',
       paragraph_one:
-        'Es gibt eine weitere Möglichkeit, geheime Nachrichten in Transaktionen zu verstecken. Bitcoin hat eine spezielle Art von Code namens OP_RETURN, der es Nutzern erlaubt, Nachrichten an Transaktionsausgaben anzuhängen. Schauen wir mal, ob wir eine finden können.',
+        'Es gibt noch eine andere Möglichkeit, geheime Nachrichten in Transaktionen zu verbergen. Bitcoin verfügt über einen speziellen Codetyp namens OP_RETURN, mit dem Benutzer Nachrichten an Transaktionsausgaben anhängen können. Mal sehen, ob wir einen finden können.',
       paragraph_two:
-        '1. Klicke <Link href="https://blockstream.info/tx/ff9148605a772a51cba39004df5fb042d40515967a3e38ff5294cfd017c452a9" target="_blank" className="underline">hier</Link>, um dir eine spezifische Transaktion anzuschauen.',
+        '1. Klicken Sie <Link href="https://blockstream.info/tx/ff9148605a772a51cba39004df5fb042d40515967a3e38ff5294cfd017c452a9" target="_blank" className="underline">hier</Link>, um eine bestimmte Transaktion anzuzeigen.',
       paragraph_three:
-        '2. Öffne die Rubrik "Details" und suche nach dem Teil, der vom Typ "OP_RETURN" ist.',
+        '2. Öffnen Sie die Details und suchen Sie den Teil vom Typ „OP_RETURN“.',
       paragraph_four:
-        '3. Jetzt suche das “SCRIPTPUBKEY (ASM)” Feld. Siehst Du den “OP_RETURN OP_PUSHBYTES_33" Teil? Dieser beinhaltet zwei unterschiedliche Opcodes. Wir interessieren uns für das, was nach den Opcodes kommt.',
+        '3. Suchen Sie nun das Feld „SCRIPTPUBKEY (ASM)“. Sehen Sie den Teil „OP_RETURN OP_PUSHBYTES_33“? Diese werden Opcodes genannt. Uns interessiert eigentlich, was danach kommt.',
       paragraph_five:
-        '4. Kopiere die lange Zeichenfolge nach "OP_RETURN OP_PUSHBYTES_33" und füge sie in den Codeblock ein. ',
-      input_challenge_label: 'Füge die Zeichenkette vom Typ OP_RETURN hier ein',
+        '4. Kopieren Sie die lange Zahlenfolge nach „OP_RETURN OP_PUSHBYTES_33“ und fügen Sie sie in den Codeblock ein.',
+      input_challenge_label: 'Geben Sie den OP_RETURN-Typ ein',
     },
-
     transacting_three: {
       title: 'Transaktionen',
-      heading: 'Eine weitere geheime Nachricht',
+      nav_title: 'Dekodieren Sie den OP_RETURN',
+      heading: 'Eine weitere geheime Botschaft',
       paragraph_one:
         'Wir haben den Teil der Transaktionsausgabe identifiziert, der die Nachricht enthält.',
       paragraph_two:
-        'Jetzt müssen wir sie, wie wir es in der vorherigen Übung getan haben, nur noch entschlüsseln. Du kannst dir die Transaktion <Link href="https://blockstream.info/tx/ff9148605a772a51cba39004df5fb042d40515967a3e38ff5294cfd017c452a9?expand" className="underline">hier</Link> noch einmal anschauen.',
+        'Jetzt muss es nur noch dekodiert werden, genau wie in der vorherigen Übung. Du kannst die Transaktion <Link href="https://blockstream.info/tx/ff9148605a772a51cba39004df5fb042d40515967a3e38ff5294cfd017c452a9?expand" className="underline">hier</Link> noch einmal nachschlagen.',
       terminal_challenge_success:
-        'Das stimmt! Sehr gute Arbeit.\n\n Wie du siehst, ist der Hinweis eine Adresse. Geh zu ihr.\n\n Die nächste Herausforderung wartet schon.',
+        'Das ist richtig! Gute Arbeit.\n\nWie Sie sehen, ist der Hinweis eine Adresse. Gehen Sie dorthin.\n\nIhre nächste Herausforderung erwartet Sie.',
       terminal_challenge_lines:
-        'Gib hier Deine Befehle ein und drücke Enter...\n\n Command: \n echo $scriptPubKeyBytes | xxd -r -p \n\n Beachte, dass die Variable $scriptPubKeyBytes dieses Mal noch nicht für Dich definiert ist. Du musst diese Variable im Code durch den Wert ersetzen, den Du auf der vorherigen Seite gefunden hast.',
+        'Geben Sie hier Ihre Befehle ein und drücken Sie die Eingabetaste...\n\nBefehl: \necho $scriptPubKeyBytes | xxd -r -p \n\nBeachten Sie, dass $scriptPubKeyBytes dieses Mal nicht für Sie definiert ist. Sie müssen diese Variable im Code durch den Wert ersetzen, den Sie auf der vorherigen Seite gefunden haben',
       terminal_challenge_error:
-        'Fastt! Erinnere dich, dass die Variable $scriptPubKeyBytes dieses Mal noch nicht für dich definiert wurde.',
+        'Fast! Denken Sie daran, dass die Variable $scriptPubKeyBytes dieses Mal nicht für Sie festgelegt ist.',
     },
-
     outro_one: {
-      title: 'Outro',
+      title: 'Andere',
+      nav_title: 'Das Abenteuer ruft',
       paragraph_one:
-        'Du rennst Deine Garage herunter, steigst in den alten Solocopter Deines Vaters, gibst die Koordinaten ein und machst dich auf den Weg zur Adresse.',
+        'Sie rennen hinunter zu Ihrer Garage, steigen in den alten Budgetcopter Ihres Vaters, geben die Koordinaten ein und machen sich auf den Weg zu Distrikt 21.',
       paragraph_two:
-        'Trotz einer Katzenhaarallergie, die so stark ist, dass selbst ein Hologram sie auslösen könnte, kommt die Holokatze mit. Du bist dagegen, aber Katzen sind nun einmal Katzen.',
-      button_text: 'Vervollständige Kapitel 1',
+        'Trotz Katzenallergien, die so stark sind, dass sie sogar auf Hologramme zutreffen, kommt der Holocat. Sie wenden ein, aber Katzen sind eben Katzen.',
+      button_text: 'Schließe Kapitel 1 ab.',
     },
-
     outro_two: {
-      title: 'Du hast es geschafft!!!',
+      title: 'Du hast es geschafft!',
+      nav_title: 'Kapitel abgeschlossen',
       description:
-        'Überragend. Du hast das erste Kapitel abgeschlossen und eine Menge über Transaktionen gelernt. Wie ist es gelaufen?',
+        'Erstaunlich. Du hast das erste Kapitel abgeschlossen und viel über Hashes und Transaktionen gelernt. Wie ist es gelaufen?',
     },
-
     end: {
-      save: 'Speichere meinen Fortschritt',
-      next: 'Fortfahren ohne zu speichern',
-      feedback: 'Teile Dein Feedback',
+      save: 'Meinen Fortschritt speichern',
+      next: 'Fortfahren ohne Speichern',
+      feedback: 'Teilen Sie Ihr Feedback',
     },
     resources: {
-      genesis: {
+      genesis_two: {
         scriptsig_heading: 'ScriptSig',
         scriptsig_paragraph:
-          "Das 'scriptSig' ist ein Skript, das Du als Teil des Eingang/Input Teils in Deiner neuen Transaktion bereitstellst. Es ist im Wesentlichen Dein Freischaltungsskript, das beweist, dass Du die Berechtigung hast, die Bitcoin aus der referenzierten UTXO auszugeben. Das 'scriptSig' ist der Teil der Daten, der in das scriptSig Feld der Eingänge/Inputs eigeben wird.",
-        blocks_heading: 'Bitcoin Blocks',
-        blocks_paragraph:
-          "Ein 'Block' in der Blockchain-Technology ist wie ein Kontainer für eine Gruppe von Transaktionen. Er ist ein wesentlicher Bestandteil der Blockchain, da jeder Block auf den vorherigen referenziert. Dieser Verweis sowie ein 'Blockheader', der wichtige Details wie einen Zeitstempel und eine eindeutige Kennung enthält, gewährleisten die Integrität und chronologische Reihenfolge der Daten. Sobald ein Block zur Blockchain hinzugefügt wurde, ist es unglaublich schwierig, ihn zu ändern, was die Sicherheit und Unveränderlichkeit der Daten gewährleistet. Die Größe eines Blocks kann von Blockchain zu Blockchain variieren, und jeder Block muss von den Netzwerkknoten validiert werden, bevor er ein fester Bestandteil der Blockchain wird. Diese Block- und Kettenstruktur ist die Grundlage für die Transparenz und Sicherheit der Blockchain.",
-        block_explorer_heading: 'Blockexplorer',
+          'Das „scriptSig“ ist ein Skript, das Sie als Teil der Eingabe in Ihrer neuen Transaktion bereitstellen. Es ist im Wesentlichen Ihr Entsperrskript, das beweist, dass Sie die Berechtigung haben, das Bitcoin vom referenzierten UTXO auszugeben. Das „scriptSig“ sind die Daten, die in das ScriptSig-Feld der Eingabe eingehen.',
+        block_explorer_heading: 'Block Explorer',
         block_explorer_paragraph:
-          'Ein Blockexplorer ist ein essentielles Werkzeug zur Navigation und zum Verständnis des Blockchain-Netzwerks. Er dient als benutzerfreundliche Schnittstelle zur Überprüfung und Analyse der in einer Blockchain gespeicherten Daten. Mit einem Block-Explorer können Nutzer die Transaktionshistorie erkunden, Kontostände einsehen und den Fortschritt einzelner Blöcke und Transaktionen verfolgen. Er sorgt für Transparenz und Rechenschaftspflicht in der Welt der dezentralen Kryptowährungen und erleichtert die Überprüfung und Nachverfolgung von Transaktionen und fördert das Vertrauen in die Blockchain-Technologie.',
-        tip_one:
-          'Suche nach der Kategorie scriptSig(Hex), die im Coinbase-Eingang/Input verschachtelt ist, nachdem Du die Transaktion innerhalb des Blocks erweitert hast.',
-        tip_two:
-          "Der 'xxd' Befehl kodiert Daten nach Hex, wobei der '-r' Zusatz es dir erlaubt den Prozess umzukehren (reverse), was es Dir ermöglicht Hex in lesenbaren Text umzuwandeln. Der '-p' Zusatz druckt (print) es dann in die Konsole, sodass Du die Ausgabe lesen kannst.",
+          'Ein Block-Explorer ist ein wichtiges Tool zum Navigieren und Verstehen von Blockchain-Netzwerken. Er fungiert als benutzerfreundliche Schnittstelle zum Überprüfen und Analysieren der in einer Blockchain gespeicherten Daten. Mit einem Block-Explorer können Benutzer Transaktionsverläufe erkunden, Kontostände anzeigen und den Fortschritt einzelner Blöcke und Transaktionen verfolgen.',
+        tip: 'Suchen Sie nach der Kategorie „scriptSig(Hex)“, die in der Coinbase-Eingabe verschachtelt ist, nachdem Sie die Transaktion innerhalb des Blocks erweitert haben.',
       },
-      transacting: {
+      genesis_three: {
+        bash_heading: 'Bash-Befehle',
+        bash_paragraph:
+          'Wir verwenden einige grundlegende Bash-Befehle und Optionen, um die Komprimierung rückgängig zu machen, die Satoshi für den in den Genesis-Block eingefügten Text vorgenommen hat.',
+        tip: 'Der Befehl „xxd“ wandelt eine Datei in Hex um und durch Hinzufügen des Tags „-r“ wird dies umgekehrt, sodass Hex in Text umgewandelt werden kann. Das Tag „-p“ gibt die Datei dann auf der Konsole aus, sodass Sie die Ausgabe lesen können.',
+      },
+      transacting_two: {
         transactions_heading: 'Transaktionen',
         transactions_paragraph:
-          'Eine Transaktion in der Welt der Kryptowährungen ist vergleichbar mit einer einzelnen atomaren Zahlung, bei der bestehende Münzen vernichtet und neue geschaffen werden. Wenn jemand eine Kryptowährungstransaktion initiiert, weist er die Blockchain im Wesentlichen an, eine bestimmte Menge an Münzen von einer digitalen Geldbörse auf eine andere zu übertragen. Um dies zu erreichen, verbraucht die Transaktion die vorhandenen Münzen des Absenders und erzeugt neue für den Empfänger, wodurch das Eigentumsbuch effektiv aktualisiert wird.',
-        bitcoin_script_heading: 'Bitcoin Skript',
+          'Eine Transaktion in der Welt der Kryptowährungen ist vergleichbar mit einer einzelnen atomaren Zahlung, bei der bestehende Münzen vernichtet und neue geschaffen werden. Wenn jemand eine Kryptowährungstransaktion initiiert, weist er die Blockchain im Wesentlichen an, eine bestimmte Menge an Münzen von einer digitalen Geldbörse in eine andere zu übertragen. Um dies zu erreichen, verbraucht die Transaktion die bestehenden Münzen des Absenders und generiert neue für den Empfänger, wodurch das Eigentumsregister effektiv aktualisiert wird.',
+        bitcoin_script_heading: 'Bitcoin-Skript',
         bitcoin_script_paragraph:
-          'Bitcoin Skript ist eine einfache, stapelbasierte Programmiersprache, die bei Bitcoin-Transaktionen verwendet wird, um die Bedingungen festzulegen, unter denen Bitcoins ausgegeben werden können. Sie besteht aus verschiedenen Opcodes (kurz für Operationscodes), die angeben, welche Operationen mit den Daten innerhalb des Skripts durchgeführt werden sollen.',
-        tip_one:
-          'Mit dem Op_Code: OP_Pushbytes_33 suchen wir nach einer 33 Byte langen Zeichenkette (insgesamt 66 Zeichen) im OP_Return der Transaktion',
-        tip_two:
-          "Dekodiere die Zeichenkette mit dem 'xxd' Befehl. Denk daran, dass wir dieses Mal keine Variable verwenden, sondern die ganze Zeichenkette eingeben müssen.",
+          'Bitcoin Script ist eine einfache, stapelbasierte Programmiersprache, die bei Bitcoin-Transaktionen verwendet wird, um die Bedingungen zu definieren, unter denen Bitcoins ausgegeben werden können. Sie besteht aus verschiedenen Opcodes (kurz für Operationscodes), die angeben, welche Operationen an den Daten im Skript ausgeführt werden sollen.',
+        tip: 'Angesichts des Op_Codes: OP_Pushbytes_33 suchen wir nach einer 33 Byte langen Zeichenfolge (insgesamt 66 Zeichen) im OP_Return der Transaktion',
+      },
+      transacting_three: {
+        secrets_heading: 'Geheimnisse in Bitcoin',
+        secrets_paragraph:
+          'Wie wir aus der vorherigen Herausforderung gesehen haben, sind in Bitcoin-Skripten eingebettete Geheimnisse seit dem Genesis-Block Teil ihrer Geschichte. Ob sie einfach verwendet werden, um einige Informationen in der Blockchain zu speichern, um Informationen durch Bitcoin-Skripte weiterzugeben, um Bitcoin einen Wert außerhalb zu geben, oder um Nachrichten an andere weiterzugeben, Menschen haben von Anfang an andere Dinge in der Blockchain gespeichert als Ein- und Ausgaben.',
+        tip: 'Denken Sie beim Dekodieren der Zeichenfolge mit dem Befehl „xxd“ daran, dass wir diesmal keine Variable verwenden. Wir müssen die gesamte Zeichenfolge eingeben.',
       },
     },
   },
-
   chapter_two: {
-    title: 'Das Hashen eines Plans',
+    title: 'Einen Plan ausarbeiten',
     paragraph_one:
-      'Die von Satoshi angegebenen Koordinaten führen Dich zu einem verlassenen Lagerhaus.',
+      'Die Koordinaten, die Satoshi Ihnen gegeben hat, enttäuschen leider nicht: Es handelt sich um ein Lagerhaus, und noch dazu um ein unheimliches, verlassenes.',
     paragraph_two:
-      'Du umkreist das Lagerhaus mit Deinem Budgetcopter nicht weniger als dreimal. Der Wärmedetektor Deines Budgetcopters nimmt nichts als Dunkelheit wahr. Wenn jemand weiß, dass es diesen Ort gibt, hat er ihn schon lange nicht mehr besucht, außer vielleicht in seinen Erinnerungen.',
-
+      'Sie umrunden das Lagerhaus mit Ihrem Budgetcopter nicht weniger als dreimal. Ja, seufz, da müssen Sie wohl rein. Der Budget-Wärmemelder Ihres Budgetcopters erkennt nichts außer Dunkelheit. Wenn jemand weiß, dass dieser Ort existiert, ist es lange her, dass er ihn besucht hat, außer in seiner Erinnerung.',
     intro_one: {
-      title: 'Das Hashen eines Plans',
+      title: 'Einleitung',
+      nav_title: 'Das Lager',
       paragraph_one:
-        'HOLOKATZE: “Man, was für ein Saustall. Dieser Ort sollte besser Sardinen oder Trockenfisch lagern. Ich würde mich auch mit einem kleinen E-Schlückchen zufrieden geben."',
+        '—HOLOCAT: „Junge, was für ein Drecksloch. Hier sollte es besser irgendwo ein paar E-Sardellen geben. Ich würde mich sogar mit etwas CyberKibble zufrieden geben.“',
       paragraph_two:
-        'Du landest, beruhigst dich und suchst nach einer Einstiegsstelle. Da, das zerbrochene Fenster scheint perfekt hierfür geeignet zu sein. Mit einem Ziegelstein zerstörst du die Reste des Fensters und dringst in das Gebäude ein. Das Gebäude ist voll mit Tausenden von staubigen, gut erhaltenen Bitcoin-Minern.',
-      paragraph_three:
-        'HOLOKATZE: “Dies ist kein Lagerhaus, sondern ein Museum. Ich glaube, das sind alte ASIC-Miner der Familie Vanderpoole. Anwendungsspezifische integrierte Schaltkreise (Application-specific integrated circuit - ASIC) waren in den Anfangstagen von Bitcoin der letzte Schrei. Kannst Du dir vorstellen, dass die Leute früher auch andere Coins geschürft haben?”',
+        'Sie landen, halten sich fest und suchen nach einem Einstiegspunkt. Das zerbrochene Fenster sollte den Zweck erfüllen. Sie schlagen mit einem Ziegelstein die Überreste des Fensters heraus und springen hinein. Das Gebäude ist mit Tausenden staubiger, gut erhaltener Bitcoin-Miner gefüllt.',
+      paragraph_three: {
+        a: '—HOLOCAT: „Das ist kein Lagerhaus, das ist ein Museum. Ich glaube, das sind alte Mining-Geräte der Familie Vanderpoole. In den frühen Tagen von Bitcoin nutzten die Miner Allzweckcomputer, um Bitcoin zu minen. Aber nach ein paar Jahren erkannten die Miner, dass sie Maschinen mit einem speziellen Chip, einem sogenannten anwendungsspezifischen integrierten Schaltkreis, verwenden konnten, oder',
+        b: 'kurz gesagt. Diese Chips machen nur eines: Bitcoin schürfen. Ihr enger Fokus erhöht ihre Effizienz und ermöglicht es den Minern, weniger Energie für das Schürfen aufzuwenden, was ihnen einen Vorteil verschafft. Können Sie glauben, dass die Leute irgendwann einmal mit ihren Laptops geschürft haben?"',
+      },
+      paragraph_four:
+        'Dies erklärt alle Maschinen in der Sammlung der Familie Vanderpoole.',
+      tooltip_one: {
+        question: 'Was ist ein ASIC-Miner?',
+        link: 'https://chat.bitcoinsearch.xyz/?author=holocat&question=What%2520is%2520an%2520ASIC%2520miner%253F',
+        highlighted: 'ASIC',
+      },
     },
-
     intro_two: {
-      title: 'Das Hashen eines Plans',
+      title: 'Einen Plan ausarbeiten',
+      nav_title: 'Einschalten des Computers',
       paragraph_one:
-        'In der Ecke blinkt ein schummriger, kaum funktionierender Computermonitor, an dem ein Zettel klebt. Auf dem Zettel steht: "Mach sie an, Dummkopf."',
-      paragraph_two: 'HOLOKATZE: “Wie frech.”',
+        'In der Ecke blinkt ein dunkler, kaum funktionierender Computermonitor, an dem eine Notiz klebt. Auf der Notiz steht: „Mach sie an, Dummkopf.“',
+      paragraph_two:
+        '—HOLOCAT: „Wie unhöflich. Wow, eine mechanische Tastatur. Ich habe von diesen Dingern gehört. Angeblich waren sie so laut, dass sie den Benutzern ihr Gehör kosteten, und wurden deshalb verboten.“',
       paragraph_three:
-        'Wow, eine mechanische Tastatur. Holokatze springt auf die Tastatur, läuft über sie und zeigt dir, welche Tasten Du drücken musst.',
+        'Holocat springt auf die Tastatur, läuft darüber und zeigt Ihnen, welche Tasten Sie drücken müssen.',
     },
-
     hashing_one: {
       title: 'Nullen',
+      nav_title: 'Der Computer erwacht zum Leben',
       paragraph_one:
-        'Entweder durch Zufall oder weil Holokatze tatsächlich wusste, was sie tat, verwandelt der Computer die zufälligen Buchstaben und Zahlen, auf die sie getreten ist, in... weitere zufällige Buchstaben und Zahlen?',
+        'Entweder durch Zufall oder weil Holocat wirklich wusste, was sie tat, verwandelten sich die zufälligen Buchstaben und Zahlen, auf die sie trat, in ... noch mehr zufällige Buchstaben und Zahlen?',
       list_one: '> QX23Y6VGECTUKSNIEUTUB[P[pihof',
       list_two:
         '> 1c31d1d9fb848a505fc0cdbea848ff1bdd46a9ed4d639d413d3a93035194eedf',
-      paragraph_two: 'Der Monitor zeigt "FALSCHER HASH. VERSUCHE ES ERNEUT."',
+      paragraph_two:
+        'Auf dem Monitor wird „FALSCHES HASH. VERSUCHEN SIE ES ERNEUT.“ angezeigt.',
       paragraph_three:
-        'Natürlich war das Kauderwelsch, was die Holokatze getippt hat. Sie ist nur eine holografische Katze!',
-      paragraph_four: 'Was passiert, wenn Du etwas anderes eingibst?',
+        'Natürlich war das Kauderwelsch, das Holocat eingetippt hat, falsch. Sie ist nur eine freche holografische Katze!',
+      paragraph_four: 'Was passiert, wenn Sie etwas anderes eingeben?',
     },
-
     hashing_two: {
       title: 'Nullen',
-      heading: 'Gib ein was Du willst',
-      return_hash:
-        'Nachfolgend siehst Du Deine Eingaben in einen Hash umgewandelt',
-      progress_message: 'Versuch es weiter...',
-      success_message:
-        'In Ordnung, gute Arbeit beim Herumspielen. Machen wir weiter.',
+      nav_title: 'Versuchen Sie, etwas zu hashen',
+      heading: 'Geben Sie etwas ein',
+      return_hash: 'Unten sehen Sie Ihre Eingabe in einen Hash umgewandelt',
+      progress_message: 'Weitermachen...',
+      success_message: 'Okay, nettes Herumspielen. Weiter geht’s.',
     },
-
     hashing_three: {
       title: 'Nullen',
-      heading: 'Ist Dir etwas besonderes bezüglicher der Hashe aufgefallen?',
+      nav_title: 'Die Leistungsfähigkeit von SHA256',
+      heading: 'Ist Ihnen an den Hashes etwas Besonderes aufgefallen?',
       list_one:
-        'So wie Fingerabdrücke ist jeder Hash einzigartig. Abgesehen von manchen außergewöhnlichen Umständen sollten die Hashe für zwei verschiedene Eingaben niemals identisch sein.',
+        'Genau wie Fingerabdrücke sind Hashes einzigartig. Außer in Ausnahmefällen sollten die Hashes für zwei verschiedene Dinge niemals gleich sein.',
       list_two:
-        'Hash-Funktionen sind eine Einbahnstraße. Man kann einen Hash nicht auf seinen Eingabewert zurückrechnen, um herauszufinden welche Daten sich hinter ihm verbergen.',
+        'Hash-Funktionen sind Einbahnstraßen. Sie können keinen Hash zurückentwickeln, um die Daten herauszufinden, aus denen er erstellt wurde.',
       list_three:
-        'Hashe sind insofern extrem zuverlässig, als das sie deterministisch sind. Das bedeutet, dass Du die selben Daten immer und immer wieder hashen kannst und immer das selbe Ergebnis erhalten wirst.',
-      paragraph_one:
-        'Die Funktion, die hier genutzt wird, nennt sich SHA-256, eine sehr beliebte Wahl.',
+        'Hashes sind in dem Sinne extrem zuverlässig, dass sie deterministisch sind. Das heißt, Sie können dieselben Daten immer wieder hashen und erhalten immer das gleiche Ergebnis.',
+      paragraph_one: {
+        a: 'Die hier verwendete Funktion heißt',
+        b: 'eine sehr beliebte Wahl.',
+      },
       paragraph_two:
-        'Okay, jetzt lass uns schauen, ob Du einen spezifischen Hash finden kannst.',
+        'Sehen wir uns nun an, ob Sie einen bestimmten Hash finden können.',
       paragraph_three:
-        'Finde einen Hash der mit einer Null beginnt (“0”). Gib unten so lange verschiedene Zeichen ein, bis Du den gewünschten Hash gefunden hast.',
+        'Suchen Sie nach einem Hash, der mit einer Null („0“) beginnt. Geben Sie unten verschiedene Dinge ein, bis Sie den gewünschten Hash finden.',
+      tooltip_one: {
+        question: 'Wie wird SHA-256 in Bitcoin verwendet?',
+        link: 'https://chat.bitcoinsearch.xyz/?author=holocat&question=how%2520is%2520SHA-256%2520used%2520in%2520bitcoin%253F',
+        highlighted: 'SHA-256',
+      },
     },
-
     hashing_four: {
       title: 'Nullen',
+      nav_title: 'Suchen Sie nach einem Hash mit einer Null',
       heading:
-        'Gib ein was du möchtest, bis du einen Hash gefunden hast, der mit einer Null beginnt (“0”)',
+        'Geben Sie etwas ein, bis Sie einen Hash finden, der mit einer Null („0“) beginnt.',
       hint_prompt:
-        'Brauchst Du einen <Tooltip id="hint_prompt" position="bottom" theme="bg-[#5e212a]" offset="-1" content="chapter_two.hashing_four.hint_tooltip">Tipp</Tooltip>?',
+        'Benötigen Sie einen <Tooltip id="hint_prompt" position="bottom" theme="bg-[#5e212a]" offset="-1" content="chapter_two.hashing_four.hint_tooltip">Hinweis</Tooltip>?',
       hint_tooltip:
-        '<span className="text-m whitespace-nowrap leading-none text-white/50">Tipp mal:</span> <span className="whitespace-nowrap text-white">popcorn</span>',
+        '<span className="text-m whitespace-nowrap leading-none text-white/50">Versuchen Sie Folgendes einzugeben:</span> <span className="whitespace-nowrap text-white">Popcorn</span>',
     },
-
     hashing_five: {
       title: 'Nullen',
-      heading: 'Das war doch gar nicht so schwer!',
+      nav_title: 'Die Hitze erhöhen',
+      heading: 'Das war nicht allzu schwer!',
       paragraph_one:
-        'Lass es uns ein bisschen kniffliger machen. Versuche einen Hash zu finden, der mit zwei Nullen beginnt ("00").',
+        'Machen wir es etwas kniffliger. Versuchen Sie, einen Hash zu finden, der mit zwei Nullen („00“) beginnt.',
     },
-
     hashing_six: {
       title: 'Nullen',
+      nav_title: 'Suchen Sie einen Hash mit zwei Nullen',
       heading:
-        'Gib ein was Du möchtest, bis Du einen Hash findest, der mit zwei Nullen beginnt (“00”)',
+        'Geben Sie etwas ein, bis Sie einen Hash finden, der mit zwei Nullen („00“) beginnt',
       hint_prompt:
-        'Brauchst Du einen <Tooltip id="hint_prompt" position="bottom" theme="bg-[#5e212a]" offset="-1" content="chapter_two.hashing_six.hint_tooltip">Tipp</Tooltip>?',
+        'Benötigen Sie einen <Tooltip id="hint_prompt" position="bottom" theme="bg-[#5e212a]" offset="-1" content="chapter_two.hashing_six.hint_tooltip">Hinweis</Tooltip>?',
       hint_tooltip:
-        '<span className="text-m whitespace-nowrap leading-none text-white/50">Try typing:</span> <span className="whitespace-nowrap text-white">trigonometry</span>',
+        '<span className="text-m whitespace-nowrap leading-none text-white/50">Versuchen Sie Folgendes einzugeben:</span> <span className="whitespace-nowrap text-white">Trigonometrie</span>',
     },
-
     scripting_one: {
       title: 'Automatisierung',
-      heading: 'Lassen wir den Computer das für uns machen.',
+      nav_title: 'Hashen des Nonce',
+      heading: 'Lassen wir das den Computer für uns erledigen.',
       paragraph_one:
-        'Okay, das hat Dich wahrscheinlich länger beschäftigt als gedacht. Stelle Dir nun vor, Du musst einen Hash finden, der mit fünf oder zehn Nullen beginnt. Das ist die Herausforderung, vor die das Bitcoin-Netzwerk die Miner stellt, wenn sie neue Blöcke mit Transaktionen einreichen wollen.',
+        'OK, das hat wahrscheinlich viel länger gedauert. Stellen Sie sich nun vor, Sie finden einen Hash, der mit fünf oder zehn Nullen beginnt. Dies ist die Herausforderung, die das Bitcoin-Netzwerk den Minern stellt, wenn sie neue Blöcke mit Transaktionen übermitteln möchten.',
       paragraph_two:
-        'Die Miner sammeln alle Informationen, die sie in einen Block einfügen wollen, z. B. den Hash des vorherigen Blockheaders, die Zeit, einen Hash der Transaktionen, die in den Block aufgenommen werden sollen (einschließlich der Coinbase-Transaktion) und kombinieren sie mit einer Zufallszahl, die Nonce genannt wird (was für "number only used once" steht). All dies wird in die Hash-Funktion eingegeben, um den sogenannten Block-Hash zu erstellen.',
+        'Miner sammeln alle Informationen, die sie in einen Block einfügen möchten, wie den Hash des vorherigen Blockheaders, einen Hash der Transaktionen, die in den Block aufgenommen werden sollen (einschließlich der Coinbase-Transaktion), die Zeit und kombinieren sie mit einer Zufallszahl, die als Nonce (Number Only Used Once) bezeichnet wird. Sie senden all dies an die Hash-Funktion, um etwas zu erstellen, das als Block-Hash bezeichnet wird.',
       paragraph_three:
-        'Als Bitcoin an den Start ging, haben die Miner die Nonce im Block-Header durchprobiert, indem sie die Werte im 32-Bit-Feld, Durchgang für Durchgang, um 1 erhöht haben. Da die Miner allerdings inzwischen so leistungsfähig und die Schwierigkeit so hoch geworden ist, durchlaufen sie diesen Zyklus ziemlich schnell und finden normalerweise keine Lösung unterhalb der Zielschwierigkeit.',
+        'Als Bitcoin zum ersten Mal auf den Markt kam, durchliefen die Miner den Nonce im Blockheader, indem sie die Daten im 32-Bit-Feld um 1 erhöhten. Mit zunehmender Leistungsfähigkeit und Effizienz der Miner steigt jedoch der Schwierigkeitsgrad. Bald wurde er so hoch, dass es üblich war, alle Möglichkeiten für das 32-Bit-Feld auszuschöpfen, ohne eine einzige Lösung unterhalb des',
       paragraph_four:
-        'Die Miner müssen entsprechend weitere Teile des Blockheaders ändern, z. B. die Zeit oder die im Block enthaltenen Transaktionen, um weitere, mögliche Hashe generieren zu können.',
+        'Um dieses Problem zu beheben, begannen die Miner, andere Teile des Blockheaders zu ändern, beispielsweise die Zeit oder die im Block enthaltenen Transaktionen.',
       paragraph_five:
-        'Das Bitcoin-Netzwerk hat eine Schwierigkeitseinstellung und akzeptiert nur Block-Hashe, die mit einer bestimmten Anzahl von Nullen beginnen. Wir nennen dies die "difficulty" und sie wird alle 2016 Blöcke angepasst.',
+        'Das Bitcoin-Netzwerk verfügt über eine Schwierigkeitseinstellung und akzeptiert nur Block-Hashes, die mit einer bestimmten Anzahl von Nullen beginnen. Wir nennen dies die „Schwierigkeit“ und sie wird alle 2016 Blöcke angepasst.',
       paragraph_six:
-        'Schreibe für die nächste Aufgabe ein Skript, das einen Hash findet, der mit fünf Nullen beginnt (00000).',
+        'Schreiben Sie für die nächste Herausforderung ein Skript, das einen Hash findet, der mit fünf Nullen (00000) beginnt.',
+      tooltip_one: {
+        question: 'Was ist die Zielschwierigkeit?',
+        link: 'https://chat.bitcoinsearch.xyz/?author=holocat&question=what%2520is%2520target%2520difficulty%253F',
+        highlighted: 'Zielschwierigkeit',
+      },
     },
-
     scripting_two: {
-      title: 'Automation',
+      title: 'Automatisierung',
+      nav_title: 'Erstellen einer Hash-Funktion',
       paragraph_one:
-        'Alles klar, jetzt ist es an der Zeit, Deinen eigenen Code zu schreiben und auszuführen. Schreibe ein Skript, das einen Sha256-Hash erzeugt, der mit fünf Nullen beginnt ("00000..."). Dein Code sollte die Funktion Sha256 wiederholt mit verschiedenen Inputs aufrufen, bis ein Output diese Anforderung erfüllt. Du solltest versuchen, eine ganze Zahl innerhalb einer Schleife Durchgang für Durchgang zu erhöhen, um verschiedene Input-Werte zu erhalten. In der Kryptographie wird diese Zahl als "Nonce" oder "number used once" bezeichnet.',
+        'Okay, es ist Zeit, Ihren eigenen Code zu schreiben und auszuführen. Schreiben Sie ein Skript, das einen SHA256-Hash generiert, der mit fünf Nullen beginnt („00000...“). Ihr Code sollte die SHA256-Funktion wiederholt mit unterschiedlichen Eingaben aufrufen, bis die Ausgabe diese Anforderung erfüllt. Sie sollten versuchen, eine Ganzzahl innerhalb einer Schleife zu erhöhen, um unterschiedliche Eingaben zu erhalten. In der Kryptographie wird diese Zahl als „Nonce“ oder „einmal verwendete Zahl“ bezeichnet.',
       python: {
         paragraph_two:
-          'Wenn Du eine Nonce mit einem Hash findest, der mit fünf Nullen beginnt, gib den Hash an die Konsole zurück. Wir verwenden die hashlib-Bibliothek in Python, um Dir bei der Erstellung dieser Funktion zu helfen. Du kannst bei Bedarf die folgenden externen Ressourcen verwenden, um Dir beim Schreiben dieser Funktion zu helfen:',
+          'Wenn Sie einen Nonce mit einem Hash finden, der mit fünf Nullen beginnt, geben Sie den Nonce von der Funktion zurück. Wir verwenden die Hashlib-Bibliothek in Python, um Sie bei der Erstellung dieser Funktion zu unterstützen. Sie können bei Bedarf die folgenden externen Ressourcen verwenden, um diese Funktion zu schreiben:',
         list_one:
-          '<Link href="https://docs.python.org/3/library/hashlib.html" target="_blank" className="underline">hashlib documentation</Link>',
+          '<Link href="https://docs.python.org/3/library/hashlib.html" target="_blank" className="underline">hashlib-Dokumentation</Link>',
         list_two:
-          '<Link href="https://datagy.io/python-sha256/" target="_blank" className="underline">Tutorial python function</Link>',
+          '<Link href="https://datagy.io/python-sha256/" target="_blank" className="underline">Tutorial zur Python-Funktion</Link>',
       },
       javascript: {
         paragraph_two:
-          'Wenn Du eine Nonce mit einem Hash findest, der mit fünf Nullen beginnt, gib den Hash an die Konsole zurück. Wir verwenden die crypto-Bibliothek in JavaScript, um Dir bei der Erstellung dieser Funktion zu helfen. Du kannst bei Bedarf die folgenden externen Ressourcen verwenden, um Dir beim Schreiben dieser Funktion zu helfen:',
+          'Wenn Sie einen Nonce mit einem Hash finden, der mit fünf Nullen beginnt, geben Sie den Nonce von der Funktion zurück. Wir verwenden die Kryptobibliothek in JavaScript, um Sie beim Erstellen dieser Funktion zu unterstützen. Sie können bei Bedarf die folgenden externen Ressourcen zum Schreiben dieser Funktion verwenden:',
         list_one:
-          '<Link href="https://www.geeksforgeeks.org/node-js-crypto-createhash-method/" target="_blank" className="underline">crypto documentation</Link>',
+          '<Link href="https://www.geeksforgeeks.org/node-js-crypto-createhash-method/" target="_blank" className="underline">Kryptodokumentation</Link>',
         list_two:
-          '<Link href="https://www.educative.io/answers/what-is-node-cryptocreatehashalgorithm-options" target="_blank" className="underline">Tutorial JavaScript function</Link>',
+          '<Link href="https://www.educative.io/answers/what-is-node-cryptocreatehashalgorithm-options" target="_blank" className="underline">Tutorial JavaScript-Funktion</Link>',
       },
-      success: 'Fünf Nullen! Geschafft!',
     },
-
     mining_one: {
-      title: 'Innerhalb der Miene',
+      title: 'In die Mine',
+      nav_title: 'Blöcke abbauen',
       heading_one:
-        'Jetzt, da wir wissen wie Mining funktioniert, wollen wir uns das mal in Aktion anschauen',
+        'Nachdem wir nun wissen, wie Mining funktioniert, wollen wir es in Aktion sehen',
       heading_two: 'Du schürfst jetzt',
       heading_three: 'Gute Arbeit!',
-      heading_four: 'Lass uns 100 Blöcke schaffen',
-      heading_five: 'Du hast es geschafft!',
+      heading_four: 'Kommen wir zu 100 Blöcken',
+      heading_five: 'Sie haben es geschafft!',
       paragraph_one:
-        'Momentan verlangt das Bitcoin-Netzwerk, dass Blöcke einen Hash mit zehn führenden Nullen aufweisen. Lass uns das hinbekommen!',
+        'Derzeit erfordert das Bitcoin-Netzwerk, dass Blöcke einen Hash mit zehn führenden Nullen haben. Legen wir los!',
       paragraph_two:
-        'Für diese einfache Simulation nehmen wir an, dass jeder Block 3500 Transaktionen und 0,061 BTC an Belohnungen und Gebühren enthält.',
-      paragraph_two_one: 'Schau, ob Du die Miner anschalten kannst.',
+        'Für diese einfache Simulation gehen wir einfach davon aus, dass jeder Block 3.500 Transaktionen und 0,061 BTC an Belohnungen und Gebühren enthält.',
+      paragraph_two_one: 'Versuchen Sie, die Bergleute zu aktivieren.',
       paragraph_three:
-        'Der Code, den Du in der vorherigen Lektion geschrieben hast, um Hashe immer und immer wieder zu berechnen, läuft.',
+        'Der Code, den Sie in der vorherigen Lektion geschrieben haben, um Hashes immer wieder zu berechnen, wird ausgeführt.',
       paragraph_four:
-        'Er hält an, sobald ein Hash mit zehn führenden Nullen gefunden wurde.',
+        'Es wird gestoppt, sobald ein Hash mit zehn führenden Nullen gefunden wurde.',
       paragraph_five:
-        'Siehst Du das Nonce-Feld nach oben schnellen? Das ist die Anzahl der Hashe, die Du bis jetzt versucht hast!!',
-      paragraph_six: 'Mit der folgenden Nonce:',
-      paragraph_seven: 'Der erzeugte Hash lautet:',
+        'Sehen Sie, wie das Nonce-Feld hochzählt? So viele Hashes haben Sie bisher ausprobiert!',
+      paragraph_six: 'Mit folgender Nonce:',
+      paragraph_seven: 'Der resultierende Hash ist:',
       paragraph_eight:
-        'Er hat die zehn führenden Nullen, die alle neuen Blöcke benötigen. Lass uns ein paar weitere Blöcke schürfen.',
-      paragraph_eight_one: 'Mach die Miner wieder an.',
+        'Es hat die zehn führenden Nullen, die alle neuen Blöcke benötigen. Lassen Sie uns noch ein paar Blöcke abbauen.',
+      paragraph_eight_one: 'Schalten Sie die Bergleute wieder ein.',
       paragraph_nine:
-        'Das kann einige Zeit dauern. Aber das zeigt Dir, wie schwer es ist, Blöcke zu schürfen und Transaktionen zu bestätigen.',
+        'Dies kann einige Zeit dauern. Es zeigt Ihnen jedoch, wie schwierig es ist, Blöcke abzubauen und Transaktionen zu bestätigen.',
       paragraph_ten:
-        'Wow! Für das ganze Hashing war eine ganze Menge Rechenleistung nötig. Sieh nur, wie viele Nonces ausprobiert wurden!  Es war wirklich hilfreich, die Hashpower, d.h. die Anzahl der Hashe, die Dein Computer in einer Sekunde ausprobieren kann, zu erhöhen.',
+        'Wow! Das Hashing hat eine ganze Menge Rechenleistung gekostet. Sehen Sie sich nur an, wie viele Nonces ausprobiert wurden! Es hat wirklich geholfen, die Hash-Leistung zu steigern, d. h. die Anzahl der Hashes, die Ihr Computer pro Sekunde ausprobieren kann.',
       paragraph_eleven:
-        'Da jeder Block 3500 Transaktionen enthält, wurden in den 100 Blöcken, die geschürft wurden, erwartungsgemäß insgesamt 350000 Transaktionen bestätigt.',
+        'Da jeder Block 3.500 Transaktionen enthält, wurden durch die 100 abgebauten Blöcke erwartungsgemäß insgesamt 350.000 Transaktionen bestätigt.',
       paragraph_twelve:
-        'Und es sieht so aus, als hättest Du eine nette Belohnung für all das Mining erhalten! Zusätzlich zur Blockbelohnung, der Menge an Bitcoin, die das Netzwerk für jeden gefundenen Block vergütet, konntest Du auch zusätzliche Einnahmen in Form von Transaktionsgebühren erzielen.',
+        'Und es sieht so aus, als ob Sie für all das Mining eine schöne Belohnung erhalten haben! Zusätzlich zur Blocksubvention, also der Menge an Bitcoin, die das Netzwerk für jeden Block belohnt, konnten Sie auch zusätzliche Einnahmen in Form von Transaktionsgebühren erzielen.',
       paragraph_thirteen:
-        'In den Anfängen von Bitcoin war es möglich, mit einem durchschnittlichen Computer zu minen, so wie wir es in dieser Simulation getan haben.',
+        'Denken Sie daran, dass dies nur eine Simulation war. Jeder Block soll durchschnittlich 10 Minuten dauern.',
       paragraph_fourteen:
-        'Heutzutage verwenden Miner eine besondere Art von Chip, der als anwendungsspezifischer integrierter Schaltkreis (Application-Specific Integrated Circuit, kurz ASIC) bezeichnet wird. Heutzutage kaufen die Leute Maschinen mit ASICs, die nur für das Mining bestimmt sind! Das erklärt all die Maschinen in der Sammlung der Familie Vanderpoole.',
+        'Wenn wir tatsächlich im aktuellen Mainnet minen würden, wäre zum Mining dieser Blöcke außerdem um ein Vielfaches mehr Rechenleistung erforderlich.',
       progress_bar_title: 'Gefundene Blöcke',
       progress_bar_one: 'Nonce',
-      progress_bar_two: 'Hashe pro Sekunde',
-      progress_bar_three: 'Bestätigte Transaktionen',
-      progress_bar_four: 'Verdiente Bitcoin',
-      button_hash: '10x Hash Power, bitte',
-      ten_x_hint: 'Klicke auf den 10x Button, um das Hashing zu beschleunigen!',
+      progress_bar_two: 'Hashes pro Sekunde',
+      progress_bar_three: 'Transaktionen bestätigt',
+      progress_bar_four: 'Bitcoin verdient',
+      button_hash: '10x Hash-Power, bitte',
+      ten_x_hint:
+        'Tippen Sie auf die 100x-Schaltfläche, um das Hashing zu beschleunigen!',
     },
     outro_one: {
-      title: 'Outro',
-      heading: 'Gute Arbeit!',
+      title: 'Andere',
+      nav_title: 'Kapitel abgeschlossen',
+      heading: 'Gut gemacht!',
       paragraph_one:
-        'Die Maschinen dröhnen zum Leben. Alles scheint zu funktionieren. Auf dem Computer erscheint eine Karte, die die Standorte anderer Lagerhäuser mit ASICs zeigt, die auf der ganzen Welt online gegangen sind. Sieht so aus, als wären sie aktiviert worden, als du die Mining-Herausforderung abgeschlossen hast!',
-      paragraph_two: 'HOLOKATZE: “Schau, hier ist eine Nachricht.”',
+        'Die Maschinen erwachen zum Leben. Alles scheint zu funktionieren. Auf dem alten Monitor erscheint eine Karte, die die Standorte anderer Lagerhäuser zeigt, die mit alten Bergbaugeräten der Familie Vanderpoole gefüllt sind, die weltweit online gegangen sind. Sieht so aus, als wären sie aktiviert worden, als Sie die Bergbau-Herausforderung abgeschlossen haben!',
+      paragraph_two: '—HOLOCAT: „Schau, da ist eine Nachricht.“',
       paragraph_three:
-        '“Gute Arbeit. Das wird dem Bitcoin-Netzwerk helfen, wieder zu einem geschürften Block  alle zehn Minuten zurückzukehren.” – Satoshi Nakamoto',
+        '„Gute Arbeit. Dies wird Bitcoin helfen, wieder alle zehn Minuten einen Block zu erreichen.“ – Satoshi Nakamoto',
       paragraph_four: 'Er schon wieder?',
     },
     resources: {
-      hashing: {
+      hashing_two: {
         hash_functions_heading: 'Hash-Funktionen',
         hash_functions_paragraph:
-          'Eine Hash-Funktion ist eine Funktion, die verwendet werden kann, um Daten beliebiger Größe auf Werte fester Größe abzubilden. Die von einer Hash-Funktion zurückgegebenen Werte werden Hash-Werte, Hash-Codes, Digests oder einfach Hashe genannt. Die Werte werden in der Regel zur Indizierung einer Tabelle fester Größe verwendet, die als Hash-Tabelle bezeichnet wird. Die Verwendung einer Hash-Funktion zur Indizierung einer Hash-Tabelle wird als Hashing oder Scatter Storage Addressing bezeichnet.',
+          'Eine Hashfunktion ist eine beliebige Funktion, mit der Daten beliebiger Größe auf Werte fester Größe abgebildet werden können. Die von einer Hashfunktion zurückgegebenen Werte werden Hashwerte, Hashcodes, Digests oder einfach Hashes genannt. Die Werte werden normalerweise zum Indizieren einer Tabelle fester Größe verwendet, die als Hashtabelle bezeichnet wird. Die Verwendung einer Hashfunktion zum Indizieren einer Hashtabelle wird als Hashing oder Scatter-Speicheradressierung bezeichnet.',
+        tip: 'Tippen Sie einfach weiter! Aufgrund des SHA-256-Algorithmus wird jede neue Eingabe zu einem völlig zufälligen Hash führen, selbst wenn die Eingaben sehr ähnlich sind',
+        spoiler: 'Versuchen Sie etwas mit 8 Zeichen.',
+      },
+      hashing_four: {
+        power_of_random_heading: 'Die Macht des Zufalls',
+        power_of_random_paragraph:
+          'Wie in einem vollkommen zufälligen Szenario ist die SHA-256-Hashfunktion wahrscheinlichkeitsmäßig bei jedem Hinzufügen neuer Daten vollkommen zufällig. Wenn Sie den Roman „Krieg und Frieden“ hashen und dann dem Originaltext nur einen zusätzlichen Buchstaben hinzufügen würden, würde dies zu einem völlig anderen Hash führen. Jeder neue Buchstabe ändert den Hash auf vollkommen zufällige Weise. Wenn man bedenkt, dass es in einem Hexadezimalsystem 16 mögliche Buchstaben gibt (0-9 und a-f), wie wahrscheinlich ist es dann, einen Hash zu finden, der mit „0“ beginnt?',
+        tip: 'Können Sie das ausrechnen? Basierend auf 16 möglichen Zeichen pro Ziffer, wie hoch schätzen Sie die Wahrscheinlichkeit ein, einen Hash zu finden, der mit „00“ beginnt? Und wie steht es mit „000“?',
+        spoiler: 'Versuchen Sie etwas, das mit dem Buchstaben „s“ beginnt.',
+      },
+      hashing_six: {
         collision_resistance_heading: 'SHA256 und Kollisionsresistenz',
         collision_resistance_paragraph:
-          'SHA-256 liefert einen 256-Bit-Hash-Wert (64 Zeichen), der eine eindeutige Darstellung der Eingabedaten ist. Es gehört zur Familie der Hash-Funktionen, die auf der Merkle-Damgård-Konstruktion basieren, einer Methode zum Aufbau von Hash-Funktionen aus einfacheren Kompressionsfunktionen. Bei dieser Konstruktion wird die Eingabenachricht in Blöcke fester Größe unterteilt, und ein Verkettungsmechanismus verarbeitet diese Blöcke iterativ, wobei die Ausgabe jedes Blocks mit dem Ergebnis des vorherigen Blocks kombiniert wird. Dieser Prozess wird so lange fortgesetzt, bis die gesamte Nachricht verarbeitet ist und der endgültige Hash-Wert vorliegt. Die robusten Sicherheitseigenschaften und die Kollisionssicherheit von SHA-256 machen es zu einem Eckpfeiler der Datenintegrität und Authentifizierung in der modernen Kryptografie. Weitere Informationen findest Du auf Wikipedia.',
-        tip_one:
-          'Tippe einfach weiter! Aufgrund des SHA256-Algorithmus führt jede neue Eingabe zu einer völlig zufälligen Eingabe, selbst wenn diese Eingaben sehr ähnlich sind',
-        tip_two:
-          "Was glaubest Du, wie hoch die Wahrscheinlichkeit ist, bei 16 möglichen Zeichen pro Ziffer einen Hash zu finden, der mit '00' beginnt? Und wie sieht es mit '000' aus? Kannst Du es ausrechnen?",
+          'SHA-256 gibt einen 256-Bit-Hashwert (64 Zeichen) zurück, der eine eindeutige Darstellung der Eingabedaten ist. Es gehört zur Familie der Hashfunktionen, die auf der Merkle-Damgård-Konstruktion basieren, einer Methode zum Erstellen von Hashfunktionen aus einfacheren Komprimierungsfunktionen. Bei dieser Konstruktion wird die Eingabenachricht in Blöcke fester Größe aufgeteilt, und ein Verkettungsmechanismus verarbeitet diese Blöcke iterativ, wobei die Ausgabe jedes Blocks mit dem Ergebnis des vorherigen Blocks kombiniert wird. Dieser Prozess wird fortgesetzt, bis die gesamte Nachricht verarbeitet ist und der endgültige Hashwert erstellt wurde. Die robusten Sicherheitseigenschaften und die Kollisionsresistenz von SHA-256 machen es zu einem Eckpfeiler der Datenintegrität und Authentifizierung in der modernen Kryptografie.',
+        tip: 'In dieser Lektion gibt es keine wirklichen Tipps. Je weiter Sie mit dem Sparen von Satoshi fortfahren, desto weniger werden Sie von uns an die Hand genommen und können die Lösung selbst finden.',
+        spoiler:
+          'Wenn Sie wissen, dass für jedes neue Zeichen ein völlig zufälliger Hash neu berechnet wird, können Sie so lange neue Zeichen hinzufügen, bis Sie mit „00“ oder höher beginnen … oder versuchen Sie es mit dem Wort „Trigonometrie“.',
       },
-      scripting: {
+      scripting_one: {
         hash_libraries_heading: 'Hash-Funktionen',
         hash_libraries_paragraph:
-          'Die Crypto-Bibliothek in Node.js und die Hashlib-Bibliothek in Python sind die Code-Bibliotheken, die die Algorithmen, die wir verwenden werden, in nützliche Werkzeuge für Entwickler umsetzen. Diese Bibliotheken werden gründlich überprüft, um ihre Genauigkeit und Sicherheit zu gewährleisten, da sich viele Menschen auf sie verlassen, um wertvolle und wichtige Systeme zu sichern.',
+          'Die Kryptobibliothek in Node.js und die Hashlib-Bibliothek in Python sind die Codebibliotheken, die die von uns verwendeten Algorithmen in nützliche Tools für Entwickler implementieren. Diese Bibliotheken werden gründlich geprüft, um ihre Genauigkeit und Sicherheit sicherzustellen, da sich viele Menschen auf sie verlassen, um wertvolle und wichtige Systeme zu sichern.',
         nonce_heading: 'Nonce',
         nonce_paragraph:
-          "Ein Nonce, kurz für 'number used once', ist eine Zufalls- oder Halbzufallszahl, die in verschiedenen kryptografischen und rechnerischen Verfahren verwendet wird. Ihr Hauptzweck ist es, Unvorhersehbarkeit einzuführen und sicherzustellen, dass eine bestimmte Operation oder Berechnung nicht einfach wiederholt oder vorhergesagt werden kann. Die Nonce ist entscheidend für die Sicherheit des Bitcoin-Minings, aber darüber werden wir später mehr erfahren...",
+          'Ein Nonce, kurz für „Number used once“, ist eine zufällige oder halbzufällige Zahl, die in verschiedenen kryptografischen und rechnerischen Prozessen verwendet wird. Sein Hauptzweck besteht darin, Unvorhersehbarkeit einzuführen und sicherzustellen, dass eine bestimmte Operation oder Berechnung nicht einfach wiederholt oder vorhergesagt werden kann. Der Nonce ist für die Sicherheit des Bitcoin-Minings von entscheidender Bedeutung, aber darüber werden wir später mehr erfahren …',
         tip_one:
-          'Vergewissere Dich, dass die Eingaben richtig dekodiert ist. Die Hash-Algorithmen geben oft Objekte zurück, die in Bytes dekodiert sind, wir wollen sie aber im Hex-Format lesen können!',
+          'Stellen Sie sicher, dass Sie die Eingaben richtig dekodieren. Die Hash-Algorithmen geben Objekte oft in Bytes dekodiert zurück, aber wir möchten sie im Hex-Format lesen können!',
         tip_two:
-          'Überlege, wie Du eine Funktion erstellen würdest, die so lange ausgeführt wird, bis die Antwort einem bestimmten Wert entspricht',
+          'Überlegen Sie, wie Sie eine Funktion erstellen würden, die so lange ausgeführt wird, bis die Antwort einem bestimmten Wert entspricht',
         tip_three:
-          'Denk daran, Deine Antwort mit <span className="px-1 border-[2px] border-dashed">console.log()</span> oder <span className="px-1 border-[2px] border-dashed">print()</span> einzulggen. Nur so kann unsere IDE versuchen, Deine Antwort zu überprüfen',
+          'Denken Sie daran, Ihre Antwort mit <span className="p-1 font-mono bg-[#0000004D] m-1">console.log()</span> oder <span className="p-1 font-mono bg-[#0000004D] m-1">print()</span> zu protokollieren. Nur so kann unsere IDE versuchen, Ihre Antwort zu validieren.',
       },
-      mining: {
-        mining_heading: 'Mining',
+      mining_one: {
+        mining_heading: 'Bergbau',
         mining_paragraph:
-          "Beim Mining kommen all diese Konzepte zusammen. Bitcoin-Mining ist der Prozess, durch den neue Bitcoins geschaffen und Transaktionen zur Blockchain hinzugefügt werden. Miner konkurrieren darum, komplexe mathematische Rätsel zu lösen, indem sie in jedem Transaktionsblock eine einzigartige, gültige 'Nonce' finden. Dieser 'Proof-of-Work'-Prozess erfordert erhebliche Rechenleistung und Energie, was ihn zu einer sicheren und dezentralen Methode zur Validierung von Transaktionen macht. Erfolgreiche Miner werden mit neu geprägten Bitcoins und Transaktionsgebühren belohnt, und sie spielen eine entscheidende Rolle bei der Aufrechterhaltung der Integrität des Bitcoin-Netzwerks.",
-        difficulty_heading: 'Difficulty',
+          'Beim Mining kommen all diese Konzepte zusammen. Beim Bitcoin-Mining werden neue Bitcoins erstellt und Transaktionen zur Blockchain hinzugefügt. Miner konkurrieren darum, komplexe mathematische Rätsel zu lösen, indem sie in jedem Transaktionsblock einen eindeutigen, gültigen „Nonce“ finden. Dieser Proof-of-Work-Prozess erfordert erhebliche Rechenleistung und Energie und ist somit eine sichere und dezentrale Methode zur Validierung von Transaktionen. Erfolgreiche Miner werden mit neu geprägten Bitcoins und Transaktionsgebühren belohnt und spielen eine entscheidende Rolle bei der Aufrechterhaltung der Integrität des Bitcoin-Netzwerks.',
+        difficulty_heading: 'Schwierigkeit',
         difficulty_paragraph:
-          'Die Mining-Schwierigkeit sorgt dafür, dass zwischen jedem neuen Block durchschnittlich 10 Minuten vergehen.',
+          'Die Mining-Schwierigkeit ermöglicht es, dass der Block zwischen jedem neuen Block durchschnittlich 10 Minuten lang bestehen bleibt.',
+        spoiler:
+          'Nichts zu verraten! Lesen Sie einfach diese Lektion durch. In zukünftigen Lektionen werden Sie weitere Gelegenheiten haben, Ihr Wissen über den Bergbau unter Beweis zu stellen!',
       },
     },
   },
   chapter_three: {
-    title: 'Die 51% Attacke',
+    title: 'Der 51%-Angriff',
     paragraph_one:
-      'Du gibst die Internetadresse eines Blockexplorers ein und siehst, dass die Blöcke wieder im Abstand von zehn Minuten entstehen. Irgendwie schläft Holokatze trotz oder durch den Lärm der Maschinen.',
-    paragraph_two:
-      '—Aber irgendetwas stimmt nicht. Die Blöcke sind leer, und die Transaktionen werden nicht verarbeitet. Hast Du einen Fehler gemacht? Kann das ein Zufall sein? Auf dem Bildschirm erscheint eine weitere Nachricht, die die Holokatze aufweckt. Das ist kein Zufall.',
+      'Sie geben die Adresse eines Block-Explorers ein und sehen, dass die Blöcke wieder im Zehn-Minuten-Takt vorliegen. Irgendwie schläft Holocat trotz des Lärms aller ASICs.',
+    paragraph_two: 'Katzen. Was kann man tun?',
+    paragraph_three:
+      'Allerdings stimmt etwas nicht. Die Blöcke sind leer und Transaktionen werden nicht verarbeitet. Haben Sie einen Fehler gemacht? Könnte das ein Zufall sein? Eine weitere Meldung erscheint auf dem Computerbildschirm und weckt Holocat.',
+    paragraph_four: 'Das ist kein Zufall.',
     intro_one: {
-      title: 'Es aus hashen',
+      title: 'Einleitung',
+      nav_title: 'Die Sache ausdiskutieren',
       paragraph_one:
-        '—SATOSHI NAKAMOTO: “He, Du! Ja, Du! Erinnerst Du dich an mich? Bitcoin ist unter einer 51%-Attacke! Vanderpoole hat einen Virus benutzt, um bestehende Mining-Pools für seine Ziele zu manipulieren. Er benutzt sie, um leere Blöcke zu schürfen, um das Bitcoin-Ökosystem als Geisel zu halten und die Leute zu zwingen, die Erhöhung der Bitcoinmenge zu unterstützen.” – Satoshi Nakamoto',
+        '—SATOSHI NAKAMOTO: „Hey, du! Ja, du! Erinnerst du dich an mich? Bitcoin wird gerade von einem 51%-Angriff getroffen! Nachdem du diese Mining-Geräte online gebracht hast, hat Vanderpoole BitReys ASICs wieder eingeschaltet und schürft leere Blöcke. Das Problem ist, dass es nicht nur seine Maschinen sind. Er hat eine Hintertür in der Standard-ASIC-Firmware verwendet, um bestehende Miner mit einem Virus zu infizieren, der sie daran hindert, etwas anderes als leere Blöcke zu schürfen. Er versucht, das Bitcoin-Ökosystem als Geisel zu nehmen und die Leute zu zwingen, die Idee einer Erhöhung des Bitcoin-Angebots zu unterstützen. Tu etwas, Dingdong!“',
       paragraph_two:
-        '—Der alte Computer hustet ein wenig und produziert dann ein Bündel von Daten, in etwas das sich "Excel-Tabelle" nennt: Kontaktinformationen für einige der größten Bitcoin-Pool-Betreiber und ein Patch für das Virus, der BitRey die Kontrolle über sie ermöglicht. Schicke die Datei an die Pool-Betreiber, damit sie die Kontrolle über ihre Rechner zurückerlangen und sich Deinem Kampf gegen BitRey anschließen können.',
+        'Der alte Computer stößt eine Staubwolke aus und produziert dann einen Datenhaufen, eine sogenannte „Tabelle“, die Kontaktinformationen einiger der größten Bitcoin-Miner sowie einen Patch für den Virus enthält. Je schneller Sie den Patch an andere Miner weitergeben können, desto schneller können diese die Kontrolle über ihre Maschinen zurückerlangen und sich Ihrem Kampf gegen BitRey anschließen.',
       paragraph_three:
-        'HOLOKATZE: “Wir haben noch mehr Arbeit vor uns. Nun, Du hast noch mehr Arbeit vor dir. Ich werde durch Wände rennen und Mäuse erschrecken.”',
+        '—HOLOCAT: „Wir haben noch mehr zu tun. Also, du hast noch mehr zu tun. Ich werde durch Wände rennen und Mäuse erschrecken.“',
     },
-
     solo_one: {
-      title: 'Du vs. Bitrey',
-      step_zero_heading: 'Lass uns dem Ganzen eine Chance geben',
+      title: 'Sie gegen BitRey',
+      nav_title: 'Alleine schürfen',
+      step_zero_heading: 'Versuchen wir es',
       step_zero_paragraph_one:
-        'Während Du auf die Poolbetreiber wartest, die Du kontaktiert hast, beschließst Du, BitRey auf eigene Faust zu bekämpfen. Hier siehst Du, wie Deine Hash-Rate ausfällt. Was glaubst Du, wie es laufen wird?',
-      step_one_heading: 'Auf in die Schlacht',
+        'Während Sie auf die Miner warten, die Sie kontaktiert haben, beschließen Sie zu sehen, ob BitRey allein abgewehrt werden kann. Vielleicht können Sie den leeren Blöcken auch ohne Hilfe ein Ende bereiten. Hier sehen Sie, wie sich Ihre Hash-Rate entwickelt. Wie wird das Ihrer Meinung nach laufen?',
+      step_one_heading: 'Jetzt geht’s los',
       step_one_paragraph_one:
-        'Wir schürfen jetzt 100 Blöcke, um zu sehen, wie viele Blöcke Du und wie viele BitRey schürfen wird.',
-      step_two_heading: 'Das ist nicht so gut gelaufen!',
+        'Wir bauen jetzt 100 Blöcke ab, um zu sehen, wie gut Sie im Vergleich zu BitRey abschneiden.',
+      step_two_heading: 'Das ist nicht gut gegangen!',
       step_two_paragraph_one:
-        'Krise, wir haben einfach nicht genug Hashpower, um mit BitRey und den virengesteuerten Pools konkurrieren zu können. Mal sehen, ob wir BitRey für die nächsten 100 Blöcke mit den anderen Poolbetreibern besiegen können. Bitcoin läuft schon seit über einem Jahrhundert und wird nicht kampflos untergehen.',
+        'Huch, wir haben einfach nicht genug Hashpower, um mit BitRey und den virusgesteuerten Minern zu konkurrieren. Mal sehen, ob wir BitRey mit den anderen Minern für die nächsten 100 Blöcke besiegen können. Bitcoin läuft seit über einem Jahrhundert und wird nicht kampflos untergehen.',
     },
-
     pool_one: {
-      title: 'Pool vs. BitRey',
+      title: 'Pool gegen BitRey',
+      nav_title: 'Freunde finden',
       waiting_screen_heading: 'Wir brauchen Unterstützung!',
       waiting_screen_paragraph_one:
-        'Deine Miner im Lagerhaus haben alleine keine Chance. Wenn Du Deine Hashpower mit anderen Pools kombinierst, kannst Du den Angriff vielleicht abwehren.',
+        'Ihre Miner im Lager haben keine Chance. Wenn Sie Ihre Hash-Power mit der anderer Miner kombinieren, können Sie dem Angriff von BitRey möglicherweise standhalten.',
       waiting_screen_paragraph_two:
-        'Lass uns warten, bis die anderen Deinem Pool beitreten, damit wir unsere Kräfte bündeln können. Holokatze besteht darauf, dass der Pool nach ihr benannt wird.',
+        'Warten wir, bis sich die anderen Ihrer Sache anschließen, damit wir unsere Kräfte bündeln können.',
       waiting_button: 'Warten...',
-      continue_button: "Los geht's",
+      continue_button: 'Lass uns gehen',
     },
-
     pool_two: {
-      title: 'Pool vs. BitRey',
-      step_zero_heading: 'Und los geht es',
+      title: 'Pool gegen BitRey',
+      nav_title: 'Gemeinsam schürfen',
+      step_zero_heading: "Auf geht's",
       step_zero_paragraph_one:
-        'Wenn Du Deine Hashrate mit den anderen Poolbetreibern kombinierst, kannst Du gegen BitRey bestehen.',
+        'Können Sie gegen BitRey bestehen, indem Sie Ihre Hashrate mit der anderer Miner bündeln?',
       step_two_heading: 'Eine weitere Niederlage!',
       step_two_paragraph_one:
-        'Irgendetwas ist faul. Nur Hash Hoppers haben Blöcke gefunden. Woran könnte das liegen?',
+        'Irgendetwas stimmt nicht. Nur Hashrate Hoppers haben Blöcke gefunden. Was glauben Sie, woran das liegen könnte?',
     },
-
     coop_one: {
-      title: 'Coop vs. BitRey',
-      heading: 'Irgendetwas stimmt hier nicht.',
+      title: 'Coop gegen BitRey',
+      nav_title: 'Da ist etwas schiefgelaufen',
+      heading: 'Irgendetwas stimmt noch nicht ganz.',
       paragraph_one:
-        'Hash Hoppers, derjenige mit der größten Hashpower, findet alle eure Blöcke, aber die anderen finden nichts.',
+        'Hashrate Hoppers, die mit der größten Hash-Leistung, finden alle Ihre Blöcke, andere finden jedoch nichts.',
       paragraph_two:
-        'Das Problem ist, dass jeder beim Mining die gleichen Nonces prüft. Wie könnte man sich besser koordinieren?',
+        'Das Problem ist, dass jeder beim Mining dieselben Nonces prüft. Wie lässt sich das besser koordinieren?',
       paragraph_three:
-        ' Du beschließt bei der Vorbereitung der Blockdaten für jeden von euch eine eindeutige Kennung in die "extraNonce" zu setzen, um doppelten Aufwand zu vermeiden.',
+        'Sie entscheiden sich, bei der Vorbereitung der Blockdaten für jeden von Ihnen eine eindeutige Kennung im „extraNonce“ zu platzieren, um doppelten Aufwand zu vermeiden.',
     },
-
     coop_two: {
-      title: 'Coop vs. BitRey',
-      heading: 'Was ist die extraNonce?',
+      title: 'Coop gegen BitRey',
+      nav_title: 'Der extraNonce',
+      heading: 'Was ist der ExtraNonce?',
       paragraph_one:
-        'Für das Stratum-Mining-Pool-Protokoll (nicht das Bitcoin-Protokoll) enthält die Coinbase-Transaktion auch eine so genannte "extra nonce". Bei der Bereitstellung der Blockdaten für die Miner teilen die Mining-Pools die Extra-Nonce in zwei Teile auf: "extranonce1" und "extranonce2".',
+        'Für das Stratum-Mining-Pool-Protokoll (nicht das Bitcoin-Protokoll) hat die Coinbase-Transaktion auch etwas, das „Extra-Nonce“ genannt wird. Wenn Mining-Pools den Minern die Blockdaten bereitstellen, teilen sie den Extra-Nonce in zwei Teile auf: „Extranonce1“ und „Extranonce2“.',
       paragraph_two:
-        'Die Aufteilung der zusätzlichen Nonce in zwei Teile hat mehrere Vorteile:',
+        'Das Aufteilen des zusätzlichen Nonce in zwei Teile hat mehrere Vorteile:',
       list_one:
-        'Es verhindert, dass Poolteilnehmer die gleiche Arbeit verrichten.',
+        'Es verhindert, dass Pool-Teilnehmer die gleiche Arbeit verrichten.',
       list_two:
-        'Es ermöglicht dem Pool, dieselbe Transaktionsliste an alle Miner zu senden, die sich zusammenschließen. Das bedeutet, dass die Miner lediglich "extranonce2" aktualisieren müssen und die im Block enthaltenen Transaktionen nicht ändern müssen.',
+        'Dadurch kann der Pool die gleiche Transaktionsliste an alle Miner senden, die gemeinsam einen Pool bilden. Das bedeutet, dass die Miner lediglich „extranonce2“ aktualisieren müssen und die im Block enthaltenen Transaktionen nicht ändern dürfen.',
       list_three:
-        'Die "extranonce1" ermöglicht es den Pools, den anteilig, geleisteten Beitrag pro Miner zu identifizieren und zu bestimmen, da jeder Miner seine eigene "extranonce1" erhält.',
+        'Mit „Extranonce1“ können Pools Anteilsbeiträge identifizieren und bestimmen, da jeder Miner sein eigenes „Extranonce1“ erhält.',
       paragraph_three:
-        ' Miner die Hashpower zu einem Pool beitragen, aktualisieren die "extranonce2" und probieren die eigentliche Nonce im Block-Header durch. Wenn sie keine Lösung finden, wiederholen sie diesen Vorgang mit einer anderen "extranonce2", bis sie eine Lösung finden.',
+        'Miner, die zu einem Pool beitragen, aktualisieren „extranonce2“ und durchlaufen den Nonce im Blockheader. Wenn sie keine Lösung finden, wiederholen sie den Vorgang mit einem anderen „extranonce2“, bis sie eine finden.',
       paragraph_four:
-        'Versuchen wir noch einmal die Arbeit aufzuteilen, jedoch dieses Mal nach der neuen Methode.',
+        'Versuchen wir noch einmal, die Arbeit mit dieser Methode aufzuteilen.',
     },
-
     coop_three: {
-      title: 'Coop vs. BitRey',
-      step_zero_heading: 'Noch einmal...',
+      title: 'Coop gegen BitRey',
+      nav_title: 'Bergbau mit Teamarbeit',
+      step_zero_heading: 'Ein Mal noch...',
       step_zero_paragraph_one:
-        'Mal sehen, ob wir jetzt mit unserer verbesserten Strategie der Aufteilung des Nonce-Raums eine Chance gegen BitRey haben.',
+        'Mal sehen, ob wir mit unserer verbesserten Strategie der Aufteilung des Nonce-Raums jetzt eine Chance gegen BitRey haben.',
       step_two_heading: 'Du hast es geschafft!',
       step_two_paragraph_one:
-        'Gemeinsam konntest Du und die anderen Pool-Betreiber den Versuch von BitRey, das Netzwerk zu übernehmen, stoppen.',
+        'Gemeinsam haben Sie und die anderen Miner den Versuch von BitRey, das Netzwerk zu übernehmen, abgewehrt.',
     },
-
     split_one: {
-      title: 'Die Belohnung aufteilen',
-      heading: 'Schön gemacht.',
+      title: 'Belohnungen aufteilen',
+      nav_title: 'Den gerechten Anteil aufteilen',
+      heading: 'Gut gemacht.',
       paragraph_one:
-        'Du hast nicht nur das Netzwerk gegen BitRey verteidigt, sondern auch Bitcoin als Belohnung verdient!',
+        'Sie haben nicht nur das Netzwerk gegen BitRey verteidigt, sondern als Belohnung auch noch Bitcoins erhalten!',
       paragraph_two:
-        'Für jeden Block, der geschürft wird, erhält der Miner eine Belohnung in Bitcoin. Wenn mehr als eine Person an dem Block gearbeitet hat, erhält die Gruppe der Miner (Mining-Pool) eine Belohnung, die sie sich teilen.',
+        'Für jeden Block, der geschürft wird, erhält der Schürfer eine Belohnung in Bitcoin. Wenn mehr als eine Person an dem Block gearbeitet hat, erhält die Gruppe der Schürfer (Schürfpool) eine Belohnung, die sie teilen kann.',
       paragraph_three: 'Diese Belohnung besteht aus zwei Dingen:',
-      list_one: 'Gebühren für alle Transaktionen des Blocks',
-      list_two: 'die Blockbelohnung',
+      list_one: 'Gebühren für alle Transaktionen im Block',
+      list_two: 'die Blocksubvention',
       paragraph_four:
-        'Du und Deine Miner-Freunde haben insgesamt 6,1 Bitcoin verdient und suchen nach einer guten Möglichkeit, diese aufzuteilen. Es sollte danach aufgeteilt werden, wie viel Arbeit jeder von euch investiert hat.',
+        'Du und deine Miner-Freunde haben insgesamt 7,41 Bitcoin verdient und suchen nach einer guten Möglichkeit, das Geld aufzuteilen. Die Aufteilung sollte nach dem Arbeitsaufwand jedes Einzelnen erfolgen.',
       paragraph_five:
-        'Mining-Pools lösen dieses Problem, indem sie verfolgen, wie viele Teillösungen jeder Miner erzeugt hat. Ein Pool weist jedem Miner eine Mindestschwierigkeit (niedriger als die Blockschwierigkeit) auf der Grundlage seiner Hashpower zu. Alle paar Sekunden findet ein Miner eine dieser leichteren Lösungen und benachrichtigt den Pool. Der Pool verfolgt dann alle eingereichten Anteile und teilt die Blockbelohnungen entsprechend auf.',
-      paragraph_six: 'Schauen wir uns das Ganze in Aktion an.',
+        'Mining-Pools lösen dieses Problem, indem sie verfolgen, wie viele Teillösungen jeder Miner generiert hat. Ein Pool weist jedem Miner basierend auf seiner Hash-Leistung eine Mindestschwierigkeit zu (niedriger als die Blockschwierigkeit). Alle paar Sekunden findet ein Miner eine dieser einfacheren Lösungen und benachrichtigt den Pool. Der Pool verfolgt dann alle übermittelten Anteile und teilt die Blockbelohnungen entsprechend auf.',
+      paragraph_six: 'Sehen wir uns das in Aktion an.',
     },
-
     split_two: {
-      title: 'Die Belohunung aufteilen',
-      step_zero_heading: 'Überprüfen wir wie viel jeder geleistet hat',
+      title: 'Belohnungen aufteilen',
+      nav_title: 'Belohnungen berechnen',
+      step_zero_heading: 'Lassen Sie uns die Bemühungen aller überprüfen',
       step_zero_paragraph:
-        'Wir werden den Kampf erneut durchführen. Diesmal werden wir uns nur auf unseren Pool konzentrieren, insbesondere auf die Anzahl der Teillösungen, die jeder Miner gefunden hat.',
-      step_two_heading: 'Rechnen wir mal nach',
+        'Wir werden den Kampf noch einmal austragen. Dieses Mal werden wir uns nur auf unseren Pool konzentrieren, insbesondere auf die Anzahl der Teillösungen, die jeder Miner gefunden hat.',
+      step_two_heading: 'Rechnen wir es mal nach',
       step_two_paragraph:
-        'Schaue Dir die obigen Zahlen an und überlege, ob Du einen fairen Weg finden könntest, die Belohnungen aufzuteilen. Hast Du es herausgefunden? Gehen wir es Schritt für Schritt durch',
-      step_three_heading: 'Hashrate in Prozent',
+        'Schauen Sie sich die Zahlen oben an und überlegen Sie, ob Sie eine faire Aufteilung der Belohnungen finden. Sie haben es herausgefunden? Dann gehen wir es Schritt für Schritt durch.',
+      step_three_heading: 'Hash-Rate-Prozentsatz',
       step_three_paragraph:
-        'Wie Du weißt, stellt dies die Menge an Arbeit dar, die jeder Miner geleistet hat, um Blöcke zu finden. Aber der Mining-Pool hat keine Möglichkeit, diese Menge zu kennen oder zu messen, da die Miner nur erfolgreiche Lösungen weiterleiten.',
-      step_four_heading: 'Gefundene Blöcke in Prozent',
+        'Wie Sie wissen, stellt dies den Arbeitsaufwand dar, den jeder Miner in die Suche nach Blöcken investiert hat. Der Mining-Pool hat jedoch keine Möglichkeit, diese Zahl zu kennen oder zu messen, da Miner nur erfolgreiche Lösungen weiterleiten.',
+      step_four_heading: 'Prozentsatz gefundener Blöcke',
       step_four_paragraph:
-        'Die Chance, einen Block zu finden, ist sehr gering, da sie viel mit Glück zu tun hat. Vor allem in Szenarien mit einigen extrem leistungsstarken Minern kann es vorkommen, dass die wirklich kleinen Miner zwar Arbeit leisten, aber keine Blöcke finden.',
-      step_five_heading: 'Teillösungen in Prozent',
+        'Die Chance, einen Block zu finden, ist sehr gering, da sie stark vom Glück abhängt. Insbesondere in Szenarien mit einigen extrem leistungsstarken Minern können die wirklich kleinen Miner zwar Arbeit leisten, aber nie Blöcke finden.',
+      step_five_heading: 'Prozentsatz der Teillösung',
       step_five_paragraph:
-        'Dieser Wert wird funktionieren. Die Miner melden diese Lösungen für einfache Probleme regelmäßig an die Pools. So können die Pools ziemlich genau messen, wie viel Arbeit jeder Pool geleistet hat.',
-      step_six_heading: 'Die Belohnung aufteilen',
+        'Nun funktioniert diese Zahl. Miner melden diese Lösungen für einfachere Probleme regelmäßig an Pools. Dadurch können Pools ziemlich genau messen, wie viel Arbeit jeder Miner geleistet hat.',
+      step_six_heading: 'Aufteilung der Belohnungen',
       step_six_paragraph:
-        'Jetzt können wir die Belohnung von 6,1 Bitcoin nehmen und sie entsprechend dem Prozentsatz der Teillösungen jedes Pools aufteilen. Herzlichen Glückwunsch!',
+        'Jetzt können wir die Belohnungen von 7,41 Bitcoin nehmen und sie entsprechend dem Prozentsatz der Teillösungen jedes Pools aufteilen. Herzlichen Glückwunsch!',
     },
-
     outro_one: {
-      title: 'Outro',
-      heading: 'Nimm das, Vanderpoole! ',
+      title: 'Andere',
+      nav_title: 'Kapitel abgeschlossen',
+      heading: 'Nimm das, Vanderpoole!',
       paragraph_one:
-        'Gute Arbeit! Du und Deine Mitstreiter waren in der Lage Vanderpooles 51% Attacke abzuwehren indem ihr eure Ressourcen gebündelt habt. Es werden keine leeren Blöcke mehr eingereicht, und es sieht so aus, als hätte er aufgegeben.',
+        'Gute Arbeit! Sie und die anderen Miner konnten Vanderpooles 51%-Angriff abwehren, indem Sie Ihre Ressourcen bündelten. Es werden keine leeren Blöcke mehr übermittelt und es sieht so aus, als hätte er aufgegeben.',
       paragraph_two:
-        'Es ist Zeit, Deine Belohnungen zu ernten! Gehe zum nächsten Kapitel, um dir Deine Bitcoin abzuholen.',
+        'Es ist Zeit, Ihre Belohnungen zu ernten! Gehen Sie zum nächsten Kapitel, um Ihr Bitcoin abzuheben.',
     },
     resources: {
       solo: {
-        hashrate_heading: 'Mining Hashrate',
+        hashrate_heading: 'Hashrate beim Mining',
         hashrate_paragraph:
-          'Die Hashrate eines einzelnen Miners bezieht sich auf die Rechenleistung, die er zum Mining-Prozess des Bitcoin-Netzwerks beiträgt. Es ist die Rate, mit der ihre Mining-Hardware die notwendigen mathematischen Berechnungen durchführen kann, um neue Blöcke zu schürfen. Die Hash-Rate eines einzelnen Miners wird in der Regel in Hashe pro Sekunde oder in Terahashe, also einer Billion Hashe pro Sekunde (TH/s), gemessen, je nach Umfang des Mining-Betriebs und den Fähigkeiten der Mining-Hardware.',
+          'Die Hashrate eines einzelnen Miners bezieht sich auf die Rechenleistung, die er zum Mining-Prozess des Bitcoin-Netzwerks beiträgt. Es ist die Rate, mit der seine Mining-Hardware die notwendigen mathematischen Berechnungen durchführen kann, um zu versuchen, neue Blöcke zu minen. Die Hashrate eines einzelnen Miners wird normalerweise in Hashes pro Sekunde oder in Terahashes, einer Billion Hashes pro Sekunde (TH/s), gemessen, abhängig vom Umfang seines Mining-Vorgangs und den Fähigkeiten seiner Mining-Hardware.',
       },
       pool: {
-        pool_heading: 'Mining Pool',
+        pool_heading: 'Bergbaubecken',
         pool_paragraph:
-          'Ein Mining-Pool spielt eine zentrale Rolle beim Mining von Kryptowährungen und bietet dem einzelnen Miner mehrere wichtige Vorteile. Durch die Bündelung der Rechenleistung und der Ressourcen vieler Teilnehmer erhöhen Mining-Pools die Chancen auf ein erfolgreiches Mining neuer Blöcke, was zu vorhersehbareren und beständigeren Einnahmen führt. Sie bieten Minern auch eine Plattform für den Zugang zu fortschrittlicher Mining-Ausrüstung und fachkundiger Unterstützung, wodurch die Einstiegshürden gesenkt und die Wettbewerbsbedingungen angeglichen werden. Darüber hinaus helfen Mining-Pools bei der effizienten Verteilung von Belohnungen und stellen sicher, dass Miner ihren gerechten Anteil für ihre Beiträge erhalten, wodurch das Mining von Kryptowährungen für eine breitere Teilnehmergemeinschaft zugänglich, stabil und finanziell lohnend wird.',
+          'Ein Mining-Pool spielt eine zentrale Rolle beim Kryptowährungs-Mining und bietet den einzelnen Minern mehrere wichtige Vorteile. Indem sie die Rechenleistung und Ressourcen vieler Teilnehmer bündeln, erhöhen Mining-Pools die Chancen, neue Blöcke erfolgreich zu minen, was zu vorhersehbareren und konsistenteren Einnahmen führt. Sie bieten Minern auch eine Plattform für den Zugriff auf fortschrittliche Mining-Ausrüstung und Expertenunterstützung, wodurch die Eintrittsbarrieren gesenkt und gleiche Wettbewerbsbedingungen geschaffen werden. Darüber hinaus helfen Mining-Pools bei der effizienten Verteilung der Belohnungen und stellen sicher, dass die Miner ihren gerechten Anteil für ihre Beiträge erhalten. Dadurch wird das Kryptowährungs-Mining für eine breitere Teilnehmergemeinschaft zugänglich, stabil und finanziell lohnend.',
       },
       coop: {
-        distribution_heading: 'Arbeitsauf-/verteilung',
+        distribution_heading: 'Stellenverteilung',
         distribution_paragraph:
-          "Mining-Pools treffen Vorkehrungen, um sicherzustellen, dass ihre Teilnehmer nicht die gleiche Nonce für denselben Block schürfen. Dies ist wichtig, weil beim Bitcoin-Mining-Prozess die Miner darum konkurrieren, eine Nonce zu finden, die zu einem gültigen Block führt. Würden zwei Miner desselben Pools gleichzeitig an derselben Nonce arbeiten, wäre das ineffizient, und nur einer der beiden würde die Blockbelohnung erhalten. Um dies zu verhindern, verwenden Mining-Pools einen Prozess namens 'Arbeitszuweisung' oder 'Arbeitsauf-/verteilung', um die Arbeit effizient zu verteilen. Mining-Pools verteilen die Arbeit an einzelne Miner. Wenn ein neuer Block geschürft werden soll, erstellt der Server des Pools (oder der Betreiber des Pools) einen eindeutigen 'Auftrag' für die Miner. Dieser Auftrag enthält alle Informationen, die für das Mining des Blocks benötigt werden, z. B. die aktuelle Liste der unbestätigten Transaktionen, den Header des vorherigen Blocks und die Zielschwierigkeit.",
-        shares_heading: 'Anteile Einreichen',
+          'Mining-Pools treffen Vorkehrungen, um sicherzustellen, dass ihre Teilnehmer nicht denselben Nonce für denselben Block minen. Dies ist wichtig, da die Miner beim Bitcoin-Mining-Prozess darum konkurrieren, einen Nonce zu finden, der zu einem gültigen Block führt. Wenn zwei Miner im selben Pool gleichzeitig an demselben Nonce arbeiten würden, wäre dies ineffizient und nur einer würde die Blockbelohnung erhalten. Um dies zu verhindern, verwenden Mining-Pools einen Prozess namens „Arbeitszuweisung“ oder „Jobverteilung“, um die Arbeit effizient zu verteilen. Mining-Pools verteilen die Arbeit an einzelne Miner oder Teilnehmer. Wenn ein neuer Block gemined werden muss, erstellt der Server des Pools (oder der Poolbetreiber) einen einzigartigen „Job“ für die Miner. Dieser Job enthält alle Informationen, die zum Mining des Blocks erforderlich sind, wie z. B. die aktuelle Liste der unbestätigten Transaktionen, den Header des vorherigen Blocks und die Zielschwierigkeit.',
+        shares_heading: 'Einreichen von Freigaben',
         shares_paragraph:
-          "Die Miner arbeiten an den ihnen zugewiesenen Aufgaben und versuchen ständig, die richtige Nonce zu finden. Wenn ein Miner glaubt, eine Lösung zu haben, sendet er einen so genannten 'Share' (Anteil) an den Pool-Server. Dieser Anteil zeigt, dass der Miner aktiv an der Lösung des Problems arbeitet. Shares sind viel leichter zu finden als die eigentliche Lösung, aber sie dienen als Beweis für die Bemühungen des Miners.",
+          'Miner arbeiten an diesen zugewiesenen Aufgaben und versuchen ständig, den richtigen Nonce zu finden. Wenn ein Miner glaubt, eine Lösung zu haben, übermittelt er einen sogenannten „Share“ an den Pool-Server. Dieser Share zeigt, dass der Miner aktiv an der Lösung des Problems arbeitet. Shares sind viel einfacher zu finden als die eigentliche Lösung, dienen aber als Beweis für die Bemühungen des Miners.',
       },
       split: {
         payout_heading: 'Auszahlungsschemata',
         payout_subheading:
-          'Ein Mining-Pool kann die Block-Belohnungen auf verschiedene Arten verteilen, die sich in einigen subtilen, aber wichtigen Punkten unterscheiden:',
-        pps_heading: 'Pay-Per-Share (PPS)',
+          'Ein Mining-Pool kann die Blockbelohnungen auf verschiedene Weise verteilen. Die Unterschiede liegen in einigen subtilen, aber wesentlichen Punkten:',
+        pps_heading: 'Bezahlung pro Aktie (PPS)',
         pps_paragraph:
-          'Bei PPS erhalten die Miner eine feste Auszahlung für jeden gültigen Anteil, den sie einreichen, unabhängig davon, ob der Pool erfolgreich einen Block schürft oder nicht. Dieses System bietet Minern ein gleichmäßiges und vorhersehbares Einkommen, was es zu einer bevorzugten Wahl für diejenigen macht, die Wert auf ein beständiges Einkommen legen. PPS minimiert die Schwankungen bei den Belohnungen, da die Miner für ihre Arbeit auf einer Pro-Share-Basis entschädigt werden, was eine zuverlässige Einkommensquelle in der Welt des volatilen Kryptowährungs-Minings darstellt. PPS kann jedoch eine Gebühr von den Einnahmen der Miner abziehen, wenn der Pool einen Block nicht erfolgreich schürft. Diese Gebühr soll die Betriebskosten decken und das Risiko für den Poolbetreiber mindern, falls innerhalb eines bestimmten Zeitrahmens keine Blöcke geschürft werden. Bei traditionellen PPS erhalten die Miner eine geringere Auszahlung, wenn der Pool in Schwierigkeiten gerät.',
+          'Bei PPS erhalten Miner eine feste Auszahlung für jeden gültigen Anteil, den sie einreichen, unabhängig davon, ob der Pool erfolgreich einen Block abbaut oder nicht. Dieses System bietet Minern ein stabiles und vorhersehbares Einkommen und ist daher die bevorzugte Wahl für diejenigen, die Wert auf Beständigkeit bei ihren Einnahmen legen. PPS minimiert die Varianz bei den Belohnungen, da Miner für ihre Arbeit pro Anteil entlohnt werden und so eine zuverlässige Einnahmequelle in der Welt des volatilen Kryptowährungs-Minings bieten. Allerdings kann PPS eine Gebühr von den Einnahmen des Miners abziehen, wenn der Pool keinen Block erfolgreich abbaut. Diese Gebühr soll die Betriebskosten decken und das Risiko für den Poolbetreiber mindern, falls innerhalb eines bestimmten Zeitraums keine Blöcke abbaut werden. Bei herkömmlichem PPS erhalten Miner eine reduzierte Auszahlung, wenn der Pool in Schwierigkeiten gerät.',
         pplns_heading: 'Pay-Per-Last-N-Shares (PPLNS)',
         pplns_paragraph:
-          'PPLNS berücksichtigt den Beitrag eines Miners über ein bestimmtes Zeitfenster der letzten N Anteile. Die Miner werden auf der Grundlage der Anzahl und des Schwierigkeitsgrads der Anteile, die sie innerhalb dieses Zeitfensters eingereicht haben, bezahlt. PPLNS ermutigt Miner, im Pool aktiv zu bleiben, da es eine beständige Beteiligung belohnt und das Risiko von Pool-Hopping-Strategien verringert. Miner erhalten Auszahlungen, wenn der Pool erfolgreich einen Block schürft, und die Belohnungen werden proportional zu ihren jüngsten Beiträgen verteilt, wodurch ein fairer und leistungsorientierter Ansatz für das Einkommen im Mining-Ökosystem geschaffen wird.',
-        pps_plus_heading: 'Pay Per Share + (PPS+)',
+          'PPLNS berücksichtigt den Beitrag eines Miners über einen bestimmten Zeitraum der letzten N Anteile. Miner werden basierend auf der Anzahl und Schwierigkeit der Anteile bezahlt, die sie innerhalb dieses Zeitraums eingereicht haben. PPLNS ermutigt Miner, im Pool aktiv zu bleiben, da es eine konstante Teilnahme belohnt und dazu beiträgt, das Risiko von Pool-Hopping-Strategien zu verringern. Miner erhalten Auszahlungen, wenn der Pool erfolgreich einen Block abbaut, und die Belohnungen werden proportional zu ihren jüngsten Beiträgen verteilt, was einen fairen und leistungsorientierten Ansatz zum Verdienen im Mining-Ökosystem bietet.',
+        pps_plus_heading: 'Vergütung pro Aktie + (PPS+)',
         pps_plus_paragraph:
-          'PPS+ bietet Minern eine feste Zahlung für jeden Anteil, den sie zu den Mining-Bemühungen des Pools beitragen. Allerdings enthält PPS+ in der Regel einen zusätzlichen Bonus oder eine Prämie als Anreiz für Miner, die zur Stabilität und Zuverlässigkeit des Pools beitragen. Dieser Bonus soll Schürfer dazu ermutigen, im Pool aktiv zu bleiben und eine langfristige Beteiligung zu fördern. PPS+ bietet Minern ein beständiges und vorhersehbares Einkommen, während der zusätzliche Bonus es zu einer attraktiven Option für diejenigen macht, die sowohl Zuverlässigkeit als auch zusätzliche Belohnungen in der Welt des Kryptowährungs-Minings suchen.',
-        fpps_heading: 'Full Pay Per Share (FPPS)',
+          'PPS+ bietet Minern eine feste Zahlung für jeden Anteil, den sie zu den Mining-Bemühungen des Pools beitragen. Allerdings beinhaltet PPS+ normalerweise einen zusätzlichen Bonus oder eine Prämie als Anreiz für Miner, die zur Stabilität und Zuverlässigkeit des Pools beitragen. Dieser Bonus soll Miner dazu ermutigen, im Pool aktiv zu bleiben und eine langfristige Teilnahme zu fördern. PPS+ bietet Minern ein beständiges und vorhersehbares Einkommen, während der zusätzliche Bonus es zu einer attraktiven Option für diejenigen macht, die sowohl Zuverlässigkeit als auch zusätzliche Belohnungen in der Welt des Kryptowährungs-Minings suchen.',
+        fpps_heading: 'Volle Bezahlung pro Aktie (FPPS)',
         fpps_paragraph:
-          'Bei Full PPS erhalten die Miner eine feste Auszahlung für jeden Anteil, den sie an den Pool abgeben, unabhängig davon, ob der Pool einen Block erfolgreich schürft oder nicht. Dieser Ansatz bietet Minern ein stetiges und vorhersehbares Einkommen und ist damit eine attraktive Wahl für alle, die Wert auf ein verlässliches Einkommen legen. Im Gegensatz zum traditionellen PPS stellt das Full PPS sicher, dass die Miner die volle Auszahlung für ihre Arbeit erhalten, ohne mögliche Abzüge, auch wenn der Pool gelegentlich Schwierigkeiten hat. Es ist eine stabile und unkomplizierte Methode, die für Miner interessant ist, die ein beständiges Einkommen in der Welt des Kryptowährungs-Minings suchen.',
+          'Bei Full PPS erhalten Miner eine feste Auszahlung für jeden Anteil, den sie an den Pool übermitteln, unabhängig davon, ob der Pool erfolgreich einen Block abbaut oder nicht. Dieser Ansatz bietet Minern ein stabiles und vorhersehbares Einkommen und ist daher eine attraktive Wahl für diejenigen, die Wert auf Zuverlässigkeit bei ihren Einnahmen legen. Im Gegensatz zu herkömmlichem PPS stellt Full PPS sicher, dass Miner ihre volle Auszahlung für ihre geleistete Arbeit ohne mögliche Abzüge erhalten, selbst wenn der Pool gelegentlich auf Schwierigkeiten stößt. Es ist eine stabile und unkomplizierte Methode, die Miner anspricht, die in der Welt des Kryptowährungs-Minings nach einem konstanten Einkommen suchen.',
       },
     },
   },
-
   chapter_four: {
-    title: 'Hol dir Deine 1.61 Bitcoin',
+    title: 'Fordern Sie Ihre 1,61 Bitcoin an',
     paragraph_one:
-      'Puh, das war knapp! Du zitterst immer noch nach Deinem Kampf mit BitRey, bist jedoch beruhigt, dass Du und Deine Freunde den Kampf für euch entscheiden konntet.',
+      'Puh, das war knapp! Du zitterst noch vom Kampf mit BitRey, bist aber erleichtert, dass du gewonnen hast.',
     paragraph_two:
-      'Als Du dich an Deinem Schreibtisch niederlässt, atmest Du tief durch und lässt die Ereignisse des Tages Revue passieren. Deine Hände spielen mit einem geheimnisvollen Umschlag und Du fragst dich, wer ihn abgeschickt haben könnte. ',
-
+      'Während Sie sich an Ihren Schreibtisch setzen, atmen Sie tief durch, driften ab und gehen die Ereignisse des Tages in Ihrem Kopf noch einmal durch.',
     intro_one: {
-      title: 'Den Ertrag sichern',
+      title: 'Einleitung',
+      nav_title: 'Sichern der Tasche',
       paragraph_one:
-        'HOLOKATZE: “Einer von uns sollte besser schlafen. Du musst nach Hause gehen und anfangen die Mining-Pools zu kontaktieren. Sie werden mehr darüber wissen wollen, als der Rest der Welt.”',
+        '—HOLOCAT: „Einer von uns sollte besser schlafen. Du musst anfangen, den Rest der Bergleute zu kontaktieren. Sie werden noch mehr wissen wollen als die ganze Welt.“',
       paragraph_two:
-        'Während Du dich an Deinem TMY92-P Hover Desk niederlässt, lässt Du die Ereignisse des Tages Revue passieren. Vanderpoole. BitRey. Die Enthüllung, dass Mining-Pools nie zugestimmt haben, aus Protest ihre Maschinen auszuschalten. Könnte das alles wahr sein? War das alles inszeniert? Und wie lange sollst Du dich noch um diese Katze kümmern?',
+        'Während Sie sich an Ihrem ButtLift Hover Desk niederlassen, gehen Sie die Ereignisse des Tages noch einmal durch. Vanderpoole. BitRey. Die Enthüllung, dass die Bergleute nie einer Protestschließung zugestimmt haben. Könnte das alles wahr sein? War das alles inszeniert? Und wie lange sollen Sie sich noch um diese Katze kümmern? (In der Ferne miaut etwas.)',
       paragraph_three:
-        'Was auch immer als Nächstes passiert, Du wirst höchstwahrscheinlich etwas Geld brauchen. Du stellst fest, dass Du die Mining-Belohnungen von Deinem Kampf mit BitRey nie eingefordert hast. Du beschließst, sie abzuheben, um damit Deinen Rückflug zu bezahlen.',
+        'Was auch immer als nächstes passiert, Sie werden Geld brauchen. Moment mal! Sie haben die Mining-Belohnungen von Ihrem Wettbewerb mit BitRey nie eingefordert! Sie beschließen, sie abzuheben.',
     },
-
     public_key_one: {
-      title: 'Öffentliche Schlüssel',
+      title: 'Öffentlicher Schlüssel',
+      nav_title: 'Schlüsselpaare',
       heading: 'Über Schlüsselpaare',
       paragraph_one:
-        'Laut dem Mining-Pool sieht es so aus, als ob Du 1,61 Bitcoin von all der Arbeit, die Du zuvor geleistet hast, beanspruchen könntest. ',
-      list_one: ' Privater Schlüssel',
+        'Laut dem Mining-Pool sieht es so aus, als ob Sie für Ihre bisherige Arbeit 1,61 Bitcoin einfordern können.',
+      list_one: 'Privater Schlüssel',
       list_two: 'Öffentlicher Schlüssel',
       paragraph_two:
-        "Aber warte, Du hast ja nicht einmal eine Wallet (Geldbörse)! Du fragst dich vielleicht, wo Du eine kaufen könntest. Du könntest zwar Hardware kaufen, um bestimmte Arten von Wallets zu erstellen, aber Du kannst auch einfach eine mit Deinem Computer oder Deinem Mobilgerät erstellen. Los geht's!",
+        'Aber Moment, Sie haben noch nicht einmal eine Brieftasche! Sie fragen sich vielleicht, wo Sie eine kaufen können. Sie können zwar Hardware kaufen, um bestimmte Arten von Brieftaschen zu erstellen, aber Sie können tatsächlich einfach eine mit Ihrem Computer oder Mobilgerät erstellen. Los geht‘s!',
       paragraph_three:
-        'Wenn Du dich irgendwann einmal für ein Konto angemeldet hast, hast Du einen so genannten persönlichen Code erhalten. In der Kryptografie wird dieser Code als "privater Schlüssel" bezeichnet und ist oft Teil eines Paares:',
+        'Wenn Sie sich irgendwann für ein Konto angemeldet haben, haben Sie einen sogenannten persönlichen Code erhalten. In der Kryptographie wird dies als „privater Schlüssel“ bezeichnet und ist oft Teil eines Paares:',
       paragraph_four:
-        ' Ein einziges Schlüsselpaar reicht aus, um eine Wallet zu erstellen und die darin enthaltenen Gelder zu kontrollieren. Wenn Du Bitcoin ausgeben möchtst, verwendest Du den privaten Schlüssel. Wenn Du Bitcoin empfangen möchten, verwendest Du den öffentlichen Schlüssel.',
+        'Ein einziges Schlüsselpaar genügt, um ein Wallet zu erstellen und die darin enthaltenen Geldmittel zu verwalten. Wenn Sie Bitcoin ausgeben möchten, verwenden Sie den privaten Schlüssel. Wenn Sie Bitcoin empfangen möchten, verwenden Sie den öffentlichen Schlüssel.',
     },
-
     public_key_two: {
       title: 'Öffentlicher Schlüssel',
+      nav_title: 'Elliptische Kurvenkryptographie',
       paragraph_one:
-        'Wir haben also den privaten Schlüssel, das ist der persönliche Code, den Du bei der Anmeldung erhalten hast. Wie können wir daraus einen öffentlichen Schlüssel generieren?',
+        'Wir haben also den privaten Schlüssel, das ist der persönliche Code, den Sie bei Ihrer Anmeldung erhalten haben. Wie generieren wir daraus einen öffentlichen Schlüssel?',
       paragraph_two:
-        'Dazu müssen wir einen Blick auf einen faszinierenden Zweig der Kryptographie werfen, die elliptischen Kurven. Dieser Zweig wird als Elliptische Kurven-Kryptographie oder kurz ECC bezeichnet.',
+        'Dazu müssen wir einen Blick auf einen faszinierenden Zweig der Kryptografie werfen, der als elliptische Kurven bezeichnet wird. Er wird Elliptic Curve Cryptography oder kurz ECC genannt.',
       paragraph_three:
-        'Bei der ECC werden bestimmte Punkte auf einer elliptischen Kurve genommen und miteinander addiert und multipliziert.',
+        'Bei ECC werden bestimmte Punkte auf einer elliptischen Kurve genommen und an diesen Punkten Addition und Multiplikation durchgeführt.',
       paragraph_four:
-        'Bitcoin verwendet eine spezielle Kurve namens secp256k1. In der Abbildung siehst Du eine vereinfachte Version, die einfacher zu visualisieren ist, aber den gleichen mathematischen Regeln folgt.',
+        'Bitcoin verwendet eine spezielle Kurve namens secp256k1. Im Bild sehen Sie eine vereinfachte Version, die leichter zu visualisieren ist, aber denselben mathematischen Regeln folgt.',
       paragraph_five:
-        'Wir starten mit einem spezifischen Punkt auf der Kurve, dem sogenannten <Link href="public-key-2/help" className="underline">Generatorpunkt</Link>.',
+        'Wir beginnen mit einem bestimmten Punkt auf dieser Kurve, dem so genannten',
+      tooltip_one: {
+        highlighted: 'Generatorpunkt',
+        question: 'Was ist der Generatorpunkt?',
+        link: 'https://chat.bitcoinsearch.xyz/?author=holocat&question=What%2520is%2520the%2520Generator%2520point%253F',
+      },
     },
-
     public_key_three: {
       title: 'Öffentlicher Schlüssel',
+      nav_title: 'Berechnen des öffentlichen Schlüssels',
       paragraph_one:
-        'Um einen öffentlichen Schlüssel aus einem privaten Schlüssel abzuleiten, führen wir eine elliptische Kurvenoperation wiederholt mit dem Generatorpunkt durch (<Link href="public-key-3/help" className="underline">Finde heraus weshalb</Link>). Der Generatorpunkt ist ein bestimmter Punkt auf der Kurve. Sein Wert ist Teil des secp256k1-Standards und ist immer gleich:',
+        'Um einen öffentlichen Schlüssel aus einem privaten Schlüssel abzuleiten, führen wir wiederholt eine elliptische Kurvenoperation mit dem Generatorpunkt durch. Der Generatorpunkt ist ein bestimmter Punkt auf der Kurve. Sein Wert ist Teil des secp256k1-Standards und immer derselbe:',
       paragraph_two:
-        'Die Operation der elliptischen Kurve ähnelt der Addition und daher ähnelt ihre Wiederholung der Multiplikation. Wir nutzen das * Symbol um den Algorithmus zu beschreiben (<Link href="public-key-3/help" className="underline">lerne mehr</Link>), bei dem `k` der private Schlüssel und `P` der korrespondierende öffentliche Schlüssel ist:',
-      paragraph_three:
-        'Vervollständige die Funktion, die einen privaten Schlüssel als hexkodierte Zeichenkette akzeptiert und den entsprechenden öffentlichen Schlüssel als GE-Objekt (Group Element) zurückgibt.',
+        'Mathematische Operationen auf einer elliptischen Kurve ähneln der Addition. Daher ähnelt die Wiederholung dieser Operationen der Multiplikation. Wir verwenden das Symbol *, um den Algorithmus zu beschreiben, wobei „k“ der private Schlüssel und „P“ der entsprechende öffentliche Schlüssel ist:',
+      python: {
+        paragraph_three:
+          'Vervollständigen Sie die Funktion <span className="text-green">privatekey_to_publickey()</span>, die einen privaten Schlüssel als hexadezimal codierte Zeichenfolge akzeptiert und den entsprechenden öffentlichen Schlüssel als GE-Objekt (Group Element) zurückgibt.',
+      },
+      javascript: {
+        paragraph_three:
+          'Vervollständigen Sie die Funktion <span className="text-green">privateKeyToPublicKey()</span>, die einen privaten Schlüssel als hexadezimal codierte Zeichenfolge akzeptiert und den entsprechenden öffentlichen Schlüssel als GE-Objekt (Group Element) zurückgibt.',
+      },
+      paragraph_four:
+        'Hier sind einige Hinweise zur Typkonvertierung für den Einstieg:',
       success:
-        'Gut gemacht! Der öffentliche Schlüssel ist ziemlich lang. Versuchen wir ihn zu komprimieren!',
+        'Gute Arbeit! Dieser öffentliche Schlüssel ist ziemlich lang. Versuchen wir, ihn zu komprimieren!',
     },
-
     public_key_four: {
       title: 'Öffentlicher Schlüssel',
+      nav_title: 'Komprimieren des öffentlichen Schlüssels',
       paragraph_one:
-        'Der öffentliche Schlüssel besteht aus einer x- und einer y-Koordinate und umfasst insgesamt 64 Bytes. Diese können auf 33 Bytes komprimiert werden, indem die y-Koordinate entfernt und ein einzelnes Byte mit Metadaten vorangestellt wird. Dieses Byte gibt an, ob die y-Koordinate gerade oder ungerade ist. Da die elliptische Kurvengleichung nur zwei Variablen hat, kann der vollständige öffentliche Schlüssel später vom Überprüfer nur mit x und den Metadaten berechnet werden:',
-      paragraph_two:
-        'Das Metadatenbyte sollte `2` sein, wenn y gerade ist und `3`, wenn y ungerade ist. Vervollständige die Funktion `compress_publickey()`, um einen öffentlichen Schlüssel zu akzeptieren und einen 33-Byte-Hex-String zurückzugeben, der den komprimierten öffentlichen Schlüssel darstellt.',
+        'Der öffentliche Schlüssel hat eine x- und eine y-Koordinate, also insgesamt 64 Bytes. Dies kann auf 33 Bytes komprimiert werden, indem die y-Koordinate entfernt und ein einzelnes Byte Metadaten vorangestellt wird. Dieses Byte gibt an, ob die y-Koordinate gerade oder ungerade ist. Da die elliptische Kurvengleichung nur zwei Variablen hat, kann der vollständige öffentliche Schlüssel später vom Prüfer nur unter Verwendung von x und den Metadaten berechnet werden:',
+      paragraph_two_javascript:
+        'Das Metadatenbyte sollte „2“ sein, wenn y gerade ist, und „3“, wenn y ungerade ist. Vervollständigen Sie die Funktion <span className="text-green">compressPublicKey()</span>, um einen öffentlichen Schlüssel zu akzeptieren und eine 33 Byte lange Hex-Zeichenfolge zurückzugeben, die den komprimierten öffentlichen Schlüssel darstellt.',
+      paragraph_two_python:
+        'Das Metadatenbyte sollte „2“ sein, wenn y gerade ist, und „3“, wenn y ungerade ist. Vervollständigen Sie die Funktion <span className="text-green">compress_publickey()</span>, um einen öffentlichen Schlüssel zu akzeptieren und eine 33 Byte lange Hex-Zeichenfolge zurückzugeben, die den komprimierten öffentlichen Schlüssel darstellt.',
       success:
-        'Ausgezeichnet. Jetzt haben wir unseren komprimierten öffentlichen Schlüssel. Als Nächstes müssen wir ihn hashen und in ein menschenfreundliches Format kodieren.',
+        'Ausgezeichnet. Jetzt haben wir unseren komprimierten öffentlichen Schlüssel. Als nächstes müssen wir ihn hashen und in ein benutzerfreundliches Format kodieren.',
     },
-
     address_one: {
-      title: 'Addresse',
+      title: 'Adresse',
+      nav_title: 'Eine Einbahnstraße',
       heading: 'Gute Arbeit!',
       paragraph_one:
-        'Und da hast Du ihn! Dein komprimierter öffentlicher Schlüssel! Es gibt eine Menge interessanter Dinge, die wir damit machen können - zum Beispiel Adressen für unsere Wallet generieren. Das werden wir in der nächsten Herausforderung lernen.',
+        'Und da haben Sie ihn! Ihren komprimierten öffentlichen Schlüssel! Wir können damit viele interessante Dinge tun, darunter das Generieren von Adressen für unser Wallet. Mehr dazu erfahren Sie in der nächsten Challenge.',
       paragraph_two:
-        'Beachte, dass die Erzeugung eines öffentlichen Schlüssels eine Einbahnstraße ist. Du kannst den privaten Schlüssel, der zur Erzeugung eines öffentlichen Schlüssels verwendet wurde, nicht herausfinden. Es sei denn, Du löst ein bekanntlich schwieriges mathematisches Problem: das so genannte Problem des diskreten Logarithmus in endlichen Körpern.',
+        'Beachten Sie, dass die Generierung eines öffentlichen Schlüssels eine Einbahnstraße ist. Sie können den privaten Schlüssel, der zur Generierung eines öffentlichen Schlüssels verwendet wird, nicht herausfinden, es sei denn, Sie lösen ein notorisch schwieriges mathematisches Problem namens',
+      tooltip_one: {
+        question:
+          'Inwiefern ist das diskrete Log-Problem für Bitcoin relevant?',
+        link: 'https://chat.bitcoinsearch.xyz/?author=holocat&question=how%2520is%2520the%2520discrete%2520log%2520problem%2520relevant%2520to%2520bitcoin%253F',
+        highlighted: 'diskretes Log-Problem',
+      },
     },
-
     address_two: {
-      title: 'Addresse',
+      title: 'Adresse',
+      nav_title: 'Hashen Sie den komprimierten öffentlichen Schlüssel',
       paragraph_one:
-        'Erinnerst Du dich an die Hashing-Herausforderung? Es stellt sich heraus, dass die einfachste Art von Bitcoin-Adresse durch Hashing Deines komprimierten öffentlichen Schlüssels zu erzeugen ist. Bitcoin verwendet dafür zwei verschiedene Hashing-Algorithmen: SHA-256 und RIPEMD-160.',
-      paragraph_two:
-        'Der erste Schritt besteht darin, einen SHA-256-Hash für deinen komprimierten öffentlichen Schlüssel zu erzeugen. Dann führst Du einen RIPEMD-160-Hash an diesem SHA-256-Ausgangshash durch. Das Endergebnis sind 20 Bytes, die als Hexadezimalzeichenfolge kodiert sind.',
+        'Erinnern Sie sich an die Hashing-Herausforderung? Es stellte sich heraus, dass Sie die einfachste Art von Bitcoin-Adresse generieren können, indem Sie Ihren komprimierten öffentlichen Schlüssel hashen. Bitcoin verwendet hierfür zwei verschiedene Hashing-Algorithmen: SHA-256 und RIPEMD-160.',
+      paragraph_two: 'Schritte:',
       paragraph_three:
-        'Vervollständige eine Funktion, die einen 33 Byte großen komprimierten öffentlichen Schlüssel als Hex-String akzeptiert und einen 20 Byte großen Hash des öffentlichen Schlüssels als Hex-String zurückgibt.',
-      success:
-        'Großartig. Noch ein weiterer Schritt und Du hast Deine Wallet-Adresse.',
+        '<span className="indent-48">1. Führen Sie einen SHA-256-Hash für Ihren komprimierten öffentlichen Schlüssel durch.</span>',
+      paragraph_four:
+        '<span className="indent-48">2. Führen Sie einen RIPEMD-160-Hash für diesen SHA-256-Ausgabe-Digest durch. Das Endergebnis sind 20 Bytes, die als Hex-String codiert sind.</span>',
+      paragraph_five:
+        'Vervollständigen Sie eine Funktion, die einen komprimierten öffentlichen Schlüssel mit 33 Byte als Hex-String akzeptiert und einen Hash des öffentlichen Schlüssels mit 20 Byte als Hex-String zurückgibt.',
+      paragraph_six:
+        'Hier ist die Dokumentation für die Hashing-Bibliotheken, die wir für Sie importiert haben: <Link href="https://nodejs.org/api/crypto.html#class-hash" target="_blank" className="underline">JavaScript: crypto</Link> <Link href="https://docs.python.org/3/library/hashlib.html#usage" target="_blank" className="underline">Python: hashlib</Link>',
+      success: 'Großartig. Noch ein Schritt und Sie haben Ihre Wallet-Adresse.',
     },
-
     address_three: {
-      title: 'Address',
+      title: 'Adresse',
+      nav_title: 'Holen Sie sich eine P2WPKH-Adresse',
       paragraph_one:
-        'Es gibt mehrere Arten von Bitcoin-Adressen. Wir wollen eine Testnet Witness Public Key Hash (wpkh)-Adresse erstellen, um den 20 Byte großen komprimierten Hash des öffentlichen Schlüssels zu kodieren. Zunächst müssen wir dem Hash die Versionsnummer des Witness (Zeugen) "0" voranstellen. Diese 21 Bytes werden als "witness program" bezeichnet. Das Witness-Programm wird in ein menschenfreundliches Format namens bech32 kodiert, das ein für Menschen lesbares Präfix und eine Prüfsumme anfügt.',
-      paragraph_two: 'Das Präfix wird durch das jeweilige Netz bestimmt:',
-      list_one: 'Mainnet: ‘bc’',
-      list_two: 'Testnet: ‘tb’',
-      list_three: 'Regtest: ‘bcrt’',
-      paragraph_three:
-        'Die Zeichen, die von dieser Funktion zurückgegeben werden, sind Deine Bitcoin-Adresse!',
-      success:
-        'Jetzt hast Du eine Adresse, an die geschürfte Bitcoin geschickt werden können.',
-    },
-
-    outro_one: {
-      title: 'Outro',
-      heading: 'Super!',
-      paragraph_one: 'Du hast Deine eigene Wallet kreiert!',
+        'Es gibt mehrere Arten von Bitcoin-Adressen. In der vorherigen Übung haben wir einen 20 Byte großen komprimierten Public-Key-Hash erstellt. Nun möchten wir diesen Hash in eine Pay-to-Witness-Public-Key-Hash-Adresse (p2wpkh) im Testnet-Netzwerk kodieren.',
       paragraph_two:
-        'Du hebst die Bitcoin aus dem Mining-Pool in das soeben erstellte Wallet ab. Du bist nun ausreichend finanziert und bereit für alles, was Vanderpoole und BitRey Dir als Nächstes vorwerfen.',
+        'Zuerst müssen wir dem Hash eine Zeugenversionsnummer von „0“ anhängen. Diese resultierenden 21 Bytes werden als <span className="font-bold">Zeugenprogramm</span> bezeichnet.',
+      paragraph_three:
+        'Anschließend wird das Zeugenprogramm in ein benutzerfreundliches Format namens <Link href="https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#user-content-Specification" target="_blank" className="underline">bech32</Link> kodiert. Dabei werden den Daten ein für Menschen lesbares Präfix und eine Prüfsumme angehängt.',
+      paragraph_four: 'Die Vorwahl wird vom Netz vorgegeben:',
+      table_heading: {
+        item_one: 'Netzwerk',
+        item_two: 'Für Menschen lesbares Präfix',
+      },
+      table_rows: {
+        key_one: 'Mainnet',
+        value_one: 'v. Chr.',
+        key_two: 'Testnetz',
+        value_two: 'tb',
+        key_three: 'Rechtsprüfung',
+        value_three: 'bcrt',
+      },
+      paragraph_five:
+        'Da wir eine Testnet-Adresse erstellen, verwenden wir das Präfix „tb“.',
+      paragraph_six:
+        'Nachdem die Daten in bech32 kodiert wurden, bleibt uns eine Bitcoin-Adresse!',
+      paragraph_seven:
+        'Vervollständigen Sie die Funktion, um eine bech32-Adresse aus einem komprimierten öffentlichen Schlüssel-Hash zu erstellen. Beginnen Sie mit der Erstellung des Witness-Programms und konvertieren Sie das Programm dann mithilfe der bech32-Bibliothek, die bereits für Sie importiert wurde, in eine Adresse.',
+      paragraph_eight:
+        'Möglicherweise müssen Sie sich in die bech32-Bibliothek einarbeiten und den Code lesen, um die richtigen Funktionen zu finden:\n',
+      paragraph_eight_javascript:
+        '<Link href="https://github.com/saving-satoshi/bech32js/blob/main/bech32.js" target="_blank" className="underline">JavaScript: @savingsatoshi/bech32js</Link>\n',
+      paragraph_eight_python:
+        '<Link href="https://github.com/saving-satoshi/bech32py/blob/main/bech32py/bech32.py" target="_blank" className="underline">Python: Einsparungenatoshi_bech32py</Link>',
+      success:
+        'Jetzt haben Sie eine Adresse, an die die geschürften Bitcoins gesendet werden können.',
+    },
+    outro_one: {
+      title: 'Andere',
+      nav_title: 'Kapitel abgeschlossen',
+      heading: 'Erfolg!',
+      paragraph_one: 'Sie haben Ihr ganz persönliches Bitcoin-Wallet erstellt!',
+      paragraph_two:
+        'Sie ziehen die Bitcoins aus dem Mining-Pool in das gerade erstellte Wallet ab. Sie sind nun vollständig finanziert und bereit für alles, was Vanderpoole und BitRey als Nächstes auf Sie zukommen lassen.',
     },
     resources: {
-      public_key: {
-        elliptic_curve_reason_heading:
-          'Der Grund für elliptische Kurvenoperationen',
-        elliptic_curve_reason_paragraph:
-          'Wir verwenden eine ganz bestimmte Reihe von Schritten zur Ableitung des öffentlichen Schlüssels, weil mathematisch bewiesen ist, dass es im Grunde unmöglich ist, diesen Vorgang umzukehren. Diese Eigenschaft gilt auch für andere Algorithmen (wie RSA), aber diese haben viel größere Schlüsselgrößen und sind weniger effizient in der Berechnung. Die Schritte, denen wir folgen, wurden gewählt, weil:',
-        elliptic_curve_reason_list_one:
-          'wir ein System wollen, bei dem jeder mit minimalen Mitteln mitmachen kann',
-        elliptic_curve_reason_list_two:
-          'wir wollen, dass die Nachrichten kurz sind (und daher günstig zu übertragen sind)',
-        elliptic_curve_reason_list_three:
-          'wir beweisen müssen, dass wir ein Geheimnis kennen, ohne dieses Geheimnis zu verraten',
-        elliptic_curve_reason_list_four:
-          'es praktisch unmöglich sein muss, dass jemand anderes unser Geheimnis errechnet.',
-        secp_heading: 'secp256k1',
-        secp_paragraph:
-          'Secp256k1 ist der Name der elliptischen Kurve, die von Bitcoin verwendet wird, um seine öffentliche Schlüsselkryptographie zu implementieren. Alle Punkte auf dieser Kurve sind gültige öffentliche Bitcoin-Schlüssel.',
-        generator_point_heading: 'Der Generatorpunkt',
+      public_key_three: {
+        generator_point_heading: 'Generatorpunkt',
         generator_point_paragraph:
-          'Ein bestimmter Punkt auf der secp256k1-Kurve. Sein Wert ist Teil des secp256k1-Standards und ist immer gleich. Dieser Punkt unterscheidet sich nicht von anderen Punkten auf der Kurve, aber er wird als Standardausgangspunkt für Berechnungen vereinbart. Niemand weiß genau, warum gerade dieser Punkt gewählt wurde.',
+          'Ein bestimmter Punkt auf der secp256k1-Kurve. Sein Wert ist Teil des secp256k1-Standards und immer gleich. Dieser Punkt unterscheidet sich nicht von anderen Punkten auf der Kurve, wird aber als Standard-Ausgangspunkt für Berechnungen vereinbart. Niemand weiß wirklich, warum dieser bestimmte Punkt gewählt wurde.',
         elliptic_curve_operations_heading: 'Elliptische Kurvenoperationen',
         elliptic_curve_operations_paragraph:
-          'Elliptische Kurven haben ihre eigenen mathematischen Regeln, so dass einfache Operationen wie Addition und Multiplikation anders funktionieren. Der Einfachheit und Kürze halber werden etablierte Symbole wiederverwendet, z. B. ein "*" für Operationen, die der Multiplikation ähnlich sind.',
+          'Elliptische Kurven haben ihre eigenen mathematischen Regeln, sodass einfache Operationen wie Addition und Multiplikation unterschiedlich funktionieren. Der Einfachheit und Kürze halber werden etablierte Symbole wiederverwendet, beispielsweise ein „*“ für Operationen, die der Multiplikation ähnlich sind.',
         discrete_log_heading: 'Diskreter Logarithmus',
         discrete_log_paragraph:
-          'Ein mathematisches System, in dem man z. B. multiplizieren, aber nicht dividieren kann. Eine einfache Metapher dafür ist der Blick auf eine Uhr. Drei Stunden nach 11 Uhr ist 2 Uhr. Wir könnten also sagen: "11+3=2". Wenn man jedoch "2-x=11" ausführt und nach x löst, erhält man unendlich viele mögliche Antworten (3, 15, 27, 39...). Mehr hierzu bei <Link href="https://en.wikipedia.org/wiki/Discrete_logarithm" className="underline">Wikipedia</Link>.',
+          'Ein mathematisches System, in dem Sie beispielsweise multiplizieren, aber nicht dividieren können. Eine einfache Metapher hierfür ist der Blick auf eine Uhr. Drei Stunden nach 11 Uhr ist 2 Uhr. Wir könnten also sagen: „11+3=2“. Wenn Sie jedoch „2-x=11“ ausführen und nach x auflösen möchten, hätten Sie unendlich viele mögliche Antworten (3, 15, 27, 39...). Mehr zu <Link href="https://en.wikipedia.org/wiki/Discrete_logarithm" className="underline">wikipedia</Link>.',
+        tip_one:
+          'Die Multiplikation mit elliptischen Kurvenpunkten ist nicht die gleiche wie die Ihnen bekannte Multiplikation mit normalen Zahlen. Wie führen Sie also eine Multiplikation durch? Beachten Sie, dass der Generatorpunkt <span className="p-1 font-mono bg-[#0000004D] m-1">G</span> vom Typ <span className="p-1 font-mono bg-[#0000004D] m-1">secp256k1.GE</span> ist. Sehen Sie sich diese Klasse an, um zu sehen, welche Methoden Sie darauf anwenden können.',
+        tip_two:
+          'Während der private Schlüssel im Hex-Format akzeptiert wird, muss er vor der Multiplikation mit dem Generatorpunkt in eine Zahl (BigInt, wenn Sie JS verwenden) umgewandelt werden.',
       },
-      address: {
+      public_key_four: {
+        y_coordinate_compression_heading:
+          'Komprimierung öffentlicher Schlüssel',
+        y_coordinate_compression_paragraph:
+          'Wenn Sie eine Punktaddition auf einer elliptischen Kurve berechnen, verwenden Sie die Koordinaten zweier Punkte, um die Koordinaten eines dritten Punkts zu ermitteln, der auf der Kurve liegt. Allerdings gibt es für jede gegebene x-Koordinate normalerweise zwei mögliche y-Koordinaten (außer in bestimmten Sonderfällen). Wenn Sie einen öffentlichen Schlüssel komprimieren, wählen Sie eine dieser y-Koordinaten aus und schließen nur die x-Koordinate zusammen mit einem Indikator ein, der angibt, welche y-Koordinate verwendet werden soll. In diesem Fall verwenden wir die angehängten Metadaten, um die y-Koordinate anzugeben.',
+        tip: 'Diese Herausforderung ist eigentlich ganz einfach: Wir versuchen lediglich zu bestimmen, ob die y-Koordinate gerade oder ungerade ist, damit wir diese Metadaten unserem öffentlichen Schlüssel voranstellen können.',
+      },
+      address_two: {
         hash_algo_heading: 'SHA-256, RIPEMD-160',
         hash_algo_paragraph:
-          'Hash-Funktionen "verdauen" jede beliebige Datenmenge und liefern immer ein Ergebnis derselben Größe. Bei SHA256 sind es 32 Byte. Bei RIPEMD-160 sind es 20 Byte. Die Ausgabe ist deterministisch (immer die gleiche Ausgabe für die gleiche Eingabe), aber ansonsten nicht vom Zufall zu unterscheiden. Hash-Funktionen reduzieren die Daten effektiv auf einen kleinen, konsistenten Fingerabdruck.',
-        wpkh_heading: 'Witness Public Key Hash (wpkh) Addressen',
+          'Hash-Funktionen verarbeiten beliebige Datenmengen und geben immer ein Ergebnis derselben Größe zurück. Bei SHA256 sind es 32 Bytes. Bei RIPEMD-160 sind es 20 Bytes. Die Ausgabe ist deterministisch (immer dieselbe Ausgabe für dieselbe Eingabe), ansonsten aber nicht von zufälligen zu unterscheiden. Hash-Funktionen reduzieren Daten effektiv auf einen kleinen konsistenten Fingerabdruck.',
+        tip_one:
+          'Beim Berechnen des SHA-256-Hashes müssen Sie darauf achten, dass Ihr komprimierter Schlüssel als Bytes und nicht als Hexadezimalwert gehasht wird. Wenn Sie JavaScript verwenden, müssen Sie dazu die Hexadezimalzeichenfolge in einen Puffer konvertieren.',
+        tip_two:
+          'Stellen Sie sicher, dass Sie die Hashing-Algorithmen in der richtigen Reihenfolge ausführen!',
+      },
+      address_three: {
+        wpkh_heading: 'Witness Public Key Hash (wpkh)-Adresse',
         wpkh_paragraph:
-          'Eine Bitcoin-Adresse ist eine Zeichenkette, die zur einfachen Benutzung für Menschen bestimmt ist. Sie ist kurz, leicht zu kopieren und einzufügen und hat eine Art von eingebauter Prüfsumme, um sicherzustellen, dass sie immer korrekt kopiert wird. Sie kodiert sicher ein Bitcoin-Ausgabeskript, das der Empfänger ausgeben kann. Es gibt verschiedene Arten von Ausgabeskripten und verschiedene Kodierungsmechanismen. In dieser Herausforderung verschlüsseln wir einen komprimierten öffentlichen Schlüssel mit bech32, um eine so genannte Witness-Hash-Adresse für den öffentlichen Schlüssel zu erstellen.',
+          'Eine Bitcoin-Adresse ist eine Zeichenfolge, die für die Handhabung durch Benutzer konzipiert ist. Sie ist kurz, lässt sich leicht kopieren und einfügen und verfügt über eine Art integrierte Prüfsumme, um sicherzustellen, dass sie immer korrekt kopiert wird. Sie kodiert sicher ein Bitcoin-Ausgabeskript, mit dem der Empfänger Geld ausgeben kann. Es gibt mehrere Arten von Ausgabeskripten und mehrere Kodierungsmechanismen. In dieser Herausforderung kodieren wir einen komprimierten öffentlichen Schlüssel mit bech32, um eine sogenannte Witness-Public-Key-Hash-Adresse zu erstellen.',
         network_heading: 'Mainnet, Testnet, Signet und Regtest',
         network_paragraph:
-          'Wenn Du Bitcoin-Software entwickelst, ist es wichtig, Deinen Code zu testen, bevor Du ihr echtes Geld anvertraust! Einer der einfachsten Wege, Bitcoin-Software zu testen, ist die Verwendung einer anderen Blockchain mit einem neuen Genesis-Block, bei dem die Coins keine Rolle spielen, Mining kostenlos und einfach ist und alles jederzeit zurückgesetzt werden kann. Diese Ketten werden von einem einzigartigen Netzwerk von Knoten unterstützt, das die echten Münzen und Knoten im Mainnet nicht beeinträchtigt. Testnet und Signet sind die Namen von zwei solchen alternativen Bitcoin-Blockchains, die parallel zum Mainnet auf globaler Ebene betrieben werden. Regtest ist ein Entwicklermodus, der lokal ausgeführt werden kann, ohne dass eine Netzwerkverbindung erforderlich ist.',
+          'Wenn Sie Bitcoin-Software entwickeln, ist es wichtig, Ihren Code zu testen, bevor Sie ihm echtes Geld anvertrauen! Eine der einfachsten Möglichkeiten, Bitcoin-Software zu testen, besteht darin, eine andere Blockchain mit einem neuen Genesis-Block zu verwenden, bei dem die Münzen keine Rolle spielen, das Mining kostenlos und einfach ist und alles jederzeit zurückgesetzt werden kann. Diese Ketten werden von einem einzigartigen Netzwerk von Knoten unterstützt, das die echten Münzen und Knoten im Mainnet nicht stört. Testnet und Signet sind die Namen zweier solcher alternativer Bitcoin-Blockchains, die parallel zum Mainnet auf globaler Ebene gepflegt werden. Regtest ist ein Entwicklermodus, der für die lokale Ausführung konzipiert ist und keinerlei Netzwerkverbindungen erfordert.',
+        tip: 'Schauen Sie sich die bech32-Bibliothek genau an, um die genauen Methoden herauszufinden, die Sie verwenden können.',
       },
     },
   },
-
   chapter_five: {
-    title: 'Der Besitzer der Schlüssel',
+    title: 'Kann der echte Satoshi bitte aufstehen?',
     paragraph_one:
-      'Es ist spät und Du wirst müde, aber als Du für einen Moment die Augen schließt, erreicht Dich eine doppelte Dosis an schlechten Nachrichten. 1) Vanderpoole ist zurück im Fernsehen. 2) Er behauptet, er sei der Urenkel von Satoshi Nakamoto. Außerdem sieht er so aus, als hätte er schon länger nicht mehr geschlafen.',
+      'Es ist spät und Sie sind müde, doch als Sie für einen Moment die Augen schließen, erreicht Sie eine doppelte Dosis schlechter Nachrichten.',
+    paragraph_two: '1) Vanderpoole ist wieder im Fernsehen.',
+    paragraph_three:
+      '2) Er behauptet, der Urenkel von Satoshi Nakamoto zu sein.',
+    paragraph_four: 'Er sieht aus, als sei er übermüdet.',
     intro_one: {
-      title: 'Don’t trust, verify',
+      title: 'Einleitung',
+      nav_title: 'Vertrauen Sie nicht, überprüfen Sie',
       paragraph_one:
-        '-DEBORAH CHUNK: "Herr Vanderpool. Sie haben kürzlich in den antisozialen Medien die erstaunliche Behauptung aufgestellt, Sie seien der Urenkel von Satoshi Nakamoto. Ist das richtig? Ist das wahr?"',
+        '—DEBORAH CHUNK: „Mr. Vanderpoole. Sie haben kürzlich in den asozialen Medien die unglaubliche Behauptung aufgestellt, Sie seien der Urenkel von Satoshi Nakamoto. Stimmt das? Ist das wahr?“',
       paragraph_two:
-        '-VANDERPOOLE: "Sowas von wahr, Deborah. Ich weiß das schon seit längerer Zeit. Du musst verstehen, meine Familie hat eine CD-ROM über Generationen weitergegeben. Sie enthält die privaten Schlüssel zum enormen Bitcoin-Bestand meines Urgroßvaters. Wenn ich also für die Miner spreche, solltet ihr wissen, dass ich auch für Satoshi Nakamoto spreche."',
+        '—VANDERPOOLE: „Das ist es, Deborah. Ich habe dieses Geheimnis sehr, sehr lange gehütet. Wissen Sie, meine Familie hat eine unscheinbar aussehende CD-ROM über Generationen weitergegeben. Um sie geheim zu halten, haben wir sie mit <span className="italic">Creed – My Own Prison</span> beschriftet. Sie enthält die privaten Schlüssel zu der riesigen Bitcoin-Reserve meines Urgroßvaters Satoshi Nakamoto. Wenn ich also für die Miner spreche, wissen Sie, dass ich auch für Satoshi Nakamoto spreche.“',
       paragraph_three:
-        '-DEBORAH CHUNK: "Können wir irgendwie überprüfen, ob Sie tatsächlich die privaten Schlüssel zu Satoshi Nakamotos Bitcoin besitzen?"',
+        '—DEBORAH CHUNK: „Können wir irgendwie überprüfen, ob Sie tatsächlich die privaten Schlüssel zu Satoshi Nakamotos Bitcoin besitzen?“',
       paragraph_four:
-        '-VANDERPOOLE: "In der Tat, das können wir. Es ist eine einfache Angelegenheit der Kryptographie mit öffentlichen Schlüsseln."',
+        '—VANDERPOOLE: „Das gibt es tatsächlich. Es ist einfach eine Frage der Public-Key-Kryptographie.“',
       paragraph_five:
-        '-DEBORAH CHUNK: Aber warum dann so lange warten, um das zu enthüllen?',
+        '—DEBORAH CHUNK: Aber warum so lange mit dieser weltbewegenden Enthüllung warten?',
     },
     intro_two: {
+      nav_title: 'Vanderpooles kühne Behauptung',
       paragraph_one:
-        '-VANDERPOOLE: "Ich hatte nicht den Mut dazu. Es gab immer Gerüchte über die Geschichte meiner Familie, die ich dann doch irgendwie aus der Welt schaffen konnte. Ich war einfach nicht bereit für so viel Publicity. Schließlich lebe ich ein bescheidenes, zurückgezogenes Leben auf einer Privatinsel."',
+        '—VANDERPOOLE: „Ich hatte nicht den Mut. Es gab immer Gerüchte über die Geschichte meiner Familie, die ich leicht hätte bestätigen können. Aber ich war nicht bereit für so viel Publizität. Schließlich führe ich ein bescheidenes, abgeschiedenes Leben in einem Schloss aus dem 14. Jahrhundert auf einer Ferienranch auf meiner liebsten Privatinsel und gebe jede Woche 5–6 Interviews wie dieses von meinem Whirlpool aus.“',
       paragraph_two:
-        '-VANDERPOOLE: "Aber jetzt, da die Zukunft von Bitcoin auf dem Spiel steht, wusste ich, dass ich nicht länger Schweigen darf. Ich kann nur sagen, es tut mir leid, dass ich nicht früher damit herausgerückt bin. Die CD-ROM enthält auch Satoshi Nakamotos überarbeitete Pläne für Bitcoin. Er bedauerte immer die Begrenzung des Angebots auf 21 Millionen. Allerdings habe ich nun vor, den Traum meines Großvaters zu erfüllen und den Bitcoin zu Gunsten einer immerwährenden Bitcoin-Ausgabe zu modifizieren."',
+        '—VANDERPOOLE: „Aber jetzt, wo die Zukunft von Bitcoin auf dem Spiel steht, wusste ich, dass es Zeit war, mich der Realität zu stellen, insbesondere der Musik von Creeds Debütalbum My Own Prison.“ *Vanderpoole summt die Melodie des gleichnamigen Songs des Albums aus dem 20. Jahrhundert*',
+      paragraph_three:
+        '—VANDERPOOLE: „Ich kann nur sagen, dass es mir leid tut, dass ich nicht früher herausgekommen bin, denn die CD-ROM enthält auch Satoshi Nakamotos überarbeitete Pläne für Bitcoin. Wissen Sie, mein Urgroßvater hat es immer bedauert, die Menge an Bitcoin auf 21 Millionen Münzen zu begrenzen, und deshalb habe ich vor, den Traum meines Urgroßvaters zu erfüllen, Bitcoin durch Hard Forking zu ersetzen und eine ewige Ausgabe von Bitcoin zu ermöglichen.“',
     },
     intro_three: {
+      nav_title: 'Eine Nachricht von Satoshi',
       paragraph_one:
-        '—Dein TXM4H-A Hover Desk erwacht zum Leben. Du hast eine neue Nachricht.',
-      paragraph_two: '—HOLOKATZE: Vergiss nicht auf meine Nase zu drücken.',
-      paragraph_three:
-        'SATOSHI NAKAMOTO: “Vanderpoole ist nicht der, der er vorgibt zu sein. Du kannst ihn entlarven. Bitte ihn, den Besitz von Satoshis Bitcoin zu beweisen, indem er eine Nachricht mit den privaten Schlüsseln signiert.” - Satoshi',
+        'Ihr TXM4H-A Hover-Bildschirm erwacht zum Leben. Sie haben eine neue Nachricht.',
+      paragraph_two: '—HOLOCAT: Vergiss nicht, mir auf die Nase zu hauen.',
+      paragraph_three: 'Du schnippst ihr auf die Nase',
+      paragraph_four:
+        '—SATOSHI NAKAMOTO: „Vanderpoole ist nicht der, für den er sich ausgibt. Sie können ihn entlarven. Fordern Sie ihn auf, den Besitz von Satoshis Bitcoin zu beweisen, indem er eine Nachricht mit den privaten Schlüsseln dieser Wallet signiert.“',
     },
     derive_message_one: {
-      title: 'Eine Nachricht herleiten',
+      title: 'Leiten Sie die Nachricht ab',
+      nav_title: 'Die fragliche Nachricht',
       heading:
-        'Vanderpoole sagt, er habe eine Nachricht mit Satoshis Schlüsseln signiert:',
+        'Vanderpoole sagt, er habe eine Nachricht mit Satoshis Schlüsseln unterzeichnet:',
       code_one:
-        '-----BEGIN BITCOIN SIGNED MESSAGE----- <br /> <br /> Ich bin Vanderpoole und ich habe die Kontrolle über den privaten Schlüssel, den Satoshi benutzt hat, um die allererste Bitcoin-Transaktion zu signieren, die in Block #170 bestätigt wurde. Diese Nachricht ist mit dem selben privaten Schlüssel signiert. <br /> <br /> -----BEGIN BITCOIN SIGNATURE----- <br /> <br />',
+        '-----BEGIN BITCOIN SIGNED MESSAGE----- \n\nIch bin Vanderpoole und habe die Kontrolle über den privaten Schlüssel, den Satoshi verwendet hat, um die allererste Bitcoin-Transaktion zu signieren, die in Block Nr. 170 bestätigt wurde. Diese Nachricht ist mit demselben privaten Schlüssel signiert. \n\n-----BEGIN BITCOIN SIGNATURE----- \n\n',
       code_two:
         '<span className="break-all"> H4vQbVD0pLK7pkzPto8BHourzsBrHMB3Qf5oYVmr741pPwdU2m6FaZZmxh4ScHxFoDelFC9qG0PnAUl5qMFth8k= </span>',
-      code_three: '<br/> <br/>-----END BITCOIN SIGNATURE-----',
-      paragraph_two: 'Was soll das überhaupt bedeuten?',
+      code_three: '\n\n-----ENDE DER BITCOIN-SIGNATUR-----',
+      paragraph_two: 'Was bedeutet das überhaupt?',
     },
     derive_message_two: {
+      nav_title: 'Den öffentlichen Schlüssel finden',
       paragraph_one:
-        'Wir haben in Kapitel 4 gelernt, dass private Schlüssel riesige Zufallszahlen sind, die derjenige, der sie erzeugt hat, geheim hält. Mit Hilfe der Elliptischen Kurve können wir einen öffentlichen Schlüssel aus diesem privaten Schlüssel ableiten.',
+        'Wir haben in Kapitel 4 gelernt, dass private Schlüssel große Zufallszahlen sind, die von demjenigen, der sie generiert hat, geheim gehalten werden. Wir können Elliptische-Kurven-Mathematik verwenden, um aus diesem privaten Schlüssel einen öffentlichen Schlüssel abzuleiten.',
       paragraph_two:
-        'Der öffentliche Schlüssel kann als eindeutige Kennung weitergegeben werden, und der private Schlüssel wird verwendet, um zu beweisen, dass eine Person die Kontrolle über diese Kennung hat. Dieser Nachweis wird als SIGNATUR bezeichnet. Um eine Signatur zu erstellen, benötigst Du eine Nachricht und einen privaten Schlüssel. Jeder kann die Signatur mit einer Kopie der Nachricht und dem entsprechenden öffentlichen Schlüssel überprüfen.',
+        'Der öffentliche Schlüssel kann als eindeutige Kennung weitergegeben werden und der private Schlüssel dient zum Nachweis, dass eine Person die Kontrolle über diese Kennung hat. Dieser Nachweis wird SIGNATUR genannt. Zum Erstellen einer Signatur benötigen Sie eine Nachricht und einen privaten Schlüssel. Jeder kann die Signatur mit einer Kopie der Nachricht und dem entsprechenden öffentlichen Schlüssel verifizieren.',
       paragraph_three:
-        'Vanderpoole hat eine Unterschrift und eine Nachricht übermittelt. Wo ist der öffentliche Schlüssel?',
+        'Vanderpoole hat eine Signatur und eine Nachricht bereitgestellt. Wo ist der öffentliche Schlüssel?',
     },
     derive_message_three: {
+      nav_title: 'Finden Sie Satoshis Signatur',
       heading: 'Beginnen wir mit der Suche nach Satoshis Signatur',
       paragraph_one:
-        'Hal Finney <link href="https://bitcointalk.org/index.php?topic=155054.0" target="_blank" className="underline">behauptete</Link>, dass Satoshi ihm die erste Bitcoin-Transaction überhaupt, bestätigt in Block #170, gesendet habe. Diese Transaktion kann in einem <Link href="https://blockstream.info/tx/f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16?expand" target="_blank" className="underline">Blockexplorer hier</Link> gefunden werden. In der scriptSig von input #0 gibt es ein Datenstück, das auf pushbytes... folgt. Suche es und füge es unten ein.',
-      placeholder: 'Füge die Daten hier ein',
+        'Block Nr. 170 enthält die <link href="https://bitcointalk.org/index.php?topic=155054.0" target="_blank" className="underline">erste Bitcoin-Transaktion</link> von Satoshi an Hal Finney. Diese Transaktion hat nur <Link href="https://blockstream.info/tx/f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16?expand" target="_blank" className="underline">einen Input</Link>. Rufen Sie die ScriptSig aus diesem Input ab. Sie enthält Satoshis Signatur!',
+      placeholder: 'Fügen Sie die Daten hier ein',
       success:
-        'Sehr schön gemacht! Dies ist tatsächlich Satoshis Unterschrift, die den Transfer seiner Bitcoin an Hal Finney autorisiert.',
+        'Gut gemacht! Dies ist tatsächlich Satoshis Unterschrift, mit der er die Überweisung seines Bitcoins an Hal Finney autorisiert.',
     },
     derive_message_four: {
-      heading: 'Wo ist also sein öffentlicher Schlüssel?',
+      nav_title: 'Finden Sie Satoshis öffentlichen Schlüssel',
+      heading: 'Also, wo ist sein öffentlicher Schlüssel?',
       paragraph_one:
-        'Er wird zusammen mit den Bitcoin gespeichert, die von Satoshi durch das Mining von Block #9 erzeugt wurden.',
+        'Es wird tatsächlich zusammen mit dem Bitcoin-Satoshi gespeichert, der durch das Mining von Block Nr. 9 generiert wird.',
       paragraph_two:
-        '<Link href="https://blockstream.info/tx/0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9?output:0&expand" target="_blank" className="underline">Folge dem Link</Link> zur Ursprungstransaktion über dem Abschnitt Input #0. Dies ist die Transaktion, die Satoshi durch das Mining von Block #9 erstellt hat. Die Transaktion erzeugt 50 BTC und sperrt sie unter der Kontrolle von... einem öffentlichen Schlüssel! Suche die Daten, die mit 04... beginnen, im scriptPubKey.',
+        '<Link href="https://blockstream.info/tx/0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9?output:0&expand" target="_blank" className="underline">Folgen Sie dem Link</Link> zur Quelltransaktion oben im Abschnitt „Eingabe #0“. Dies ist die Transaktion, die Satoshi durch das Mining von Block #9 erstellt hat. Die Transaktion erstellt 50 BTC und sperrt sie unter der Kontrolle von... einem öffentlichen Schlüssel! Suchen Sie im scriptPubKey nach den Daten, die mit 0411... beginnen.',
       paragraph_three:
-        'Der öffentliche Schlüssel befindet sich zwischen den Skriptbefehlen OP_PUSHBYTES und OP_CHECKSIG. Füge ihn hier unten ein:',
-      placeholder: 'Füge die Daten hier ein',
-      success: 'Geschafft!',
+        'Der öffentliche Schlüssel befindet sich zwischen den Skriptbefehlen OP_PUSHBYTES und OP_CHECKSIG. Fügen Sie ihn unten ein:',
+      placeholder: 'Fügen Sie die Daten hier ein',
+      success: 'Das ist es!',
     },
     derive_message_five: {
+      nav_title: 'Als nächstes wird die Signatur überprüft',
       paragraph_one:
-        'Satoshi erstellte also eine Transaktion, die 50 Bitcoin an seinen öffentlichen Schlüssel schickte. Dann benutzte er seinen privaten Schlüssel, um eine Signatur zu erstellen, die 10 dieser Bitcoin an den öffentlichen Schlüssel von Hal Finney übertrug.',
+        'In der vorherigen Übung haben wir gesehen, dass Satoshi 50 BTC für das Mining von Block Nr. 9 erhielt. Er verwendete dies als Eingabe für seine Transaktion an Hal Finney (in Block Nr. 170), indem er 10 BTC an Hal Finneys öffentlichen Schlüssel schickte und 40 BTC als Wechselgeld an sich selbst zurückgab. Satoshis privater Schlüssel wurde verwendet, um eine Signatur zu erstellen, die die Überweisung dieser Gelder autorisierte.',
       paragraph_two:
-        'Als Nächstes müssen wir lernen, wie man eine Signatur überprüft. Aber etwas fehlt noch... wie lautet die Nachricht, die Satoshi signiert hat, um die Transaktion für Hal zu autorisieren?',
+        'Als nächstes müssen wir lernen, wie man eine Signatur verifiziert. Aber etwas fehlt noch ... was ist die Nachricht, die Satoshi unterzeichnet hat, um die Transaktion für Hal zu autorisieren?',
     },
     derive_message_six: {
-      heading: 'Leite die Nachricht aus der Transaktion ab',
+      nav_title: 'Leiten Sie die Nachricht ab',
+      heading: 'Leiten Sie die Nachricht aus der Transaktion ab',
       paragraph_one:
-        'Ein Blick auf die Blockexplorer-Webseite zeigt, dass eine Bitcoin-Transaktion aus vielen verschiedenen Teilen besteht. Einige Teile sind nur kleine Zahlen und einige Teile sind größere Datenblöcke. Das Bitcoin-Protokoll hat einen sehr spezifischen Algorithmus zur Erstellung von Nachrichten aus Transaktionen, sodass diese Nachrichten mit privaten Schlüsseln signiert werden können.',
+        'Schon beim bloßen Betrachten der Block-Explorer-Webseite sollte klar sein, dass eine Bitcoin-Transaktion aus vielen verschiedenen Teilen besteht. Einige Teile sind nur kleine Zahlen und andere Teile sind größere Datenblöcke. Das Bitcoin-Protokoll verfügt über einen sehr spezifischen Algorithmus zum Erstellen von Nachrichten aus Transaktionen, sodass diese Nachrichten mit privaten Schlüsseln signiert werden können.',
       paragraph_two:
-        'Wir fassen den hier skizzierten Prozess zusammen. Er verwendet praktischerweise genau <Link href="https://en.bitcoin.it/wiki/OP_CHECKSIG#Code_samples_and_raw_dumps" target="_blank" className="underline">diese Transaktion</Link> als Beispiel.',
+        'Wir fassen den hier beschriebenen Prozess <Link href="https://en.bitcoin.it/wiki/OP_CHECKSIG" target="_blank" className="underline">zusammen</Link>. Er verwendet praktischerweise <Link href="https://en.bitcoin.it/wiki/OP_CHECKSIG#Code_samples_and_raw_dumps" target="_blank" className="underline">genau diese Transaktion aus Block Nr. 170</Link> als Beispiel.',
       paragraph_three:
-        'Zunächst benötigen wir die Rohbytes, aus denen die gesamte Transaktion besteht. <Link href="https://blockstream.info/api/tx/f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16/hex" target="_blank" className="underline">Unser Blockexplorer</Link> kann hier helfen. Verwende den API-Endpunkt "hex" und füge den gesamten Datenblock ein.',
-      input_challenge_label: 'Füge die hex-kodierte Transaktion ein',
+        'Zu Beginn benötigen wir die Rohbytes, aus denen die gesamte Transaktion besteht. <Link href="https://blockstream.info/api/tx/f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16/hex" target="_blank" className="underline">Unser Block-Explorer</Link> kann dabei helfen. Verwenden Sie den API-Endpunkt „Hex“ und fügen Sie den gesamten Datenblock ein.',
+      input_challenge_label: 'Einfügen des Transaktions-Blobs',
       success_message_line_one:
-        'Dies ist die Rohtransaktion mit der Kennzeichnung der einzelnen Komponenten:',
+        'Dies ist die Rohtransaktion mit den Beschriftungen für jede Komponente:',
       success_message_line_two: 'Version:',
-      success_message_line_three: 'Anzahl an Inputs',
-      success_message_line_four:
-        'Hash der Tx (little-endian /"rückwärts"), aus der Input #0 stammt ,:',
+      success_message_line_three: 'Anzahl Eingänge:',
+      success_message_line_four: 'Hash der TX, von der Eingabe Nr. 0 stammt:',
       success_message_line_five:
-        'Index des Outputs der Tx, die vom Input #0 aus ausgeben wird:',
+        'Index des Inputs Nr. 0 in der Finanzierungstransaktion:',
       success_message_line_six:
-        'scriptSig, um die Ausgabe des angegebenen Betrags zu genehmigen:',
-      success_message_line_seven: 'Input #0 Sequenze:',
-      success_message_line_eight: 'Anzahl an Outputs:',
+        'scriptSig zum Autorisieren der Ausgabeneingabe Nr. 0:',
+      success_message_line_seven: 'Eingabe #0 Sequenz:',
+      success_message_line_eight: 'Anzahl der Ausgänge:',
       success_message_line_nine:
-        'Wert von Output #0 (10 BTC oder 1,000,000,000 Satoshis):',
+        'Ausgabewert Nr. 0 (10 BTC oder 1.000.000.000 Satoshis):',
       success_message_line_ten:
-        'Output #0 scriptPubKey (Hal Finney’s öffentlicher Schlüssel plus OP_CHECKSIG):',
+        'Ausgabe Nr. 0 scriptPubKey (Hal Finneys öffentlicher Schlüssel plus OP_CHECKSIG):',
       success_message_line_eleven:
-        'Wert von Output #1 (40 BTC oder 4,000,000,000 satoshis):',
+        'Ausgabewert Nr. 1 (40 BTC oder 4.000.000.000 Satoshis):',
       success_message_line_twelve:
-        'Output #1 scriptPubKey (Wieder Satoshi’s eigener öffentlicher Schlüssel, für das Wechselgeld):',
-      success_message_line_thirteen: 'Locktime:',
+        'Ausgabe Nr. 1 scriptPubKey (zur Abwechslung noch einmal Satoshis eigener öffentlicher Schlüssel):',
+      success_message_line_thirteen: 'Sperrzeit:',
     },
     derive_message_seven: {
+      nav_title: 'Erstellen Sie die zu signierende Nachricht',
       paragraph_one:
-        'Es ist unmöglich, eine Nachricht zu signieren, die ihre eigene Signatur enthält, also muss scriptSig entfernt werden. Im Bitcoin-Protokoll wird sie tatsächlich durch den scriptPubKey des Transaktions-Outputs ersetzt, den wir ausgeben.',
+        'Es ist unmöglich, eine Nachricht zu signieren, die ihre eigene Signatur enthält. Daher muss das ScriptSig entfernt werden. Im Bitcoin-Protokoll wird es tatsächlich durch den ScriptPubKey der Transaktionsausgabe ersetzt, die wir ausgeben.',
       paragraph_two:
-        'Den scriptPubKey haben wir bereits im vorherigen Schritt gefunden, Du kannst ihn in das erste Leerzeichen einfügen.',
-      paragraph_three:
-        'Das Letzte, das wir für unsere Transaktionsnachricht brauchen, ist eine "<span className="font-bold">Sighash Type Flag</span>." Wir werden uns das noch genauer im nächsten Kapitel anschauen, im Moment ist dies ausreichend. Wir fügen den Wert <span className="font-bold">01000000</span> einfach an das Ende der Nachricht.',
+        'Den scriptPubKey haben wir bereits im vorigen Schritt gefunden, diesen können Sie in das erste Feld einfügen.',
+      paragraph_three: {
+        a: 'Das letzte, was wir für unsere Transaktionsnachricht brauchen, ist eine',
+        b: '. Wir werden im nächsten Kapitel näher darauf eingehen, aber vorerst fügen wir einfach den Wert <span className="font-bold">01000000</span> an das Ende der Nachricht an.',
+      },
+      tooltip_one: {
+        question: 'Was sind Sighash-Flaggen?',
+        link: 'https://chat.bitcoinsearch.xyz/?author=holocat&question=what%2520are%2520sighash%2520flags%253F',
+        highlighted: 'Flagge vom Typ „Sighash“',
+      },
+      success: 'Schön! Sie haben eine zu unterzeichnende Nachricht erstellt.',
     },
     verify_signature_one: {
-      title: 'Verifiziere die Signatur',
-      heading: 'Endlich haben wir die Nachricht!',
+      title: 'Überprüfen der Signatur',
+      nav_title: 'Überprüfung der Signatur',
+      heading: 'Endlich haben wir eine Nachricht!',
       paragraph_one:
-        'Wir haben auch eine Signatur, von der wir wissen, dass Satoshi sie mit seinem eigenen privaten Schlüssel erstellt hat, und wir haben seinen öffentlichen Schlüssel. Lass uns nun lernen, wie man die Signatur verifiziert, sodass wir im Anschluss versuchen können, Vanderpooles Signatur zu überprüfen.',
+        'Wir wissen auch, dass Satoshi eine Signatur mit seinen eigenen privaten Schlüsseln erstellt hat, und wir haben seinen öffentlichen Schlüssel. Lassen Sie uns lernen, wie man die Signatur überprüft, und dann können wir versuchen, Vanderpooles Signatur zu überprüfen.',
     },
     verify_signature_two: {
-      title: 'Verifiziere die Signatur',
-      heading: 'Hash des Transaktionsdigests (Verdaus)',
+      title: 'Überprüfen der Signatur',
+      nav_title: 'Hashen Sie die Nachricht',
+      heading: 'Hashen Sie den Transaktions-Digest',
       paragraph_one:
         'Die serialisierten Transaktionsdaten, die wir im letzten Schritt zusammengestellt haben, sind eigentlich zu lang, um sie mit ECDSA zu signieren oder zu verifizieren.',
       paragraph_two:
-        'Kennen wir eine Möglichkeit, große Datenmengen in konsistente, überschaubare Teile zu komprimieren? Aber sicher doch: Hashing.',
-      paragraph_three:
-        'Das Bitcoin-Protokoll verwendet einen doppelten SHA256-Digest (Verdau), um eine Transaktion in eine signierbare Nachricht zu komprimieren.',
+        'Kennen wir eine Möglichkeit, große Datenmengen in einheitlichere, handlichere Teile zu komprimieren? Sicherlich kennen wir sie: Hashing.',
+      paragraph_three: {
+        a: 'Das Bitcoin-Protokoll verwendet eine',
+        b: 'um eine Transaktion in eine signierbare Nachricht zu komprimieren.',
+      },
       paragraph_four:
-        'Sobald wir einen 32-Byte-Hash haben, werden diese Daten in eine Ganzzahl uminterpretiert. Ja, eine 32-Byte-Ganzzahl (das ist wirklich eine riesige Zahl)!',
-      success: 'Sehr gut gemacht!',
+        'Sobald wir einen 32-Byte-Hash haben, werden diese Daten als Ganzzahl neu interpretiert. Ja, eine 32-Byte-Ganzzahl (das ist wirklich eine enorme Zahl)!',
+      tooltip_one: {
+        question:
+          'Warum wird bei Bitcoin für alles ein doppelter Hash (HASH256) verwendet?',
+        link: 'https://chat.bitcoinsearch.xyz/?author=holocat&question=Why%2520does%2520everything%2520in%2520bitcoin%2520use%2520double%2520hash%2520%28HASH256%29%253F',
+        highlighted: 'doppelter SHA256-Digest',
+      },
+      success: 'Gut gemacht!',
     },
     verify_signature_three: {
-      heading: 'Entschlüsseln der Signatur',
-      label_one: 'Füge den R-Wert ein',
-      label_two: 'Füge den S-Wert ein',
+      nav_title: 'Entschlüsseln Sie die Signatur',
+      heading: 'Entschlüsseln Sie die Signatur',
+      label_one: 'Fügen Sie den R-Wert ein',
+      label_two: 'Fügen Sie den S-Wert ein',
       paragraph_one:
-        'Satoshis Signatur ist in einem System namens DER kodiert, das eine Untermenge von ASN.1 ist.',
+        'Die Signatur von Satoshi ist in einem System namens DER codiert, das eine Teilmenge von ASN.1 ist.',
       paragraph_two:
-        'Es gibt zwei 32-Byte-Zahlen, die wir extrahieren müssen. Sie werden als R bzw. S bezeichnet und sind jeweils durch die Bytes 0220 in der DER-Sequenz vorangestellt. Anstatt den DER-Blob (Binary Large Object) vollständig zu dekodieren, suchen wir einfach nach den Präfixen und fügen die Werte R und S ein.',
+        'Es gibt zwei 32-Byte-Zahlen, die wir extrahieren müssen. Sie werden als R bzw. S bezeichnet und haben in der DER-Sequenz jeweils das Byte 0220 als Präfix. Anstatt den DER-Blob vollständig zu dekodieren, suchen Sie einfach nach den Präfixen und fügen Sie die R- und S-Werte ein.',
       paragraph_three:
-        '# Satoshis Unterschrift, aus dem Input-scriptSig der Transaktion an Hal Finney',
-      paragraph_four:
-        'sig_der = """304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d09"""',
+        '# Satoshis Signatur aus dem EingabescriptSig der Transaktion an Hal Finney (Block 170)',
     },
     verify_signature_four: {
-      heading: 'Entschlüssle den öffentlichen Schlüssel',
-      label_one: 'Füge die X-Koordinaten ein',
-      label_two: 'Füge die Y-Koordinaten ein',
+      nav_title: 'Den öffentlichen Schlüssel entschlüsseln',
+      heading: 'Dekodieren des öffentlichen Schlüssels',
+      label_one: 'Fügen Sie die x-Koordinate ein',
+      label_two: 'Fügen Sie die y-Koordinate ein',
       paragraph_one:
-        'Wir haben in Kapitel 4 gelernt, dass öffentliche Schlüssel eigentlich Punkte in der ECDSA-Kurve sind, d.h. sie haben einen x- und y-Wert. Das erste Byte 04 bedeutet "unkomprimiert" (im Gegensatz zu 02 und 03, wie wir in Kapitel 4 gelernt haben). Entferne dieses erste Byte und die verbleibenden Daten sind 32-Byte-X- und -Y-Koordinaten. Kopieren und wieder einfügen.',
+        'Wir haben in Kapitel 4 gelernt, dass öffentliche Schlüssel eigentlich Punkte in der ECDSA-Kurve sind, d. h. sie haben einen x- und einen y-Wert. Das erste Byte 04 bedeutet „unkomprimiert“ (im Gegensatz zu 02 und 03, wie wir in Kapitel 4 gelernt haben). Entfernen Sie dieses erste Byte und die verbleibenden Daten sind 32-Byte-x- und y-Koordinaten. Kopieren und erneut einfügen.',
       paragraph_two:
-        "# Satoshi's öffentlicher Schlüssel, aus dem Coinbase Output scriptPubKey von Block 9",
-      paragraph_three:
-        'pubkey = """0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3"""',
+        '# Satoshis öffentlicher Schlüssel, aus Block 9 Coinbase-Ausgabe scriptPubKey',
     },
     verify_signature_five: {
-      title: 'Verifiziere die Signatur',
-      heading: 'Prüfe die Signatur!',
-      success:
-        'Du hast es geschafft! Du hast Satoshis Unterschrift verifiziert!',
+      title: 'Überprüfen der Signatur',
+      nav_title: 'Testen der Signatur',
+      heading: 'Signatur prüfen!',
+      success: 'Du hast es geschafft! Du hast Satoshis Signatur verifiziert!',
       paragraph_one:
-        'Jetzt haben wir alles, was wir brauchen, um einige ECDSA-Rechnungen durchzuführen.',
+        'An diesem Punkt haben wir alles, was wir für einige ECDSA-Berechnungen benötigen.',
       paragraph_two:
-        'Der ECDSA-Signaturprüfungsalgorithmus wird <Link className="underline" href="https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm#Signature_verification_algorithm" target="_blank">hier</Link> und <Link className="underline" href="https://www.secg.org/sec1-v2.pdf#page=52" target="_blank">hier</Link> erklärt.',
+        'Der ECDSA-Signaturüberprüfungsalgorithmus wird <Link className="underline" href="https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm#Signature_verification_algorithm" target="_blank">hier</Link> und <Link className="underline" href="https://www.secg.org/sec1-v2.pdf#page=52" target="_blank">hier</Link> erläutert.',
       paragraph_three:
-        'Wir haben ein Group Element Objekt aus dem öffentlichen Schlüssel X und Y Elementen für Dich erstellt. Du musst die Implementierung der ECDSA-Signaturprüfungsfunktion  <span className="text-green">verify()</span> abschließen, die nur True zurückgeben sollte, wenn alles gültig ist!',
+        'Wir haben für Sie ein Gruppenelementobjekt aus den öffentlichen Schlüsselelementen X und Y erstellt. Sie müssen die Implementierung der ECDSA-Signaturüberprüfungsfunktion <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">verify()</span> abschließen, die nur dann True zurückgeben sollte, wenn alles gültig ist!',
       paragraph_four:
-        'Wir wissen, dass Satoshis Signatur gültig ist, da sie seit 2010 von jedem Bitcoin-Fullnode überprüft wurde! Wenn Dein Programm nicht True zurückgibt, ist etwas schief gelaufen.',
+        'Wir wissen, dass Satoshis Signatur gültig ist, sie wurde seit 2010 von jedem Bitcoin-Full-Node überprüft! Wenn Ihr Programm nicht True zurückgibt, stimmt etwas nicht.',
       python: {
         paragraph_five_part_one:
-          'Tipp: die <span className="text-green">pow()</span>',
+          'Hinweis: das <span className="text-green">pow()</span>',
         paragraph_five_part_two:
-          'Methode kann negative Exponenten und einen Modulus als Argumente akzeptieren. Mehr hier in der <Link className="underline" href="https://docs.python.org/3/library/functions.html#pow" target="_blank">Dokumentation</Link>.',
+          'Die Methode kann negative Exponenten und einen Modul als Argumente akzeptieren. Mehr dazu in der <Link className="underline" href="https://docs.python.org/3/library/functions.html#pow" target="_blank">Dokumentation</Link>.',
       },
       javascript: {
         paragraph_five_part_one:
-          'Wir haben eine Hilfsfunktion <span className="text-green">invert()</span> bereitgestellt',
+          'Wir haben eine Hilfsfunktion bereitgestellt <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">invert()</span>',
         paragraph_five_part_two:
-          'die Du anstelle einer JavaScript-eigenen modularen Potenzierungsfunktion benötigst.',
+          'die Sie anstelle einer nativen modularen Exponentiationsfunktion von JavaScript benötigen.',
       },
     },
     validate_signature_one: {
-      title: 'Validiere die Signatur',
-      heading: 'Bereite Vanderpooles Nachricht zur Überprüfung vor',
+      title: 'Validieren der Signatur',
+      nav_title: 'Vorbereiten der Nachricht',
+      heading: 'Vanderpooles Nachricht zur Überprüfung vorbereiten',
       paragraph_one:
-        'Vanderpoole nutze ein <Link href="https://github.com/bitcoin/bips/blob/master/bip-0137.mediawiki" target="_blank" className="underline">Bitcoin-Nachrichten-signier-Protokoll</Link> für seine Show. Für die Berechnung wird derselbe Algorithmus verwendet, den wir bereits definiert haben, aber die Aufbereitung der Daten ist ein wenig anders.',
+        'Vanderpoole verwendete für seinen Stunt ein <Link href="https://github.com/bitcoin/bips/blob/master/bip-0137.mediawiki" target="_blank" className="underline">Bitcoin Message Signing Protocol</Link>. Die Berechnung verwendet denselben Algorithmus, den wir bereits definiert haben, aber die Aufbereitung der Daten ist etwas anders.',
       paragraph_two:
-        "Zunächst müssen wir seine Nachricht in ein Array von Bytes kodieren, das der folgenden Vorlage entspricht:',",
-      paragraph_three:
-        'Dann werden wir diesen Datenblock mit einem doppelten SHA256-Hash versehen und diesen Hash in eine Ganzzahl umwandeln. Vervollständige die Funktion encode_message(). Sie sollte einen 32-Byte-Hex-Wert zurückgeben.',
-      success: 'Sehr gut gemacht',
+        'Zuerst müssen wir seine Nachricht in ein Byte-Array kodieren, das der folgenden Vorlage entspricht:',
+      paragraph_three: {
+        pre_link: 'Dann werden wir',
+        highlighted: 'doppelter SHA-256-Hash',
+        question: 'Warum verwenden wir bei Bitcoin doppeltes Hashing?',
+        post_link:
+          'diesen Datenblock und konvertieren Sie diesen Hash in eine Ganzzahl. Vervollständigen Sie die Funktion <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">encode_message()</span>. Sie sollte einen 32-Byte-Hexadezimalwert zurückgeben.',
+      },
+      success: 'Gut gemacht',
     },
     validate_signature_two: {
-      heading: 'Bereite Vanderpooles Nachricht zur Überprüfung vor',
+      nav_title: 'Signatur vorbereiten',
+      heading: 'Bereiten Sie Vanderpooles Unterschrift zur Überprüfung vor',
       paragraph_one:
-        'Das von Vanderpoole verwendete Bitcoin-Protokoll zum Signieren von Nachrichten gibt base64 für die Signatur vor. Wir müssen diese base64-Zeichenfolge in eine 65-Byte-Sequenz dekodieren. Für den Moment können wir das erste Byte der Metadaten außer Acht lassen. Der Rest der Daten sind die 32-Byte-Werte r und s, die wir in Schritt 6 kennengelernt haben.',
+        'Das von Vanderpoole verwendete Bitcoin-Nachrichtensignaturprotokoll gibt Base64 für die Signatur an. Wir müssen diese Base64-Zeichenfolge in eine 65-Byte-Sequenz dekodieren. Das erste Byte der Metadaten können wir vorerst ignorieren. Der Rest der Daten sind die 32-Byte-r- und s-Werte, die wir in Schritt 6 kennengelernt haben.',
       javascript: {
-        paragraph_two:
-          'Verfollständige die Funktion <span className="italic">decodeSig()</span>. Sie sollte ein Array mit den [r, s]-Werten als BigInts zurückgeben.',
+        paragraph_two: {
+          post_link:
+            'Vervollständigen Sie die Funktion <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">decode_sig()</span>.',
+          return:
+            'Es sollte ein Array mit den [r, s]-Werten als BigInts zurückgeben.',
+        },
       },
       python: {
-        paragraph_two:
-          'Verfollständige die Funktion <span className="italic">decode_sig()</span>. Sie sollte ein Tuple mit den (r, s) Werten zurückgeben.',
+        paragraph_two: {
+          post_link:
+            'Vervollständigen Sie die Funktion <span className=" text-green">decode_sig()</span>.',
+          return: 'Es sollte ein Tupel mit den (r, s)-Werten zurückgeben.',
+        },
       },
+      success: 'Gut gemacht',
     },
     validate_signature_three: {
-      title: 'Validiere die Signatur',
+      title: 'Validieren der Signatur',
+      nav_title: 'Sehen Sie, ob Vanderpoole gelogen hat',
       heading: 'Also, ist Vanderpoole ein Lügner?!',
       paragraph_one:
-        'Es gibt nicht mehr viel zu tun, außer alles zusammenzufügen und das Programm zu starten! Trommelwirbel bitte...',
-      success: 'Signatur ist nicht valide',
+        'Lassen Sie uns alle notwendigen Komponenten für das Programm sammeln und überprüfen, ob Vanderpooles Signatur tatsächlich von dem privaten Schlüssel stammt, der mit Satoshis öffentlichem Schlüssel verknüpft ist! Bitte füllen Sie die fehlenden Parameter aus, die zur Ausführung der Funktion <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm"> verify()</span> erforderlich sind, mithilfe des bereitgestellten Codes.',
+      paragraph_two:
+        'Dann können wir das Programm ausführen, um zu sehen, ob Vanderpoole gelogen hat. Trommelwirbel bitte ...',
+      success:
+        'Diese Meldung zeigt an, dass die Signatur nicht vom öffentlichen Schlüssel von Satoshi stammt, da die Überprüfung fehlgeschlagen ist.',
     },
     validate_signature_four: {
-      title: 'Validiere die Signatur',
+      title: 'Validieren der Signatur',
+      nav_title: 'Den richtigen Schlüssel finden',
       heading: 'Wie hat Vanderpoole diese Signatur überhaupt erstellt?',
       paragraph_one:
-        'Holokatze meldet sich zu Wort und sagt, dass ein Überläufer von BitRey uns die tatsächliche Adresse geschickt hat, die Vanderpoole genutzt hat und die ist definitiv nicht die Adresse von Satoshi!',
-      paragraph_two: 'mit dem entsprechenden öffentlichen Schlüssel:',
+        'Holocat mischt sich ein und sagt, ein Überläufer von BitRey habe uns eine Liste mit öffentlichen Schlüsseln geschickt, die Vanderpoole häufig verwendet. Vielleicht habe er einen dieser Schlüssel zum Signieren der Nachricht verwendet.',
+      paragraph_two:
+        'Bitte geben Sie den Schlüssel ein, der den Überprüfungsprozess erfolgreich abschließt und es uns ermöglicht, den öffentlichen Schlüssel zu identifizieren, den Vanderpoole zum Signieren dieser Nachricht verwendet hat.',
       paragraph_three:
-        'Kannst Du die Nachricht und die Signatur von Vanderpoole mit DIESEM Schlüssel überprüfen?',
-      success: 'Die Signatur ist valide!',
+        'Mal sehen, ob Sie Vanderpooles Nachricht und Signatur mit einem DIESER Schlüssel verifizieren können?',
+      success:
+        'Die Signatur ist für diesen öffentlichen Schlüssel von Vanderpoole gültig, dies war nicht Satoshi!',
     },
     outro_one: {
-      title: 'Outro',
+      title: 'Andere',
+      nav_title: 'Kapitel abgeschlossen',
       heading: 'Vanderpoole hat gelogen!',
       paragraph_one:
-        'Die ganze Geschichte über seine Familie war eine Erfindung und Du hast es der ganzen Welt bewiesen. Dies wirft einen großen Schatten auf seine Glaubwürdigkeit und die Glaubwürdigkeit seines Unternehmens. Aber das ist es, was man bekommt, wenn man trickst.',
+        'Sie haben eine der wichtigsten Lektionen in Sachen Bitcoin gelernt. Sie haben nicht vertraut, sondern überprüft.<br><br>Dabei haben Sie festgestellt, dass Vanderpoole nicht Satoshis Schlüssel verwendet hat, um die Nachricht zu signieren, was einen großen Schatten auf seine Familiengeschichte, seine Glaubwürdigkeit und die Glaubwürdigkeit von BitRey wirft.<br><br>Wenn Sie jetzt nur dieses Lied aus Ihrem Kopf bekommen könnten.',
     },
     resources: {
-      derive_message: {
+      derive_message_three: {
         op_pushdata_heading: 'OP_PUSHDATA',
         op_pushdata_paragraph_one:
-          'OP_PUSHDATA im Bitcoin-Skript spielt eine entscheidende Rolle bei der Erleichterung des Einfügens beliebiger Daten in die Blockchain. Es handelt sich um einen Opcode, der das Einfügen von Datenelementen unterschiedlicher Größe ermöglicht, wodurch die Bitcoin-Skriptsprache vielseitiger wird. Dieser Opcode ist besonders wichtig, um die Implementierung verschiedener Smart-Contract-Funktionen und benutzerdefinierter Transaktionsarten zu ermöglichen. Du kannst mehr über einige dieser OP_CODES und weiteres <Link href="https://en.bitcoin.it/wiki/Script#Constants" target="_blank" className="underline">hier</Link> lesen.',
+          'OP_PUSHDATA spielt im Bitcoin-Skript eine entscheidende Rolle, wenn es darum geht, das Einfügen beliebiger Daten in die Blockchain zu erleichtern. Es handelt sich eigentlich um eine ganze Kategorie von Opcodes, die das Einfügen von Datenelementen unterschiedlicher Größe ermöglichen und so die Skriptsprache von Bitcoin vielseitiger machen. Dieser Opcode ist besonders wichtig, um die Implementierung verschiedener Smart-Contract-Funktionen und benutzerdefinierter Transaktionstypen zu ermöglichen. Da wir wissen, dass damit 71 Byte Daten auf den Stapel geschoben werden sollen, können Sie herausfinden, wie dieser Opcode in Hex dargestellt werden könnte? Sie können mehr über einige dieser OP_CODES und mehr <Link href="https://en.bitcoin.it/wiki/Script#Constants" target="_blank" className="underline">hier</Link> lesen.',
       },
-      verify_signature: {
-        eliptic_curve_heading:
-          'Elliptic Curve Digital Signature Algorithmus (ECDSA)',
-        eliptic_curve_paragraph_one:
-          'ECDSA ist ein kryptographischer Algorithmus, der von Bitcoin verwendet wird, um sicherzustellen, dass Gelder nur von ihren rechtmäßigen Eigentümern ausgegeben werden können. Ein öffentlicher Schlüssel wird von einem privaten Schlüssel durch elliptische Kurvenmultiplikation abgeleitet, was rechnerisch einfach ist. Die Umkehrung dieses Prozesses zur Ableitung des privaten Schlüssels aus dem öffentlichen Schlüssel ist jedoch rechnerisch nicht machbar. Diese Einwegfunktion ist ein Eckpfeiler der Sicherheit von Bitcoin.',
-        public_private_key_heading: 'Public and Private Keys',
-        public_private_key_paragraph_one:
-          'In Bitcoin wird ein Schlüsselpaar verwendet, um sichere Transaktionen zu gewährleisten. Der private Schlüssel, der geheim gehalten wird, wird verwendet, um Transaktionen zu signieren und den Besitz einer Bitcoin-Adresse zu beweisen. Der öffentliche Schlüssel, der vom privaten Schlüssel abgeleitet ist, kann weitergegeben werden und wird verwendet, um zu überprüfen, ob eine Unterschrift vom Inhaber des privaten Schlüssels geleistet wurde, ohne den privaten Schlüssel preiszugeben.',
-        signature_verification_heading: 'Signatur Verifizierung',
+      derive_message_four: {
+        op_checksig_heading: 'ON_CHECKSIG',
+        op_checksig_paragraph_one:
+          'OP_CHECKSIG in Bitcoin-Skripten ist von entscheidender Bedeutung, um sicherzustellen, dass der richtige private Schlüssel eine bestimmte Transaktion ausgeben kann. In fast jedem Bitcoin-Skript gibt es ein OP_CHECKSIG, um sicherzustellen, dass die Person, die versucht, Bitcoin auszugeben, dies mit dem angegebenen Schlüssel tun kann. Einige dieser OP_CODES und mehr können Sie <Link href="https://en.bitcoin.it/wiki/Script#Constants" target="_blank" className="underline">hier</Link> nachlesen.',
+      },
+      derive_message_six: {
+        transaction_parts_heading: 'Transaktionsteile',
+        transaction_parts_one:
+          'Version: Diese Version gibt an, wie die Transaktion organisiert wird.',
+        transaction_parts_two:
+          'Anzahl der Eingaben: Die Anzahl der Eingaben in dieser Transaktion.',
+        transaction_parts_three:
+          'Eingabe Nr. 0 TXID: Dies ist der Hash der Transaktion, aus der Eingabe Nr. 0 ausgibt.',
+        transaction_parts_four:
+          'Eingabeindex Nr. 0: Dies ist der Ausgabeindex der durch die obige TXID identifizierten Transaktion, die eine Geldquelle bereitstellt.',
+        transaction_parts_five:
+          'Scriptsig: Dies sind die Daten, die die Ausgabe der oben angegebenen Ausgabe autorisieren. Besteht normalerweise aus Signaturen.',
+        transaction_parts_six:
+          'Eingabesequenz Nr. 0: Dies ist die Sequenznummer für die Ausgabeneingabe.',
+        transaction_parts_seven:
+          'Anzahl Ausgänge: Hiermit wird angegeben, wie viele Ausgänge der TX hat.',
+        transaction_parts_eight:
+          'Ausgabewert Nr. 0: Dies ist der Betrag, der von der ersten Ausgabe ausgegeben wird, ausgedrückt als Little-Endian-Ganzzahl.',
+        transaction_parts_nine:
+          'Ausgabe Nr. 0 scriptPubKey: Dies ist das Skript, das bestimmt, was zum Ausgeben der Mittel erforderlich ist. Besteht normalerweise aus einem öffentlichen Schlüssel und anderen Opcodes, die eine Herausforderung bilden.',
+        transaction_parts_ten:
+          'Ausgabewert Nr. 1: Dies ist der Betrag, der von der zweiten Ausgabe ausgegeben wird, ausgedrückt als Little-Endian-Ganzzahl.',
+        transaction_parts_eleven:
+          'Ausgabe Nr. 1 scriptPubKey: Dies ist das Skript, das bestimmt, was zum Ausgeben der Mittel erforderlich ist. Besteht normalerweise aus einem öffentlichen Schlüssel und anderen Opcodes, die eine Herausforderung bilden.',
+        transaction_parts_twelve:
+          'Sperrzeit: Eine Blockhöhe, vor der diese Transaktion nicht zur Bestätigung gültig ist.',
+      },
+      derive_message_seven: {
+        sighash_type_flag_heading: 'SigHash-Typ-Flag',
+        sighash_type_flag_paragraph_one:
+          'SigHash-Flags sind ein Mechanismus in Bitcoin, der definiert, welche Teile einer Transaktion in den Hash aufgenommen werden, der mit einem privaten Schlüssel signiert wird. Im Wesentlichen bestimmen sie den Umfang der Verpflichtung des Unterzeichners gegenüber bestimmten Teilen der Transaktionsdaten. Das SigHash-Flag ist ein einzelnes Byte, das an jede Signatur angehängt wird und zwischen Eingaben innerhalb derselben Transaktion variieren kann. Es gibt mehrere Arten von SigHash-Flags, über die Sie <Link href="https://river.com/learn/terms/s/sighash-flag" target="_blank" className="underline">hier</Link> mehr erfahren können.',
+      },
+      verify_signature_two: {
+        tip_one:
+          'JavaScript-Hinweis: Sie können einen Hex-String in einen Byte-Puffer umwandeln, indem Sie <span className="p-1 font-mono bg-[#0000004D] m-1">Buffer.from(someString, \'hex\');</span> verwenden.',
+        signature_verification_heading: 'Signaturprüfung',
         signature_verification_paragraph_one:
-          'Die Verifizierung von Signaturen ist in Bitcoin entscheidend, um zu bestätigen, dass eine Transaktion vom Inhaber des privaten Schlüssels autorisiert wurde. Im Kontext von ECDSA beinhaltet sie die Überprüfung, ob eine Signatur (bestehend aus zwei Zahlen, r und s) für einen bestimmten öffentlichen Schlüssel und eine Nachricht gültig ist. Diese Überprüfung gewährleistet die Integrität und Authentizität einer Transaktion.',
-        finite_field_arithmetic_heading: 'Arithmetik der endlichen Felder',
-        finite_field_arithmetic_paragraph_one:
-          'Diese Art der Arithmetik, die in ECDSA verwendet wird, umfasst Zahlen innerhalb eines festen Bereichs oder Felder. Operationen wie Addition, Subtraktion, Multiplikation und die Suche nach modularen Inversen werden in Bezug auf die Größe dieses Feldes durchgeführt. Dies ist wesentlich für die elliptischen Kurvenberechnungen in der Bitcoin-Kryptographie.',
-        ge_and_fe_heading: 'Gruppen Elemente (GE) und Felder Elemente (FE)',
-        ge_and_fe_paragraph_one:
-          'Im Zusammenhang mit der Kryptographie elliptischer Kurven stellt ein Gruppenelement normalerweise einen Punkt auf der elliptischen Kurve dar. In der Aufgabe bezieht sich GE auf einen solchen Punkt mit bestimmten x- und y-Koordinaten. FE steht für ein Element des endlichen Feldes, das für Berechnungen innerhalb der Feldbeschränkungen verwendet wird.',
-        modular_inverse_heading: 'Modularer Kehrwert',
-        modular_inverse_paragraph_one:
-          'Der modulare Kehrwert einer Zahl a modulo m ist eine Zahl b, für die (a * b) % m = 1 gilt. Die Ermittlung des modularen Kehrwerts ist ein wichtiger Schritt bei der ECDSA-Signaturprüfung. Er wird bei der Berechnung von u1 und u2 während des Verifikationsprozesses verwendet.',
+          'Die Signaturüberprüfung ist ein mathematischer Algorithmus, bei dem eine Partei ein Datenelement (die Signatur) bereitstellt, das nur generiert werden kann, wenn diese Partei eine geheime Nummer (den privaten Schlüssel) kennt. Bei der Überprüfung werden die Signatur, der öffentliche Schlüssel und eine bestimmte Nachricht verglichen. Wenn der Algorithmus einen Booleschen Wert TRUE ausgibt, gilt die Signatur als authentisch.',
       },
-      validate_signature: {
-        message_verification_heading:
-          'Die Wichtigkeit der Nachrichtenverifizierung',
+      verify_signature_three: {
+        signature_encoding_heading: 'Signaturcodierung',
+        signature_encoding_paragraph_one:
+          'Eine (DER)-Signatur oder Distinguished Encoding Rules ist einfach ein Format, das zum Kodieren einer ECDSA-Signatur in Bitcoin verwendet wird. Eine ECDSA-Signatur wird mithilfe eines privaten Schlüssels und eines Hashs der signierten Nachricht generiert. Sie besteht aus zwei 32-Byte-Zahlen (r,s). Sie hat mehrere Komponenten, über die Sie <Link href="https://technicaldifficulties.io/2020/07/22/bip-66-unpacking-der-signatures/" target="_blank" className="underline">hier</Link> mehr erfahren können.',
+      },
+      verify_signature_four: {
+        eliptic_curve_heading:
+          'Algorithmus für digitale Signaturen mit elliptischen Kurven (ECDSA)',
+        eliptic_curve_paragraph_one:
+          'ECDSA ist ein kryptografischer Algorithmus, der von Bitcoin verwendet wird, um sicherzustellen, dass Gelder nur von ihren rechtmäßigen Eigentümern ausgegeben werden können. Ein öffentlicher Schlüssel wird durch elliptische Kurvenmultiplikation aus einem privaten Schlüssel abgeleitet, was rechnerisch unkompliziert ist. Die Umkehrung dieses Prozesses, um den privaten Schlüssel aus dem öffentlichen Schlüssel abzuleiten, ist jedoch rechnerisch nicht machbar. Diese Einwegfunktion ist ein Eckpfeiler der Sicherheit von Bitcoin.',
+        public_private_key_heading: 'Öffentliche und private Schlüssel',
+        public_private_key_paragraph_one:
+          'Bei Bitcoin wird ein Schlüsselpaar verwendet, um sichere Transaktionen zu gewährleisten. Der geheim gehaltene private Schlüssel wird verwendet, um Transaktionen zu signieren und den Besitz einer Bitcoin-Adresse nachzuweisen. Der öffentliche Schlüssel, der vom privaten Schlüssel abgeleitet ist, kann weitergegeben werden und wird verwendet, um zu überprüfen, ob eine Signatur vom Inhaber des privaten Schlüssels stammt, ohne den privaten Schlüssel preiszugeben.',
+      },
+      verify_signature_five: {
+        finite_field_arithmetic_heading: 'Finite-Körper-Arithmetik',
+        finite_field_arithmetic_paragraph_one:
+          'Diese Art der Arithmetik, die in ECDSA verwendet wird, umfasst Zahlen innerhalb eines festen Bereichs oder Felds. Operationen wie Addition, Subtraktion, Multiplikation und das Finden modularer Inverser werden in Bezug auf die Größe dieses Felds ausgeführt. Dies ist für die elliptischen Kurvenberechnungen in der Kryptographie von Bitcoin von wesentlicher Bedeutung.',
+        ge_and_fe_heading: 'Gruppenelemente (GE) und Feldelemente (FE)',
+        ge_and_fe_paragraph_one:
+          'Im Kontext der elliptischen Kurvenkryptographie stellt ein Gruppenelement typischerweise einen Punkt auf der elliptischen Kurve dar. In der Herausforderung bezieht sich GE auf einen solchen Punkt mit bestimmten x- und y-Koordinaten. FE stellt ein Element des endlichen Felds dar, das für Berechnungen innerhalb der Beschränkungen des Felds verwendet wird.',
+        modular_inverse_heading: 'Modulare Umkehrung',
+        modular_inverse_paragraph_one:
+          'Das modulare Inverse einer Zahl a modulo m ist eine Zahl b, sodass (a * b) % m = 1. Das Finden des modularen Inversen ist ein kritischer Schritt bei der ECDSA-Signaturüberprüfung. Es wird während des Überprüfungsprozesses zur Berechnung von u1 und u2 verwendet.',
+      },
+      validate_signature_one: {
+        message_verification_heading: 'Bedeutung der Nachrichtenüberprüfung',
         message_verification_paragraph_one:
-          'Die Nachrichtenverifizierung erhöht die Sicherheit der Kommunikation innerhalb des Bitcoin-Ökosystems. Sie ermöglicht es den Parteien, die Authentizität und Integrität von Nachrichten zu verifizieren, was in Situationen wertvoll ist, in denen Vertrauen und Verifikation essentiell sind, wie z.B. bei Peer-to-Peer-Transaktionen oder der Kommunikation zwischen Parteien in einem Smart Contract. Darüber hinaus dient die Nachrichtenüberprüfung als Grundlage für verschiedene Anwendungen, einschließlich der Identitätsüberprüfung und der Bescheinigung des Eigentums an einer bestimmten Bitcoin-Adresse. Sie fügt eine Ebene der kryptographischen Sicherheit hinzu und verstärkt die vertrauenslose und dezentrale Natur des Bitcoin-Netzwerks.',
+          'Die Nachrichtenüberprüfung erhöht die Sicherheit der Kommunikation innerhalb des Bitcoin-Ökosystems. Sie ermöglicht es den Parteien, die Authentizität und Integrität von Nachrichten zu überprüfen, was in Situationen wertvoll ist, in denen Vertrauen und Überprüfung unerlässlich sind, wie etwa bei Peer-to-Peer-Transaktionen oder der Kommunikation zwischen Parteien in einem Smart Contract. Darüber hinaus dient die Nachrichtenüberprüfung als Grundlage für verschiedene Anwendungen, darunter die Identitätsüberprüfung und die Bestätigung des Eigentums an einer bestimmten Bitcoin-Adresse. Sie fügt eine Ebene kryptografischer Sicherheit hinzu und verstärkt die vertrauenslose und dezentrale Natur des Bitcoin-Netzwerks.',
+      },
+      validate_signature_two: {
+        base64_encoding_heading: 'Base64-Kodierung',
+        base64_encoding_paragraph_one:
+          'Base64 ist ein einfaches Byte-zu-Text-Kodierungsschema, das lediglich die Konvertierung von Daten in Bytes ermöglicht, die dann in Puffern verwendet oder von Bytes in Text umgewandelt werden können, und zwar auf eine Weise, die alle Probleme mit URL-Pfaden und Abfrageparametern vermeidet. Dies unterscheidet sich vom Base58-Kodierungsschema dadurch, dass es immer noch die ähnlichen Zeichen (Null, großes „O“, großes „I“ und kleines „l“) enthält, die andernfalls für einen Benutzer verwirrend sein könnten, wenn er versucht, die kodierte Nachricht zu kopieren oder zu diktieren.',
+      },
+      validate_signature_three: {
+        signing_and_ownership_heading:
+          'Nachrichtensignatur und Eigentumsrechte',
+        signing_and_ownership_paragraph_one:
+          'Aufgrund der Pseudo-Anonymität von Bitcoin sind wir in unseren Beweismöglichkeiten eingeschränkt, da der Besitzer eines Schlüssels die Signatur einer Nachricht verweigern oder eine Nachricht absichtlich mit einem falschen Schlüssel signieren kann. Das Einzige, was wir beweisen können, ist, dass der Schlüssel, der eine ungültige Signatur erzeugt, nicht mit einem Schlüssel übereinstimmt, mit dem eine Nachricht signiert werden kann.',
+      },
+      validate_signature_four: {
+        one_for_one_heading: 'Eins für Eins',
+        one_for_one_paragraph_one:
+          'Um die Zuverlässigkeit und Sicherheit von ECDSA zu gewährleisten, kann eine mit einem privaten Schlüssel erstellte Signatur nur mit dem entsprechenden öffentlichen Schlüssel verifiziert werden. Wenn verschiedene private Schlüssel denselben öffentlichen Schlüssel oder dieselbe Signatur erzeugen könnten, würde dies die Sicherheit und Zuverlässigkeit von ECDSA untergraben. Dadurch können wir wissen, dass der öffentliche Schlüssel, der diese Nachricht signieren konnte, Eigentümer dieses Bitcoins ist.',
       },
     },
   },
-
   chapter_six: {
-    title: `Angriff ist die beste Verteidigung`,
+    title: 'Der Schlüsselhalter',
+    paragraph_one:
+      'Ahhh! Vanderpoole hat es auf Sie abgesehen, weil Sie seine betrügerischen Behauptungen aufgedeckt haben. Doch obwohl der Holocaust nun aus dem Sack ist, halten viele verängstigte Menschen weiterhin an dem Mythos fest, den Vanderpoole um sich selbst, seine Familie und ihre angebliche Abstammung geschaffen hat. Die Zeiten sind beängstigend und die Menschen brauchen einen Helden. Leider ist er für viele der Beste, den sie haben.',
     intro_one: {
-      title: 'Intro',
+      title: 'Einleitung',
+      nav_title: 'War das wirklich Satoshi',
       paragraph_one:
-        '—SATOSHI NAKAMOTO: ”Großartige Arbeit. Jetzt kann die Welt mit eigenen Augen sehen, dass Vanderpoole ein Betrüger ist. Auch wenn einige es noch nicht glauben, werden sie es tun, bevor unsere Arbeit getan ist.” – Satoshi Nakamoto',
+        '—SATOSHI NAKAMOTO: „Gut gemacht. Jetzt kann die Welt selbst sehen, dass Vanderpoole ein Betrüger ist. Auch wenn manche es noch nicht glauben, werden sie es tun, bevor unsere Arbeit getan ist.“',
       paragraph_two:
-        '—Du hälst einen Moment inne und stellst fest, dass jede Nachricht bis zu diesem Zeitpunkt mit "Satoshi Nakamoto" unterzeichnet war. Du hattest einfach angenommen, dass es sich um einen pseudonymen Namen handelt, der von jemandem verwendet wird, der sich an die Grundprinzipien von Bitcoin hält. Sicherlich konnte er nicht der echte Satoshi Nakamoto sein. Aber schließlich beschließst Du, dass es sich lohnt zu fragen.',
+        'Sie halten einen Moment inne und stellen fest, dass jede Nachricht bis zu diesem Zeitpunkt mit „Satoshi Nakamoto“ unterzeichnet war. Sie hatten gerade angenommen, dass dies ein Pseudonym von jemandem war, der sich an die Grundprinzipien von Bitcoin hält. Das kann doch nicht der echte Satoshi Nakamoto sein. Aber Sie entscheiden schließlich, dass es sich lohnt, danach zu fragen.',
       paragraph_three:
-        '—”Das klingt jetzt vielleicht blöd, aber sind Sie der echte Satoshi?”',
-      paragraph_four:
-        '—HOLOKATZE: “Das ist wohl kaum das Einzige, was Dich bisher dumm erscheinen ließ.”',
+        '— „Das klingt vielleicht dumm, aber sind Sie der echte Satoshi?“',
     },
     intro_two: {
+      title: 'Einleitung',
+      nav_title: 'Mika 3000 bezahlen',
       paragraph_one:
-        '—HOLOKATZE: “Das ist wohl kaum das Einzige, was Dich bisher dumm erscheinen ließ.”',
+        '—HOLOCAT: „Das ist kaum das Einzige, was dich in letzter Zeit dumm klingen lässt.“',
       paragraph_two:
-        '—SATOSHI NAKAMOTO: “Bitcoin hat sich vor vielen, vielen Jahren weit außerhalb der Kontrolle seines Schöpfers bewegt. Es würde keine Rolle spielen, ob Vanderpoole oder ich Satoshis Enkel wären. Bitcoin wird von der Gemeinschaft definiert und kann nicht von einem einzelnen Individuum oder einer Entität vereinnahmt werden - Satoshi eingeschlossen. Dies zu beweisen, ist der wahre Kampf. Ich hoffe, es macht Dir nichts aus, aber ich habe Deinen exzentrischen, freiberuflichen Reporterfreund gebeten, sich zu melden.”',
-      paragraph_three: '—Er hat was? Ding.',
-      paragraph_four: '—HOLOCAT: Vergiss nicht auf meine Nase zu drücken.',
-      paragraph_five:
-        '—MIKE RAMEN: “Du hast Mumm. Aber Du brauchst mehr. Was du entdeckt hast, ist nur der Anfang. Es gibt noch mehr zu dieser Geschichte, aber wir müssen Vanderpooles Privatinsel besuchen, um es zu bekommen. Das wird teuer, also könnte ich deine Hilfe dabei gebrauchen, meine Gelder von der Multi-signature-Wallet abzuziehen, bei der du mir geholfen hast, sie einzurichten. Du hast immer noch einen meiner Schlüssel, richtig?”',
+        '—SATOSHI NAKAMOTO: „Bitcoin hat sich vor vielen Jahren der Kontrolle seines Schöpfers entzogen. Es wäre egal, ob Vanderpoole oder ich Satoshi oder einer ihrer Nachkommen wären. Bitcoin wird von seiner Community definiert und kann nicht von einer einzelnen Person oder Entität – einschließlich Satoshi – vereinnahmt werden. Dies zu beweisen, ist der wahre Kampf. Ich hoffe, es macht Ihnen nichts aus, aber ich habe Ihren exzentrischen Freund, den freiberuflichen Reporter, gebeten, sich bei mir zu melden.“',
+      paragraph_three: '—Er was?',
+      paragraph_four: '—Ding.',
+      paragraph_five: '—HOLOCAT: Vergiss nicht, mich anzustupsen.',
+      paragraph_six:
+        '—MIKA 3000: „Du hast Mumm, aber Mumm allein reicht nicht. Was du entdeckt hast, ist nur der Anfang. Es steckt noch mehr hinter dieser Geschichte, aber wir müssen Vanderpooles Privatinsel besuchen, um sicher zu wissen, was „mehr“ bedeutet. Das wird viel kosten, also könnte ich deine Hilfe gebrauchen, um Geld von der Multisig-Wallet abzuheben, die du mir beim Einrichten geholfen hast. Du hast noch einen meiner Schlüssel, oder?“',
     },
-    paragraph_one:
-      'Vanderpoole hat es auf Dich abgesehen, jetzt, da Du ihn als Betrüger entlarvt hast. Aber trotzdem klammern sich viele verängstigte Menschen weiterhin an den Mythos, den er um sich selbst, seine Familie und ihre angebliche Abstammung geschaffen hat. Die Zeiten sind beängstigend, und die Menschen brauchen einen Helden. Leider ist er für viele der beste, den sie haben.',
-    in_out_two: {
-      title: 'Die Details kennen',
+    in_out_one: {
+      title: 'Die Vor- und Nachteile',
+      nav_title: 'Der nicht ausgegebene UTXO',
       paragraph_one:
-        'Mike Ramen gibt Dir eine Adresse, an die Du Deinen Beitrag von 1 BTC schicken kannst:',
+        'Mika 3000 braucht 1 BTC, um Ausrüstung für ihre Reise zu Vanderpooles Privatinsel zu kaufen. Sie beschließen, ihr 1 BTC aus Ihren Mining-Belohnungen aus Kapitel 3 zu schicken, die vom Mining-Pool an die Adresse gesendet wurden, die Sie in Kapitel 4 erstellt haben.',
       paragraph_two:
-        'Hm, diese Adresse sieht viel länger aus als Deine! Ich frage mich, warum...',
-      paragraph_three: `Wie auch immer, wir müssen eine Transaktion erstellen und unterschreiben, die einen Deiner 1,61 BTC an diese Adresse sendet. Wir haben uns Satoshis Transaktionsstruktur in Kapitel 5 angeschaut, aber Deine Transaktion wird ein bisschen anders sein. Die Technologie hat sich seit Block 170 stark verbessert, und Bitcoin-Transaktionen sind jetzt Version 2 und folgen einem neuen Protokoll namens Segregated Witness.`,
+        'Sie öffnen Ihren Bitcoin-Vollknoten und führen einen Befehl aus, um zu sehen, wo sich Ihr Geld in der Blockchain befindet.',
+      paragraph_three:
+        'Dies ist eine nicht ausgegebene Transaktionsausgabe (auch bekannt als „UTXO“). Sie erkennen Ihren komprimierten öffentlichen Schlüssel-Hash und Ihre Adresse möglicherweise aus Kapitel 4. Auch der Betrag sieht richtig aus: 1,61 BTC.',
+    },
+    in_out_two: {
+      title: 'Die Vor- und Nachteile',
+      nav_title: 'Die Empfangsadresse',
+      paragraph_one:
+        'Mika 3000 gibt Ihnen eine Adresse, an die Sie Ihren 1-BTC-Beitrag senden können:',
+      paragraph_two:
+        'Hm, diese Adresse sieht viel länger aus als deine! Ich frage mich, warum ...',
+      paragraph_three:
+        'Wir müssen eine Transaktion erstellen und unterzeichnen, die einen Ihrer 1,61 BTC an diese Adresse sendet. Wir haben uns Satoshis Transaktionsstruktur in Kapitel 5 angesehen, aber Ihre wird etwas anders sein. Heute gibt es neuere Methoden zum Erstellen von Transaktionen. Wir verwenden ein Protokoll namens Segregated Witness, das die Transaktionsversion auf 2 setzt.',
     },
     in_out_three: {
-      title: 'Die Details kennen',
+      title: 'Die Vor- und Nachteile',
+      nav_title: 'Transaktionsschritte',
       paragraph_one:
-        'Segregierte Witness-Transaktionen funktionieren genauso wie ihre alten Vorgänger. Es gibt ein paar globale Werte wie Version und Sperrzeit (Locktime). Es gibt eine Reihe von Eingängen (UTXOs, die wir ausgeben wollen) und eine Reihe von Ausgängen (neue UTXOs, die wir erstellen wollen, damit andere Leute sie in Zukunft ausgeben können). Es wird auch eine Reihe von Witnessen geben, einen für jeden Input. Dort werden Signaturen und Skripte anstelle von scriptSig abgelegt.',
+        'Segregated Witness-Transaktionen funktionieren genau wie ihre Vorgänger. Es gibt einige globale Werte wie Version und Sperrzeit. Es gibt ein Array von Eingaben (UTXOs, die wir ausgeben möchten) und ein Array von Ausgaben (neue UTXOs, die wir erstellen möchten, damit andere Personen sie in Zukunft ausgeben können). Es wird auch ein Array von Zeugen geben, einen für jede Eingabe. Dorthin werden Signaturen und Skripte anstelle des Skriptsignaturs gehen.',
       paragraph_two:
-        'Die Serialisierung zur Übermittlung für alle diese Komponenten ist <Link href="https://en.bitcoin.it/wiki/Protocol_documentation#tx" target="_blank" className="underline">hier</Link>  und <Link href="https://github.com/bitcoinbook/bitcoinbook/blob/develop/ch06.asciidoc" target="_black" className="underline" >hier</Link> dokumentiert.',
+        'Die Nachrichtenserialisierungen für alle diese Komponenten sind <Link href="https://en.bitcoin.it/wiki/Protocol_documentation#tx" target="_blank" className="underline">hier</Link> und <Link href="https://github.com/bitcoinbook/bitcoinbook/blob/6d1c26e1640ae32b28389d5ae4caf1214c2be7db/ch06_transactions.adoc" target="_black" className="underline" >hier</Link> dokumentiert.',
+    },
+    in_out_four: {
+      normal: {
+        title: 'Die Vor- und Nachteile',
+        nav_title: 'Die Eingabeklasse',
+        heading: 'Betrachtung der Implementierung der Input-Klasse',
+        paragraph_one:
+          'Bitcoin-Transaktionseingaben verweisen immer auf vorhandene, nicht ausgegebene Transaktionsausgaben. Daher verfügt unsere Input-Klasse über eine Methode <span className="text-green"> from_output() </span>, die zum Erstellen einer Eingabe durch Übergabe der Ausgabebeschreibung verwendet wird:',
+        paragraph_two:
+          'Die ersten beiden Argumente sind die Transaktions-ID und der Index der Ausgabe der Transaktion, von der Sie ausgeben möchten. Schließlich übergeben wir die txid- und vout-Werte, die Sie oben von listunspent erhalten haben.',
+        paragraph_three: {
+          a: 'Hashes in Bitcoin sind',
+          b: {
+            text: ' umgedreht ',
+            question: 'Warum verwenden wir in Bitcoin umgekehrte Hashes?',
+            href: 'https://chat.bitcoinsearch.xyz/?author=holocat&question=why%2520are%2520hashes%2520reversed%2520in%2520bitcoin',
+          },
+          c: 'wenn wir sie als hexadezimale Zeichenfolgen sehen. Wenn wir Hashes als Zeichenfolgen von einem Benutzer akzeptieren, müssen wir die Bytereihenfolge umkehren, bevor wir sie als Rohbytes speichern oder übertragen. Aus diesem Grund kehren wir die Bytereihenfolge des hier übergebenen txid-Arguments um.',
+        },
+        paragraph_four:
+          'Die zweiten beiden Argumente sind der Wert der Ausgabe, die wir ausgeben möchten (in Satoshis) und etwas, das als Skriptcode bezeichnet wird. Vorerst speichern wir diese Daten einfach als leeres Byte-Array, wir werden sie erst später benötigen.',
+        paragraph_five:
+          'Wir benötigen außerdem eine <span className="text-green"> serialize() </span>-Methode, die ein Byte-Array gemäß der Spezifikation zurückgibt. So wird die Transaktion tatsächlich zwischen Knoten im Netzwerk gesendet und so wird sie in einem Block ausgedrückt:',
+        heading_two: 'Endpunkt',
+        table_one: {
+          heading: {
+            one: 'Beschreibung',
+            two: 'Name',
+            three: 'Typ',
+            four: 'Größe',
+          },
+          row_one: {
+            column: {
+              one: 'Hash der Transaktion, die ausgegeben wird von',
+              two: 'txid',
+              three: 'Bytes',
+              four: '32',
+            },
+          },
+          row_two: {
+            column: {
+              one: 'Position der ausgegebenen Ausgabe im Ausgabe-Array der Transaktion',
+              two: 'Index',
+              three: 'int',
+              four: '4',
+            },
+          },
+        },
+        heading_three: 'Eingang',
+        table_two: {
+          row_one: {
+            column: {
+              one: 'txid und Ausgabeindex werden ausgegeben von',
+              two: 'Ausgangspunkt',
+              three: 'Bytes',
+              four: '36',
+            },
+          },
+          row_two: {
+            column: {
+              one: 'ScriptSig-Länge (immer 0 für Segregated Witness)',
+              two: 'Länge',
+              three: 'int',
+              four: '1',
+            },
+          },
+          row_three: {
+            column: {
+              one: 'Für Segregated Witness immer leer',
+              two: 'Skript',
+              three: 'Bytes',
+              four: '0',
+            },
+          },
+          row_four: {
+            column: {
+              one: 'Der Standardwert ist 0xffffffff, kann aber für relative Zeitsperren verwendet werden',
+              two: 'Sequenz',
+              three: 'int',
+              four: '4',
+            },
+          },
+        },
+        paragraph_six:
+          'Und denken Sie daran: Ganzzahlen in Bitcoin werden im Little-Endian-Format serialisiert!',
+        success: 'Die Input-Klasse sieht gut aus. Gute Arbeit!',
+      },
+      hard: {
+        title: 'Die Vor- und Nachteile',
+        nav_title: 'Erstellen der Eingabeklasse',
+        heading: 'Beenden Sie die Implementierung von Class Input',
+        paragraph_one: 'Es sollte die folgende Methode haben:',
+        paragraph_two:
+          'Die ersten beiden Argumente sind die Transaktions-ID und der Index der Ausgabe der Transaktion, die Sie ausgeben möchten.',
+        paragraph_three:
+          'Schließlich werden wir die txid- und vout-Werte übergeben, die Sie oben von listunspent erhalten haben. Beachten Sie, dass Hashes in Bitcoin Little-Endian sind, was bedeutet, dass Sie die Byte-Reihenfolge der txid-Zeichenfolge umkehren müssen!',
+        paragraph_four:
+          'Die zweiten beiden Argumente sind der Wert der Ausgabe, die wir ausgeben möchten (in Satoshis) und etwas, das als Skriptcode bezeichnet wird. Speichern Sie diese Daten vorerst einfach als Eigenschaften der Input-Klasse, wir werden sie erst in Schritt 6 benötigen.',
+        paragraph_five:
+          'Wir benötigen außerdem eine <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">serialize()</span>-Methode, die ein Byte-Array gemäß der Spezifikation zurückgibt:',
+        heading_two: 'Endpunkt',
+        table_one: {
+          heading: {
+            one: 'Beschreibung',
+            two: 'Name',
+            three: 'Typ',
+            four: 'Größe',
+          },
+          row_one: {
+            column: {
+              one: 'Hash der Transaktion, die ausgegeben wird von',
+              two: 'txid',
+              three: 'Bytes',
+              four: '32',
+            },
+          },
+          row_two: {
+            column: {
+              one: 'Position der ausgegebenen Ausgabe im Ausgabe-Array der Transaktion',
+              two: 'Index',
+              three: 'int',
+              four: '4',
+            },
+          },
+        },
+        heading_three: 'Eingang',
+        table_two: {
+          row_one: {
+            column: {
+              one: 'txid und Ausgabeindex werden ausgegeben von',
+              two: 'Ausgangspunkt',
+              three: 'Bytes',
+              four: '36',
+            },
+          },
+          row_two: {
+            column: {
+              one: 'ScriptSig-Länge (immer 0 für Segregated Witness)',
+              two: 'Länge',
+              three: 'int',
+              four: '1',
+            },
+          },
+          row_three: {
+            column: {
+              one: 'Für Segregated Witness immer leer',
+              two: 'Skript',
+              three: 'Bytes',
+              four: '0',
+            },
+          },
+          row_four: {
+            column: {
+              one: 'Der Standardwert ist 0xffffffff, kann aber für relative Zeitsperren verwendet werden',
+              two: 'Sequenz',
+              three: 'int',
+              four: '4',
+            },
+          },
+        },
+        success: 'Die Input-Klasse sieht gut aus. Gute Arbeit!',
+      },
+    },
+    in_out_five: {
+      title: 'Die Vor- und Nachteile',
+      nav_title: 'Erstellen der Ausgabeklasse',
+      heading: 'Beenden Sie die Implementierung der Output-Klasse',
+      paragraph_one:
+        'Wie die Input-Klasse benötigt sie eine Methode <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">from_options()</span>, die aus benutzerdefinierten Daten ein Output-Objekt erstellt:',
+      paragraph_two:
+        'Es akzeptiert eine Bitcoin-Adresse als Zeichenfolge (wie die Adresse von Mika 3000) und einen Wert als Ganzzahl. Der Wert wird als Anzahl von Satoshis ausgedrückt! Denken Sie daran, 1 BTC = 100000000 Satoshis. Sie müssen unsere bech32-Bibliothek erneut verwenden, um die Adresse in Versions- und Datenkomponenten zu dekodieren.\nDie Klasse benötigt außerdem eine <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">serialize()</span>-Methode, die ein Byte-Array gemäß der Spezifikation zurückgibt:',
+      heading_two: 'Ausgabe',
+      table: {
+        heading: {
+          one: 'Beschreibung',
+          two: 'Name',
+          three: 'Typ',
+          four: 'Größe',
+        },
+        row_one: {
+          column: {
+            one: 'Anzahl der gesendeten Satoshis.',
+            two: 'Wert',
+            three: 'Bytes',
+            four: '8',
+          },
+        },
+        row_two: {
+          column: {
+            one: 'Gesamtlänge des folgenden Skripts (des „Zeugenprogramms“).“',
+            two: 'Länge',
+            three: 'int',
+            four: '1',
+          },
+        },
+        row_three: {
+          column: {
+            one: 'Die Segregated Witness-Version. Abgeleitet von der bech32-Adresse.',
+            two: 'Version',
+            three: 'int',
+            four: '1',
+          },
+        },
+        row_four: {
+          column: {
+            one: 'Länge der folgenden Zeugenprogrammdaten.',
+            two: 'Länge',
+            three: 'int',
+            four: '1',
+          },
+        },
+        row_five: {
+          column: {
+            one: 'Die aus der Bech32-Adresse abgeleitete Datenkomponente.',
+            two: 'Index',
+            three: 'Bytes',
+            four: '(unser)',
+          },
+        },
+      },
       paragraph_three:
-        'Und denk bitte daran: Integers werden in Bitcoin als little-endian serialisiert!',
+        'Vergessen Sie nicht: Ganzzahlen in Bitcoin werden im Little-Endian-Format serialisiert!',
+      success: 'Die Ausgabeklasse sieht gut aus. Gute Arbeit!',
     },
     put_it_together_one: {
-      title: 'Das Ganze zusammenfügen',
+      normal: {
+        title: 'Alles zusammenfügen',
+        nav_title: 'Erstellen des Transaktionsdigests',
+        heading: 'Transaktionsübersicht',
+        paragraph_one:
+          'In Kapitel 5 haben wir gelernt, dass wir zum Signieren einer Transaktion zunächst deren Daten neu anordnen und in eine Nachricht hashen müssen, die dann zu einem der Roheingaben für unseren Signieralgorithmus wird. Da wir jetzt Segregated Witness verwenden, müssen wir auch den aktualisierten Transaktions-Digest-Algorithmus implementieren, der in <Link href="https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki" target="_blank" className="underline">BIP 143</Link> angegeben ist.',
+        paragraph_two:
+          'Denken Sie daran, dass jeder Transaktions-Input seine eigene Signatur benötigt. Einige Komponenten des Digest-Algorithmus können zwischengespeichert und wiederverwendet werden, andere unterscheiden sich jedoch, je nachdem, welcher Input signiert wird! Beenden Sie die Transaktionsmethode <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">digest(input_index)</span>, die die 32-Byte-Nachricht zum Signieren eines Inputs berechnet.',
+        list_heading: 'Einige Hinweise:',
+        list_one: '„Double SHA-256“ oder dSHA256 = sha256(sha256(data))',
+        list_two:
+          'value ist die Menge der Satoshis in der Ausgabe, die ausgegeben werden. Wir haben es in Schritt 2 zu unserer Eingabeklasse hinzugefügt und es bis jetzt einfach dort in der Klasse gespeichert.',
+        list_three:
+          'scriptcode ist das Roh-Bitcoin-Skript, das ausgewertet wird. Wir haben es in Schritt 2 auch zu unserer Input-Klasse hinzugefügt.',
+        list_four: 'Alle Ganzzahlen werden als Little-Endian kodiert!',
+        paragraph_three:
+          'Wir werden im nächsten Abschnitt tiefer darauf eingehen, aber um von Ihrer Pay-to-Witness-Public-Key-Hash (P2WPKH)-Adresse aus Geld auszugeben, würde Ihr Skriptcode lauten:',
+        paragraph_four:
+          '... das sich in das folgende Bitcoin-Skript dekodieren lässt.',
+        paragraph_five:
+          'Weitere Informationen zum Skriptcode finden Sie unter <Link href="https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki" target="_blank" className="underline">BIP 143</Link>.',
+        paragraph_six:
+          'Die Rohtransaktion verfügt über ein Urbild, das die Serialisierung von Folgendem darstellt:',
+        headings: {
+          item_one: 'Beschreibung',
+          item_two: 'Name',
+          item_three: 'Typ',
+          item_four: 'Größe',
+        },
+        table: {
+          row_one: {
+            item_one: 'Transaktionsversion, Standard 2',
+            item_two: 'Version',
+            item_three: 'int',
+            item_four: '4',
+          },
+          row_two: {
+            item_one:
+              'Der dSHA256 aller Outpoints von allen Inputs, serialisiert',
+            item_two: 'Bytes',
+            item_three: 'Bytes',
+            item_four: '32',
+          },
+          row_three: {
+            item_one:
+              'Der dSHA256 aller Sequenzwerte aus allen Eingängen, serialisiert',
+            item_two: 'Sequenzen',
+            item_three: 'Bytes',
+            item_four: '32',
+          },
+          row_four: {
+            item_one:
+              'Der serialisierte Outpoint des einzelnen Inputs, der signiert wird',
+            item_two: 'Ausgangspunkt',
+            item_three: 'Bytes',
+            item_four: '36',
+          },
+          row_five: {
+            item_one: 'Das Ausgabeskript wird ausgegeben von',
+            item_two: 'Skriptcode',
+            item_three: 'Bytes',
+            item_four: '(unser)',
+          },
+          row_six: {
+            item_one:
+              'Der Wert in Satoshis, der von dem einzelnen Input ausgegeben wird, der signiert wird',
+            item_two: 'Wert',
+            item_three: 'int',
+            item_four: '8',
+          },
+          row_seven: {
+            item_one: 'Der Sequenzwert des einzelnen Inputs, der signiert wird',
+            item_two: 'Sequenz',
+            item_three: 'int',
+            item_four: '4',
+          },
+          row_eight: {
+            item_one: 'Der dSHA256 aller Ausgänge, serialisiert',
+            item_two: 'Ausgänge',
+            item_three: 'Bytes',
+            item_four: '32',
+          },
+          row_nine: {
+            item_one: 'Transaktionssperrzeit, Standard 0',
+            item_two: 'Sperrzeit',
+            item_three: 'int',
+            item_four: '4',
+          },
+          row_ten: {
+            item_one:
+              'Signatur-Hash-Typ, wir verwenden 1, um „ALLE“ anzuzeigen',
+            item_two: 'seufzen',
+            item_three: 'int',
+            item_four: '4',
+          },
+        },
+        paragraph_seven:
+          'Schließlich ist die Nachricht, die wir signieren, der doppelte SHA-256 aller dieser serialisierten Daten.',
+        success: 'Die Digest()-Methode sieht gut aus. Gute Arbeit!',
+      },
+      hard: {
+        title: 'Alles zusammenfügen',
+        nav_title: 'Erstellen der Zeugenklasse',
+        heading: 'Beenden Sie die Implementierung von Class Witness',
+        paragraph_one:
+          'Es sollte die folgende Methode haben, die ein Byte-Array akzeptiert und dieses Element zum Zeugenstapel hinzufügt.',
+        paragraph_two:
+          'Außerdem wird eine <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">serialize()</span>-Methode benötigt, die den serialisierten Zeugenstapel zurückgibt.',
+        subheading_one: 'Zeugenstapel',
+        headings: {
+          item_one: 'Beschreibung',
+          item_two: 'Name',
+          item_three: 'Typ',
+          item_four: 'Größe',
+        },
+        table_one: {
+          row_one: {
+            item_one: 'Die Anzahl der Elemente im Zeugenstapel',
+            item_two: 'zählen',
+            item_three: 'int',
+            item_four: '1',
+          },
+          row_two: {
+            item_one: 'Serialisierte Stapelelemente',
+            item_two: 'Artikel',
+            item_three: '(Artikel)',
+            item_four: '(unser)',
+          },
+        },
+        subheading_two: 'Zeugenstapelelement',
+        table_two: {
+          row_one: {
+            item_one: 'Gesamtlänge des folgenden Stapelelements',
+            item_two: 'Länge',
+            item_three: 'int',
+            item_four: '1',
+          },
+          row_two: {
+            item_one: 'Die Rohbytes des Stapelelements',
+            item_two: 'Daten',
+            item_three: 'Bytes',
+            item_four: '(unser)',
+          },
+        },
+        success: 'Die Witness-Klasse sieht gut aus. Gute Arbeit!',
+      },
+    },
+    put_it_together_two: {
+      normal: {
+        title: 'Alles zusammenfügen',
+        nav_title: 'Erstellen der Zeugenklasse',
+        heading: 'Unterschreiben Sie und füllen Sie den Zeugen aus!',
+        paragraph_one:
+          'Im letzten Kapitel haben wir einige wichtige ECDSA-Signaturüberprüfungscodes geschrieben. Um nun eine gültige Signatur zu erstellen, werden wir diesen Code nehmen und ein wenig umstellen.',
+        paragraph_two:
+          'In dieser Übung implementieren wir einige der mathematischen Grundlagen des ECDSA-Signaturalgorithmus. Weitere Informationen zur Funktionsweise finden Sie in diesen Ressourcen:',
+        paragraph_three:
+          '• Die Wikipedia-Seite für <Link href="https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm" target="_blank" className="underline">Elliptic Curve Digital Signature Algorithm</Link>',
+        paragraph_four:
+          '• <Link href="https://www.secg.org/sec1-v2.pdf#subsubsection.4.1.3" target="_blank" className="underline">Standards for Efficient Cryptography 1 (SEC 1)</Link>: Seite 44, Abschnitt 4.1.3',
+        heading_one: 'Schritt 1',
+        paragraph_five:
+          'In der Klasse Transaction gibt es eine Methode, <span className="text-green p-1 text-base font-mono bg-[#0000004D] m-1">compute_input_signature(index, key)</span>, die die Indexnummer einer Eingabe und einen privaten Schlüssel (eine 32-Byte-Ganzzahl oder BigInt in JavaScript) akzeptiert. Beenden Sie diese Methode, damit sie den Nachrichten-Digest für die gewählte Eingabe berechnet. Verwenden Sie die Methode <span className="text-green p-1 text-base font-mono bg-[#0000004D] m-1">digest()</span> aus unserem letzten Schritt und geben Sie dann eine ECDSA-Signatur in Form von zwei 32-Byte-Ganzzahlen zurück: <span className="italic">r</span> und <span className="italic">s</span>.',
+        heading_two: 'Schritt 2',
+        paragraph_six:
+          'Für den Signaturalgorithmus erfordert das Bitcoin-Protokoll noch eine weitere Sache. Der <span className="italic">s</span>-Wert muss „niedrig“ sein, also kleiner als die Ordnung der Kurve geteilt durch 2. Fügen Sie diese Prüfung zu <span className="text-green p-1 text-base font-mono bg-[#0000004D] m-1">compute_input_signature()</span> hinzu.',
+        paragraph_seven:
+          'Weitere Informationen finden Sie unter <Link href="https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki#low_s" target="_blank" className="underline">BIP 146</Link>.',
+        heading_three: 'Schritt 3',
+        paragraph_eight:
+          'Vervollständigen Sie die Methode <span className="text-green p-1 text-base font-mono bg-[#0000004D] m-1">sign_input(index, key)</span>, sodass sie <span className="text-green p-1 text-base font-mono bg-[#0000004D] m-1"> compute_input_signature(index, key)</span> aufruft. Bei der Verarbeitung des Rückgabewerts müssen <span className="italic">r</span> und <span className="italic">s</span> mit einem Algorithmus namens DER kodiert werden, den wir für Sie implementiert haben.',
+        heading_four: 'Schritt 4',
+        paragraph_nine:
+          'Bitcoin erfordert ein zusätzliches Byte, das an das Ende der DER-Signatur angehängt wird. Dieses Byte stellt den „Sighash-Typ“ dar. Im Moment verwenden wir hierfür immer das Byte <span className="p-1 text-base font-mono bg-[#0000004D] m-1">0x01</span>, das „SIGHASH ALL“ anzeigt.',
+        heading_five: 'Schritt 5',
+        paragraph_ten:
+          'Der letzte Schritt besteht darin, ein Witness-Objekt mit zwei Stapelelementen zu erstellen: dem DER-codierten Signatur-Blob, den wir gerade erstellt haben, und Ihrem komprimierten öffentlichen Schlüssel. Pushen Sie zuerst die Signatur und dann den öffentlichen Schlüssel.',
+        paragraph_eleven:
+          'Hängen Sie das Zeugenstapelobjekt an das Zeugen-Array des Transaktionsobjekts an.',
+        success:
+          'Die Methoden compute_input_signature() und sign_input() sehen gut aus. Gute Arbeit!',
+      },
+      hard: {
+        title: 'Alles zusammenfügen',
+        nav_title: 'Serialisieren Sie die Transaktion',
+        heading: 'Beenden Sie die Implementierung der Klassentransaktion',
+        paragraph_one:
+          'Es sollte die globalen Eigenschaften „Locktime“ und „Version“ sowie ein Array von Eingaben, Ausgaben und Zeugenstapeln haben.',
+        paragraph_two:
+          'Es wird eine <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">serialize()</span>-Methode benötigt, die die gesamte Transaktion als für die Übertragung im Bitcoin-P2P-Netzwerk formatierte Bytes ausgibt.',
+        headings: {
+          item_one: 'Beschreibung',
+          item_two: 'Name',
+          item_three: 'Typ',
+          item_four: 'Größe',
+        },
+        table: {
+          row_one: {
+            item_one: 'Derzeit 2',
+            item_two: 'Version',
+            item_three: 'int',
+            item_four: '4',
+          },
+          row_two: {
+            item_one: 'Muss für einen getrennten Zeugen genau 0x0001 sein.',
+            item_two: 'Flaggen',
+            item_three: 'Bytes',
+            item_four: '2',
+          },
+          row_three: {
+            item_one: 'Die Anzahl der Eingänge',
+            item_two: 'in Anzahl',
+            item_three: 'int',
+            item_four: '1',
+          },
+          row_four: {
+            item_one: 'Alle Transaktionseingaben,serialisiert',
+            item_two: 'Eingänge',
+            item_three: 'Eingaben[]',
+            item_four: '(unser)',
+          },
+          row_five: {
+            item_one: 'Die Anzahl der Ausgänge',
+            item_two: 'auszählen',
+            item_three: 'int',
+            item_four: '1',
+          },
+          row_six: {
+            item_one: 'Alle Transaktionsausgaben,serialisiert',
+            item_two: 'Ausgänge',
+            item_three: 'Ausgaben[]',
+            item_four: '(unser)',
+          },
+          row_seven: {
+            item_one: 'Alle Zeugenstapel, serialisiert',
+            item_two: 'Zeuge',
+            item_three: 'Zeugen[]',
+            item_four: '(unser)',
+          },
+          row_eight: {
+            item_one: 'Das Setzen auf 0 zeigt Endgültigkeit an',
+            item_two: 'Sperrzeit',
+            item_three: 'int',
+            item_four: '4',
+          },
+        },
+        paragraph_three:
+          'Beachten Sie, dass es für Zeugen keinen „Anzahl“-Wert gibt. Das liegt daran, dass die Anzahl der Zeugenstapel immer genau der Anzahl der Eingänge entsprechen muss.',
+        success: 'Die Serialize()-Methode sieht gut aus. Gute Arbeit!',
+      },
+    },
+    put_it_together_three: {
+      normal: {
+        title: 'Alles zusammenfügen',
+        nav_title: 'Unterzeichnen Sie die Transaktion',
+        heading: 'Beenden Sie die Implementierung der Klassentransaktion',
+        paragraph_one:
+          'Um unsere Transaktion abzuschließen, benötigen wir eine <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">serialize()</span>-Methode, die die gesamte Transaktion als für die Übertragung im Bitcoin-P2P-Netzwerk formatierte Bytes ausgibt.',
+        paragraph_two:
+          'Unser Skript soll ein Transaktionsobjekt erstellen und signieren. Es wird einen Input (den UTXO, den wir in <span className="underline">der Input-Klasse</span> identifiziert haben) und zwei Outputs haben:',
+        paragraph_three:
+          'Wir kennen unseren Input, wir kennen unseren Output. Sind wir bereit, eine Transaktion zu erstellen und zu unterzeichnen? Nicht ganz. Wir haben einen Input von 1,61 BTC und einen Output von 1 BTC ... was passiert mit den anderen 0,61 BTC? Das meiste davon wird „Wechselgeld“ sein und wir müssen es an unsere eigene Adresse zurückschicken!',
+        paragraph_four:
+          'Beachten Sie, dass es für Zeugen keinen „Anzahl“-Wert gibt. Das liegt daran, dass die Anzahl der Zeugenstapel immer genau der Anzahl der Eingänge entsprechen muss.',
+        paragraph_five:
+          'Aber warten Sie! Wir müssen eine „Gebühr“ einbeziehen. Wir werden einen winzigen Teil unseres Wechselgeldes für die Mining-Pools abziehen, um sie zu motivieren, unsere Transaktion in einen Block aufzunehmen. Reduzieren wir unser Wechselgeld von 61.000.000 auf 60.999.000 Satoshis.',
+        paragraph_six:
+          'Endlich ist unsere Arbeit getan. Ihr Skript sollte am Ende das Ergebnis der Transaktionsmethode serialize() zurückgeben. Dies ist eine gültige signierte Bitcoin-Transaktion und wir können sie an das Netzwerk senden, um Mika 3000 das Geld zu schicken, das sie braucht!',
+        headings: {
+          item_one: 'Beschreibung',
+          item_two: 'Name',
+          item_three: 'Typ',
+          item_four: 'Größe',
+        },
+        table: {
+          row_one: {
+            item_one: 'Derzeit 2',
+            item_two: 'Version',
+            item_three: 'int',
+            item_four: '4',
+          },
+          row_two: {
+            item_one: 'Muss für einen getrennten Zeugen genau 0x0001 sein.',
+            item_two: 'Flaggen',
+            item_three: 'Bytes',
+            item_four: '2',
+          },
+          row_three: {
+            item_one: 'Die Anzahl der Eingänge',
+            item_two: 'in Anzahl',
+            item_three: 'int',
+            item_four: '1',
+          },
+          row_four: {
+            item_one: 'Alle Transaktionseingaben, serialisiert',
+            item_two: 'Eingänge',
+            item_three: 'Eingaben[]',
+            item_four: '(unser)',
+          },
+          row_five: {
+            item_one: 'Die Anzahl der Ausgänge',
+            item_two: 'auszählen',
+            item_three: 'int',
+            item_four: '1',
+          },
+          row_six: {
+            item_one: 'Alle Transaktionsausgaben, serialisiert',
+            item_two: 'Ausgänge',
+            item_three: 'Ausgaben[]',
+            item_four: '(unser)',
+          },
+          row_seven: {
+            item_one: 'Alle Zeugenstapel, serialisiert',
+            item_two: 'Zeuge',
+            item_three: 'Zeugen[]',
+            item_four: '(unser)',
+          },
+          row_eight: {
+            item_one: 'Das Setzen auf 0 zeigt Endgültigkeit an',
+            item_two: 'Sperrzeit',
+            item_three: 'int',
+            item_four: '4',
+          },
+        },
+        bullet_one:
+          'Mika 3000 erhält 100.000.000 Satoshis an bc1qgghq08syehkym52ueu9nl5x8gth23vr8hurv9dyfcmhaqk4lrlgs28epwj',
+        bullet_two:
+          'Sie erhalten 61.000.000 zurück an Ihre Adresse bc1qm2dr49zrgf9wc74h5c58wlm3xrnujfuf5g80hs',
+        success:
+          'Sie haben es geschafft! Sie haben eine Transaktion durchgeführt!',
+      },
+      hard: {
+        title: 'Alles zusammenfügen',
+        nav_title: 'Erstellen des Transaktionsdigests',
+        heading: 'Transaktionsübersicht',
+        paragraph_one:
+          'In Kapitel 5 haben wir gelernt, dass wir zum Signieren einer Transaktion zunächst deren Daten neu anordnen und in eine Nachricht hashen müssen, die dann zu einem der Roheingaben für unseren Signieralgorithmus wird. Da wir jetzt Segregated Witness verwenden, müssen wir auch den aktualisierten Transaktions-Digest-Algorithmus implementieren, der in <Link href="https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki" target="_blank" className="underline">BIP 143</Link> angegeben ist.',
+        paragraph_two:
+          'Denken Sie daran, dass jeder Transaktions-Input seine eigene Signatur benötigt. Einige Komponenten des Digest-Algorithmus können zwischengespeichert und wiederverwendet werden, andere unterscheiden sich jedoch, je nachdem, welcher Input signiert wird! Beenden Sie die Transaktionsmethode <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">digest(input_index)</span>, die die 32-Byte-Nachricht zum Signieren eines Inputs berechnet.',
+        list_heading: 'Einige Hinweise:',
+        list_one: '„Double SHA-256“ oder dSHA256 = sha256(sha256(data))',
+        list_two:
+          'value ist die Menge der Satoshis in der Ausgabe, die ausgegeben werden. Wir haben es in Schritt 2 zu unserer Eingabeklasse hinzugefügt und es bis jetzt einfach dort in der Klasse gespeichert.',
+        list_three:
+          'scriptcode ist das Roh-Bitcoin-Skript, das ausgewertet wird. Wir haben es in Schritt 2 auch zu unserer Input-Klasse hinzugefügt.',
+        paragraph_three:
+          'Wir werden im nächsten Abschnitt tiefer darauf eingehen, aber um von Ihrer Pay-to-Witness-Public-Key-Hash-Adresse auszugeben, würde Ihr Skriptcode lauten:',
+        paragraph_four:
+          '... das sich in das folgende Bitcoin-Skript dekodieren lässt.',
+        paragraph_five:
+          'Weitere Informationen zum Skriptcode finden Sie unter <Link href="https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki" target="_blank" className="underline">BIP 143</Link>.',
+        paragraph_six:
+          'Die Rohtransaktion verfügt über ein Urbild, das die Serialisierung von Folgendem darstellt:',
+        headings: {
+          item_one: 'Beschreibung',
+          item_two: 'Name',
+          item_three: 'Typ',
+          item_four: 'Größe',
+        },
+        table: {
+          row_one: {
+            item_one: 'Transaktionsversion, Standard 2',
+            item_two: 'Version',
+            item_three: 'int',
+            item_four: '4',
+          },
+          row_two: {
+            item_one:
+              'Der dSHA256 aller Outpoints von allen Inputs, serialisiert',
+            item_two: 'Bytes',
+            item_three: 'Bytes',
+            item_four: '32',
+          },
+          row_three: {
+            item_one:
+              'Der dSHA256 aller Sequenzwerte aus allen Eingängen, serialisiert',
+            item_two: 'Sequenzen',
+            item_three: 'Bytes',
+            item_four: '32',
+          },
+          row_four: {
+            item_one:
+              'Der serialisierte Outpoint des einzelnen Inputs, der signiert wird',
+            item_two: 'Ausgangspunkt',
+            item_three: 'Bytes',
+            item_four: '36',
+          },
+          row_five: {
+            item_one: 'Das Ausgabeskript wird ausgegeben von',
+            item_two: 'Skriptcode',
+            item_three: 'Bytes',
+            item_four: '(unser)',
+          },
+          row_six: {
+            item_one:
+              'Der Wert in Satoshis, der von dem einzelnen Input ausgegeben wird, der signiert wird',
+            item_two: 'Wert',
+            item_three: 'int',
+            item_four: '8',
+          },
+          row_seven: {
+            item_one: 'Der Sequenzwert des einzelnen Inputs, der signiert wird',
+            item_two: 'Sequenz',
+            item_three: 'int',
+            item_four: '8',
+          },
+          row_eight: {
+            item_one: 'Der dSHA256 aller Ausgänge, serialisiert',
+            item_two: 'Ausgänge',
+            item_three: 'Bytes',
+            item_four: '32',
+          },
+          row_nine: {
+            item_one: 'Transaktionssperrzeit, Standard 0',
+            item_two: 'Sperrzeit',
+            item_three: 'int',
+            item_four: '4',
+          },
+          row_ten: {
+            item_one: 'Signatur-Hash-Typ, wir verwenden 1, um "ALLE',
+            item_two: 'seufzen',
+            item_three: 'int',
+            item_four: '4',
+          },
+        },
+        paragraph_seven:
+          'Schließlich ist die Nachricht, die wir signieren, der doppelte SHA-256 aller dieser serialisierten Daten.',
+        success: 'Die Digest()-Methode sieht gut aus. Gute Arbeit!',
+      },
+    },
+    put_it_together_four: {
+      hard: {
+        title: 'Alles zusammenfügen',
+        heading: 'Unterzeichnung!',
+        nav_title: 'Unterzeichnen Sie die Transaktion',
+        paragraph_one:
+          'Wir haben im letzten Kapitel den ECDSA-Signaturüberprüfungscode geschrieben. Jetzt müssen wir ihn ein wenig umstellen, um eine gültige Signatur zu erstellen. Fügen Sie Ihrer Transaktionsklasse eine Methode namens <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">compute_input_signature(index: int, key: int)</span> hinzu, die eine Eingabeindexnummer und einen privaten Schlüssel (eine 32-Byte-Ganzzahl!) akzeptiert. Sie sollte den Nachrichten-Digest für die gewählte Eingabe mithilfe der Methode <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">digest()</span> aus Schritt 6 berechnen und eine ECDSA-Signatur in Form von zwei 32-Byte-Ganzzahlen r und s zurückgeben.',
+        paragraph_two:
+          'Informationen zum ECDSA-Signaturalgorithmus finden Sie unter <Link href="https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm" target="_blank" className="underline">dieser Seite</Link>. Außerdem <Link href="https://www.secg.org/sec1-v2.pdf#subsubsection.4.1.3" target="_blank" className="underline">dieses PDF</Link> (Seite 44, Abschnitt 4.1.3).',
+        paragraph_three:
+          'Das Bitcoin-Protokoll erfordert einen zusätzlichen Schritt für den Signaturalgorithmus. Dieser erfordert, dass der s-Wert „niedrig“ ist, also kleiner als die Ordnung der Kurve geteilt durch 2. Weitere Informationen hierzu finden Sie in <Link href="https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki#low_s" target="_blank" className="underline">BIP 146</Link>.',
+        success:
+          'Die Methode compute_input_signature() sieht gut aus. Gute Arbeit!',
+      },
+    },
+    put_it_together_five: {
+      hard: {
+        title: 'Alles zusammenfügen',
+        heading: 'Den Zeugen auffüllen',
+        nav_title: 'Den Zeugen auffüllen',
+        paragraph_one:
+          'Beenden Sie die Methode <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">sign_input(index: int, key: int)</span>, die unsere Methode aus Schritt 7 <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">compute_input_signature(index, key)</span> aufruft und ihren Rückgabewert verarbeitet. Die r- und s-Zahlen müssen mit einem Algorithmus namens DER codiert werden, den wir für Sie implementiert haben.',
+        paragraph_two:
+          'Bitcoin erfordert ein zusätzliches Byte, das an die DER-Signatur angehängt wird und den „Sighash-Typ“ darstellt. Im Moment verwenden wir hierfür immer das Byte 0x01, das „SIGHASH ALL“ anzeigt.',
+        paragraph_three:
+          'Sobald wir diesen Signatur-Blob haben, müssen wir ein Witness-Objekt mit zwei Stapelelementen erstellen: dem Signatur-Blob und Ihrem komprimierten öffentlichen Schlüssel. Pushen Sie zuerst die Signatur und dann den öffentlichen Schlüssel.',
+        paragraph_four:
+          'Das Zeugenstapelobjekt kann dann an das Zeugen-Array des Transaktionsobjekts angehängt werden.',
+        success: 'Die Methode sign_input() sieht gut aus. Gute Arbeit!',
+      },
+    },
+    put_it_together_six: {
+      hard: {
+        title: 'Alles zusammenfügen',
+        heading: 'Alles zusammenfügen',
+        nav_title: 'Setzen Sie alles zusammen!',
+        paragraph_one:
+          'Wir kennen unseren Input, wir kennen unseren Output. Sind wir bereit, eine Transaktion zu erstellen und zu unterzeichnen? Nicht ganz. Wir haben einen Input von 1,61 BTC und einen Output von 1 BTC ... was passiert mit den anderen 0,61 BTC? Das meiste davon wird „Wechselgeld“ sein und wir müssen es an unsere eigene Adresse zurückschicken!',
+        paragraph_two:
+          'Schreiben Sie ein Skript, das ein Transaktionsobjekt erstellt und signiert. Es sollte einen Eingang (den UTXO, den wir in Schritt 1 identifiziert haben) und zwei Ausgänge haben:',
+        paragraph_three:
+          'Aber warten Sie! Wir müssen eine „Gebühr“ einbeziehen. Wir werden einen winzigen Teil unseres Wechselgeldes für die Mining-Pools abziehen, um sie zu motivieren, unsere Transaktion in einen Block aufzunehmen. Reduzieren wir unser Wechselgeld von 61.000.000 auf 60.999.000 Satoshis.',
+        paragraph_four:
+          'Endlich ist unsere Arbeit getan. Ihr Skript sollte am Ende das Ergebnis der Transaktionsmethode <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">serialize()</span> zurückgeben. Dies ist eine gültige signierte Bitcoin-Transaktion und wir können sie an das Netzwerk senden, um Mika 3000 das Geld zu schicken, das er braucht!',
+        bullet_one:
+          'Mika 3000 erhält 100.000.000 Satoshis an bc1qgghq08syehkym52ueu9nl5x8gth23vr8hurv9dyfcmhaqk4lrlgs28epwj',
+        bullet_two:
+          'Sie erhalten 61.000.000 zurück an Ihre Adresse bc1qm2dr49zrgf9wc74h5c58wlm3xrnujfuf5g80hs',
+        success:
+          'Sie haben es geschafft! Sie haben eine Transaktion durchgeführt!',
+      },
     },
     outro_one: {
-      title: 'Outro',
+      title: 'Andere',
+      nav_title: 'Kapitel abgeschlossen',
+      heading: 'Du hast es geschafft!',
+      paragraph_one:
+        'Sie haben erfolgreich eine Transaktion von Grund auf erstellt, um Mika 3000 für ihre Hilfe zu bezahlen. Nachdem wir hier fertig sind, wollen wir sehen, was wir auf Vanderpooles Insel finden können.',
+    },
+    resources: {
+      in_out: {
+        input_class_heading: 'Eingabeklasse',
+        input_class_paragraph_one: 'Platzhalterressourcen',
+        output_class_heading: 'Ausgabeklasse',
+        output_class_paragraph_one: 'Platzhalterressourcen',
+      },
+      put_it_together: {
+        building_a_transaction_heading: 'Erstellen einer Transaktion',
+        building_a_transaction_paragraph_one: 'Platzhalterressourcen',
+      },
     },
   },
-
   chapter_seven: {
-    title: `Einundzwanzig`,
+    title: 'Angriff ist die beste Verteidigung',
+    paragraph_one:
+      'Sie und Mika 3000 erreichen Vanderpooles Privatinsel zuerst mit dem Flugzeug und dem Fallschirm, dann mit einem Dünenbuggy und schließlich mit einem von selbst rudernden Ruderboot.',
+    intro_one: {
+      title: 'Einleitung',
+      nav_title: 'Infiltration des Geländes',
+      paragraph_one:
+        'Sie fragen Ihre Landsleute, ob sie über Vanderpooles Armee von Sicherheitsdrohnen besorgt sind.',
+      paragraph_two:
+        '—HOLOCAT: „Geben Sie mir 15 Minuten. Im Grunde sind sie Vögel und ich bin eine Katze. Sie haben keine Chance.“',
+      paragraph_three:
+        'Holocat fährt ihre Krallen aus und erledigt Vanderpooles Drohnenarmee Schlag für Schlag. Mika 3000 reicht Ihnen einen schwarzen Rollkragenpullover, Handschuhe und eine Nachtsichtbrille.',
+      paragraph_four:
+        '—MIKA 3000: „In einem Hawaiihemd kann man keine Spionage betreiben. Was hast du dir dabei gedacht? Das ist kein weiteres verlassenes Lagerhaus, das ist eine Festung. Hier, das hätte ich fast vergessen. Nimm diesen Enterhaken.“',
+      paragraph_five:
+        'Sie fragen sich, worauf Sie sich da eingelassen haben, und erklimmen mit Mika 3000 die Burgmauern von Vanderpooles Hauptwohnsitz. Zu Ihrer Überraschung quillt sein Haus über vor pro-Bitcoin-Kunst, Büchern und Printmagazinen. Er ist, oder vielmehr war, ein echter Bitcoiner. In Glasvitrinen ist eine Sammlung von Minern aus 125 Jahren ausgestellt. Und dann sehen Sie es: Vanderpooles Werkstatt.',
+    },
+    intro_two: {
+      nav_title: 'Der Kontrollraum',
+      paragraph_one:
+        'Der riesige Raum ist ein einziges Chaos, obwohl sein Aufbau methodisch ist. Erinnern Sie sich, als die Miner das Bitcoin-Netzwerk mit leeren Blöcken verstopften? In offenen Notizbüchern finden Sie Vanderpooles Entwürfe für die Hintertür, die er benutzte, detailliert skizziert. Sie hatten recht: Es war alles eine Lüge, allerdings nicht von einem hinterhältigen Bösewicht, sondern von einem verzweifelten Bitcoin-Anhänger, dessen Unternehmen nicht mehr konkurrenzfähig war. Um sein Vermächtnis zu bewahren, infizierte Vanderpoole die Miner mit einem Virus.',
+      paragraph_two:
+        'Der Virus ersetzt einen Teil des Codes, der von allen Minern verwendet wird, unabhängig davon, ob sie Teil eines Pools sind oder nicht. Es handelt sich dabei um die Blockaufbaulogik, den Algorithmus, der Transaktionen in einer Blockvorlage zusammenfügt. Die Vorlage wird weiterhin an legitimen Hashing-Code zum Nachweis der Arbeit weitergegeben. Auf der Suche nach einem gültigen Hash werden Vorlagen mit Abermillionen verschiedener Nonces kombiniert, aber bis einer gefunden wird, ist der Schaden – das Fehlen jeglicher Transaktionen in der Blockvorlage – bereits angerichtet.',
+      paragraph_three:
+        '—HOLOCAT: „Was für ein Verlust. Seine Familie war einst großartig. Es ist so traurig, dass es mit den Vanderpooles so weit gekommen ist.“',
+    },
+    intro_three: {
+      nav_title: 'Korrektur der Software',
+      paragraph_one:
+        'Aber Sie können den beschädigten Mining-Code nicht einfach auf Vanderpooles Server belassen. Er wird weiterhin Miner infizieren. Sie müssen ihn reparieren! Während Sie den Code durchlesen, zeigt Ihnen Holocat eine Mempool-Anzeige, die sich mit unbestätigten Transaktionen füllt. Je schneller dieser Code repariert wird, desto besser.',
+    },
+    mempool_transaction_one: {
+      title: 'Bausteine',
+      nav_title: 'Einen Block zusammenbauen',
+      heading: 'Code-Herausforderung',
+      python: {
+        paragraph_one:
+          'Dies ist der Code, den Sie auf Vanderpooles Server finden. Er importiert den aktuellen Mempool aus einer JSON-Datei und speichert alle unbestätigten Transaktionen im Speicher als Instanzen der Klasse MempoolTransaction. Die Funktion, die Vanderpoole beschädigt hat, ist <span className="text-green">assemble_block()</span>. Wenn Sie den Code so ausführen, wie Vanderpoole ihn hinterlassen hat, werden Sie das Problem sofort erkennen.',
+      },
+      javascript: {
+        paragraph_one:
+          'Dies ist der Code, den Sie auf Vanderpooles Server finden. Er importiert den aktuellen Mempool aus einer JSON-Datei und speichert alle unbestätigten Transaktionen im Speicher als Instanzen der Klasse MempoolTransaction. Die Funktion, die Vanderpoole beschädigt hat, ist <span className="text-green">assembleBlock()</span>. Wenn Sie den Code so ausführen, wie Vanderpoole ihn hinterlassen hat, werden Sie das Problem sofort erkennen.',
+      },
+      paragraph_two: {
+        a: 'Sie müssen die Blockassemblierungsfunktion nicht nur reparieren, um gültige Blöcke zu erstellen, sondern auch, um die Gebühren im Block zu maximieren, damit die Miner unter Berücksichtigung der Konsensregeln den größtmöglichen Gewinn erzielen können. Die wichtigsten Konsensregeln, die Sie beachten müssen, sind die Beschränkung der Gesamtsumme',
+        b: {
+          text: 'Transaktionsgewicht',
+          href: 'https://chat.bitcoinsearch.xyz/?author=holocat&question=what%2520are%2520weighted%2520units',
+          question: 'Was sind gewichtete Einheiten?',
+        },
+        c: 'und die',
+        d: {
+          text: 'Reihenfolge der Transaktionen',
+          href: 'https://chat.bitcoinsearch.xyz/?author=holocat&question=what%2520order%2520do%2520transactions%2520need%2520to%2520be%2520in%2520a%2520block',
+          question:
+            'In welcher Reihenfolge müssen die Transaktionen in einem Block erfolgen?',
+        },
+        e: 'im Block.',
+      },
+      paragraph_three:
+        'Um Ihre Mission zu erfüllen, können Sie die folgenden Annahmen treffen:',
+      bullet_one:
+        'Alle Transaktionen im Mempool wurden bereits als gültig verifiziert.',
+      bullet_two:
+        'Die Coinbase-Transaktion und das Gewicht, das sie zum Block beiträgt, können ignoriert werden.',
+      paragraph_four:
+        'Sie können die gesamte Raw-Mempool-JSON-Datei <Link href="https://github.com/saving-satoshi/resources/blob/main/chapter-7/mempool.json" target="_blank" className="underline">hier</Link> anzeigen.',
+      paragraph_five:
+        'Oder durchsuchen Sie einen Auszug der Datei in dieser Tabelle nach einigen grundlegenden Mustern:',
+      headings: {
+        item_one: 'Transaktions-ID',
+        item_two: 'Gebühr',
+        item_two_b: 'Satoshis',
+        item_three: 'Gewicht',
+        item_three_b: 'Gewichtseinheiten (WU)',
+        item_four: 'Vorfahren',
+      },
+      table_one: {
+        footer:
+          'Sehen Sie sich die JSON-Datei <Link href="https://github.com/saving-satoshi/resources/blob/main/chapter-7/mempool.json" target="_blank" className="underline">hier</Link> für den Rest der Transaktionsdaten an',
+      },
+      poor: 'Es ist ein gültiger Block, aber können Sie es noch besser machen? Versuchen Sie, mehr Gebühren einzutreiben.',
+      good: 'Es handelt sich um eine gültige Sperre, aber Sie erhalten noch nicht die höchsten Gebühren. Arbeiten Sie weiter oder fahren Sie fort, Sie haben die Wahl.',
+      success:
+        'Es ist ein gültiger Block und Sie haben die Gebühren optimiert. Schön!',
+    },
+    outro_one: {
+      title: 'Andere',
+      nav_title: 'Kapitel abgeschlossen',
+      heading: 'Du hast es geschafft!',
+      paragraph_one:
+        'Sie entkommen aus dem Lager und kehren nach Hause zurück. Als die Geschichte ans Licht kommt, verkaufen die Investoren massenhaft ihre BitRey-Aktien, wodurch Vanderpooles Nettovermögen rapide sinkt.',
+    },
+    resources: {
+      mempool_transaction_one: {
+        bytes_v_weight_heading: 'Bytes vs. Gewichtseinheiten',
+        bytes_v_weight_paragraph_one:
+          'Beim Aufbau von Bitcoin-Blöcken werden mit „Weight Units“ (WU) und „Bytes“ zwei unterschiedliche Maßeinheiten verwendet, um die Größe von Transaktionen und Blöcken zu messen.',
+        bytes_v_weight_subheading_bytes: 'Bytes',
+        bytes_v_weight_paragraph_two:
+          'Bytes beziehen sich auf die Rohgröße einer Transaktion oder eines Blocks in Bezug auf die tatsächlichen Daten. Es ist die wörtliche Größe der Transaktionsdaten, wenn sie serialisiert (in ein Format konvertiert werden, das gespeichert oder übertragen werden kann). Vor der Implementierung von Segregated Witness (SegWit) war die Blockgröße auf 1 Megabyte (1 MB), gemessen in Bytes, begrenzt.',
+        bytes_v_weight_subheading_wu: 'Gewichtete Einheiten',
+        bytes_v_weight_paragraph_three:
+          'Gewichtete Einheiten sind eine komplexere Metrik, die mit SegWit im Bitcoin Improvement Proposal 141 <Link href="https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#user-content-Other_consensus_critical_limits" target="_blank" className="undeline">BIP 141</Link> eingeführt wurde. Dieses System zielt darauf ab, Blockplatz gerechter zu verteilen, indem die Auswirkungen von Zeugendaten separat berücksichtigt werden.',
+        bytes_v_weight_paragraph_four:
+          'In unserer Lektion hier ist es nur wichtig zu beachten, dass wir Gewichtseinheiten verwenden, um die maximale Blockgröße zu berechnen, und das Gleiche gilt für jede Transaktion. Stellen Sie also sicher, dass Ihr Block die maximale Größe von 4.000.000 Gewichtseinheiten nicht überschreitet.',
+      },
+    },
   },
-
   chapter_eight: {
-    title: 'Eine Frage der Nachhaltigkeit',
+    title: 'Einundzwanzig Millionen',
+    paragraph_one:
+      'Dank Ihrer Recherchen wollen die Leute unbedingt etwas von Ihnen hören. Sie schnippst Holocat an die Nase und enthüllen eine Einladung von Deborah Chunk, die Sie einlädt, persönlich in den Büros von LARGE BIG NEWS Studios zu erscheinen. Die Story muss an die Öffentlichkeit gelangen, also steigen Sie erneut in Ihren Budgetcopter.',
+    intro_one: {
+      title: 'Einleitung',
+      nav_title: 'Vanderpooles Täuschung',
+      paragraph_one:
+        '—DEBORAH CHUNK: „Diese Dokumente enthüllen die angeblichen Lügen von Thomas Vanderpoole auf eine Weise, die sicherlich historisch, ja sogar skandalös ist. Das Erste, was die Leute wissen wollen, ist, ob Sie allein gehandelt haben. Das Zweite ist, woher Sie Ihre Informationen haben.“',
+      paragraph_two:
+        'Sie erzählen ihr von Holocat und nur von Holocat. Sie sagen, die Informationen seien direkt an Sie und Mika 3000 von jemandem übermittelt worden, der behauptet, Satoshi Nakamoto zu sein, und von dem Sie vermuten, dass es sich in Wirklichkeit um ein Hackerkollektiv handelt. Dieser letzte Punkt veranlasst Thomas Vanderpoole, direkt in der Show anzurufen.',
+    },
+    intro_two: {
+      title: 'Einleitung',
+      nav_title: 'Vanderpooles Wut',
+      paragraph_one:
+        '—THOMAS VANDERPOOLE: „Meine Familie ist Satoshi Nakamoto! Verstehen Sie, was dieser Hootenanny gerade gesagt hat? Er hat gerade zugegeben, mit Hackern zusammenzuarbeiten, einem Kollektiv, das nur den Namen Satoshi Nakamoto verwendet, um ein Erbe zu beanspruchen, das rechtmäßig mir gehört. Dieser Schurke lügt, um die Proteste der Bitcoin-Benutzer zu untergraben, die zu Recht über die Abschaffung der Blockbelohnungen verärgert sind!“',
+      paragraph_two:
+        'Vanderpoole schleudert Ihnen weiterhin zwei Jahrhunderte alte Beleidigungen entgegen. Er nennt Sie ein Ungeziefer, einen Halunken, einen Feigling, einen Grünschnabel und mehr. Man hat fast Mitleid mit ihm. Seine Familie war unbestreitbar wichtig für die Geschichte von Bitcoin, auch wenn seine Behauptungen über Satoshi Nakamoto offensichtlich falsch sind.',
+    },
+    intro_three: {
+      intro: 'Einleitung',
+      nav_title: 'Vorwürfe gegen Vanderpoole',
+      paragraph_one:
+        '—DEBORAH CHUNK: „Mr. Vanderpoole, wenn ich darf. Die Leute sind verwirrt und unsicher, ob die Bitcoin-Versorgung manipuliert wurde. Können Sie beweisen, dass Sie an der angeblichen Manipulation nicht beteiligt waren? Mysteriöser Hacker und sein Holocat, können Sie beweisen, dass Vanderpoole dieses Verbrechen gegen Bitcoin versucht hat?“',
+    },
+    building_blocks_one: {
+      title: 'Bausteine',
+      nav_title: 'Finden der Kettenspitze',
+      paragraph_one: {
+        a: 'Sie wissen, dass Vanderpoole versucht hat, die Leute zu verwirren, indem er Blöcke minte, die mehr Bitcoins generieren, als ihnen erlaubt sind, was letztlich die Geldmenge aufbläht. Diese Blöcke sind ungültig, weil sie hartcodierte Protokollregeln verletzen, aber sie könnten trotzdem einige Leute täuschen, die fehlerhafte oder bösartige Software verwenden, oder',
+        b: {
+          text: 'Light-Clients',
+          href: 'https://chat.bitcoinsearch.xyz/?author=holocat&question=what%2520are%2520light%2520clients%253F',
+          question: 'Was sind Light-Clients?',
+        },
+        c: 'die Netzwerkdaten nicht vollständig überprüfen.',
+      },
+      paragraph_two:
+        'Sie wissen auch, dass sich irgendwo im Netzwerk eine Kette gültiger Blöcke vom Genesis-Block bis zur heutigen „Kettenspitze“ befindet, in der jede Transaktion und jeder Block den Regeln folgt. Diese Kette ist die einzige <span className="italic">echte</span>-Kette, die einzige Kette, die zählt, und die einzige Kette, in der der Bitcoin-Vorrat von 21 Millionen ursprünglichen Bitcoins intakt ist.',
+      paragraph_three:
+        'Jetzt müssen Sie im Live-Fernsehen vor der ganzen Welt die längste gültige Blockchain finden und die Integrität der Münzversorgung überprüfen. Wenn Sie schon dabei sind, können Sie auch beweisen, dass Vanderpoole das Bitcoin-Netzwerk in ein Minenfeld ungültiger Blöcke verwandelt hat.',
+    },
+    building_blocks_two: {
+      title: 'Bausteine',
+      nav_title: 'Ein Bitcoin-Blockbaum',
+      paragraph_one:
+        'Jeder Block hat genau einen vorhergehenden Block, kann aber mehrere nachfolgende Blöcke haben. Aus diesem Grund bilden Bitcoin-Blöcke eher einen Baum als eine Kette. Einige der Zweige sind Sackgassen und, wie Sie beweisen müssen, sind einige der Zweige aufgrund von Vanderpooles Machenschaften ungültig.',
+      paragraph_two:
+        'Irgendwo in diesem Labyrinth gibt es einen Pfad vom Genesis-Block zum aktuellsten Block von heute. Du musst ihn finden und Deborah Chunk sagen, welcher Block sich an der Spitze der gültigsten Kette des Baums befindet ... vor der nächsten Werbepause. Ahhh!',
+      paragraph_three:
+        'Diese künstlerische Interpretation des Blockchain-„Baums“ von Bitcoin zeigt, dass jeder Block genau einen übergeordneten Block hat, aber auch mehrere untergeordnete Blöcke haben kann. Jeder Block ist mit seinem Hash und dem Hash seines übergeordneten Blocks (<span className="p-1 font-mono m-0.5 text-sm">prev</span>) gekennzeichnet.',
+      paragraph_four:
+        'Einige dieser Blöcke sind rot, weil sie ungültig sind. Der längste Pfad von Blöcken, der vom Genesis-Block ausgeht, ist grün gefärbt und stellt die „arbeitsreichste“ oder „gültigste“ Kette dar. Transaktionen in diesen Blöcken sind die einzigen wirklich „bestätigten“ Transaktionen. Andere gültige Blöcke, die blauen, haben nicht so viele Nachkommen wie die „arbeitsreichste“ Kette. Sie enden in sogenannten <span className="italic">veralteten Tipps</span>.',
+    },
+    building_blocks_three: {
+      title: 'Bausteine',
+      nav_title: 'Entdecken Sie die Bitcoin-API',
+      heading: 'Die Bitcoin-API',
+      paragraph_one:
+        'Um diese Fragen zu beantworten, müssen Sie über die JSON-RPC-API mit einem Bitcoin-Vollknoten interagieren. Wir haben für Sie eine Bibliothek namens <span className="p-1 font-mono bg-[#0000004D] m-1">bitcoin_rpc</span> importiert, die die sichere HTTP-Verbindung von Ihrem Skript zum Vollknoten verwaltet, Ihre Befehle ausführt und die Antworten zurückgibt. Ihr Vollknoten wird „beschnitten“, sodass er nur auf die letzten 300 Blöcke zugreifen kann, aber das sollte ausreichen, um den gesamten Zeitraum von Vanderpooles jüngstem Skandal abzudecken.',
+      paragraph_two:
+        'Machen wir uns zunächst mit der API vertraut. Die Bibliothek verfügt über eine Funktion, die ein erforderliches Argument, <span className="p-1 font-mono bg-[#0000004D] m-1">method</span> (einen String), und ein optionales Argument, <span className="p-1 font-mono bg-[#0000004D] m-1">params</span> (entweder einen String oder eine Zahl), akzeptiert:',
+      paragraph_three:
+        'Die API verfügt auch über eine praktische „Hilfe“-Methode! Bitten Sie sie um Hilfe, um mehr über die verfügbaren Befehle zu erfahren, und bestehen Sie dann die Herausforderung, indem Sie den aktuellen Netzwerkschwierigkeitsgrad ausdrucken.',
+      success: 'Gute Arbeit beim Erkunden der API! Lasst uns weitermachen.',
+    },
+    building_blocks_four: {
+      title: 'Bausteine',
+      nav_title: 'Finden Sie den kleinsten Transaktionsblock',
+      heading: 'Daten blockieren',
+      paragraph_one:
+        'Jeder Bitcoin-Vollknoten verfügt über eine Datenbank. Dort werden Blöcke gespeichert und anhand ihrer Hashes indiziert. Der Vollknoten verfolgt mithilfe eines zweiten Index, der Höhe -> [Block-Hashes] zuordnet, welche Blöcke auf welcher Höhe in der Kette Kandidaten sind.',
+      paragraph_two:
+        'Die JSON-RPC-API gibt Blockdaten als JSON-Objekte zurück, die eine Eigenschaft<span className="p-1 font-mono bg-[#0000004D] m-1">txs</span> enthalten, bei der es sich um ein Array von Transaktionsobjekten handelt.',
+      paragraph_three:
+        'Rufen Sie alle Blockkandidaten in der Höhe 6929996 ab und drucken Sie den Hash des Blocks mit den wenigsten Transaktionen darin.',
+      success: 'Gut gemacht',
+    },
+    building_blocks_five: {
+      title: 'Bausteine',
+      nav_title: 'Holen Sie sich die Transaktionsgebühr',
+      heading: 'Transaktionsdaten',
+      paragraph_one:
+        'Die in einem Block bestätigten Transaktionsobjekte sind JSON-Objekte, die Arrays von „Eingaben“ und „Ausgaben“ enthalten. Beide Arrays sind Listen von UTXOs, auch „Coins“ genannt. Coin-Objekte haben eine „Wert“-Eigenschaft, die in Satoshis dargestellt wird.',
+      paragraph_two:
+        'Das Array „Inputs“ enthält die von der Transaktion ausgegebenen (vernichteten) Münzen und das Array „Outputs“ enthält die von der Transaktion erstellten Münzen. Sie erinnern sich vielleicht aus Kapitel 6, dass für Transaktionen immer eine Gebühr anfällt, um die Miner zu motivieren, sie in einen Block aufzunehmen. Diese Gebühr entspricht genau der Wertdifferenz zwischen den gesamten Input- und Outputwerten einer Transaktion.',
+      paragraph_three:
+        'Mit anderen Worten: Der Miner darf alle Bitcoins behalten, die in die Transaktion eingesendet, aber nicht an die Transaktionsempfänger zurückgesendet wurden.',
+      paragraph_four: 'Es gibt eine Transaktion mit der txid:',
+      paragraph_five: 'in einem Block mit dem Hash:',
+      paragraph_six:
+        'Drucken Sie die Gebühr dieser Transaktion in Satoshis aus.',
+      success: 'Gut gemacht',
+    },
+    building_blocks_six: {
+      title: 'Bausteine',
+      nav_title: 'Bestimmen Sie die Subvention',
+      heading: 'Die Coinbase-Transaktion',
+      paragraph_one:
+        'Die erste Transaktion in jedem Block wird Coinbase genannt. Sie kann auch als „0.“ Transaktion bezeichnet werden (in Bezug auf txs[0]) und hat einige ganz besondere Eigenschaften. Erstens hat sie keine Eingaben! Das liegt daran, dass sie keine vorhandenen Münzen ausgibt. Zweitens ist ihr Ausgabewert streng durch das Protokoll definiert (egal, was Vanderpoole sagen mag!). Dies ist der Mechanismus, mit dem Miner sowohl Gebühren aus Transaktionen erheben als auch neue Münzen generieren.',
+      paragraph_two:
+        'Es ist relativ einfach zu verstehen, wie sich die gesamten Transaktionsgebühren in einem Block zusammensetzen, aber woher kommt dieser Blocksubventionswert? Wie bestimmt jeder Teilnehmer im Bitcoin-Netzwerk genau, wie viel neue Bitcoin-Miner zu einem bestimmten Zeitpunkt generieren dürfen?',
+      paragraph_three:
+        'Dies ist der von Satoshi Nakamoto geschriebene Algorithmus, der seit Beginn eine unveränderliche Kerneigenschaft des Bitcoin-Systems geblieben ist:',
+      list_one:
+        'Beginnend mit Block Nr. 1, der 2009 geschürft wurde, beträgt die Blocksubvention 50 BTC (oder 5.000.000.000 Satoshis).',
+      list_two: 'Alle 210.000 Blöcke wird dieser Wert halbiert.',
+      paragraph_four:
+        'Bei Blockhöhe 209.999 betrug die Subvention 50 BTC. Im nächsten Block bei Höhe 210.000 betrug die Subvention 25 BTC und so weiter. Nach 63 „Halbierungen“ beträgt die Subvention einen einzigen Satoshi. Bei der letzten Halbierung sinkt die Subvention auf Null.',
+      paragraph_five: 'UND DIE LETZTE HALBIERUNG WAR GESTERN!',
+      paragraph_six:
+        'Schließen Sie die Implementierung der folgenden Funktion ab, die eine Blockhöhe als Argument akzeptiert und den Wert der Subvention in Satoshis zurückgibt.',
+      success: 'Die get_subsidy-Funktion sieht großartig aus. Gute Arbeit!',
+    },
+    building_blocks_seven: {
+      title: 'Bausteine',
+      nav_title: 'Holen Sie sich den gültigen Block',
+      heading: 'Dieser bösartige Schlingel!',
+      paragraph_one:
+        'Es gibt vier Blockkandidaten auf der Höhe 6929851. Nur einer davon ist ein gültiger Block, die anderen drei wurden von Vanderpooles Kartell in rücksichtslosen Versuchen, die Bitcoin-Geldmenge aufzublähen, geschürft.',
+      paragraph_two:
+        'Schreiben Sie mithilfe der Blocksubventionsfunktion, die Sie in der vorherigen Herausforderung geschrieben haben, und der JSON-RPC-API eine Funktion, um die Gültigkeit eines Blockkandidaten zu überprüfen. Überprüfen Sie dazu, ob die Coinbase-Ausgabe korrekt ist. Ihre Funktion sollte „true“ zurückgeben, wenn der Block gültig ist.',
+      paragraph_three:
+        'So wird Ihr Code verwendet, um den einen gültigen Block in der Höhe 6929851 zu finden:',
+      success:
+        'Die Blockvalidierungsfunktion sieht großartig aus. Gute Arbeit!',
+    },
+    building_blocks_eight: {
+      title: 'Bausteine',
+      nav_title: 'Show Time!',
+      heading_one: 'Show Time!',
+      paragraph_one:
+        'Die Kameras laufen, zwei Milliarden Menschen weltweit verfolgen den Livestream. Nur noch wenige Minuten bis zur nächsten Werbepause. Deborah Chunk schwitzt. Irgendwie schwitzt auch Holocat. Irgendwo am anderen Ende der Leitung muss auch Vanderpoole schwitzen. Das ist Ihr Moment.',
+      paragraph_two:
+        'Suchen Sie, beginnend mit dem gültigen Block direkt vor dem, den Sie auf Höhe 6929851 gefunden haben, die längste Kette gültiger Blöcke, die Sie finden können. Speichern Sie die Kette als Array von Block-Hashes. Pflegen Sie, wenn Sie schon dabei sind, auch ein Array aller ungültigen Blöcke, die Sie finden, nur um der Welt zu zeigen, wie sehr Vanderpoole versucht hat, Bitcoin zu knacken. Die Reihenfolge dieser ungültigen Block-Hashes ist egal, aber Ihre gültige Kette MUSS mit dem Hash von Block 6929850 beginnen, gefolgt von einem Block-Hash auf jeder Höhe bis hinauf zur Kettenspitze.',
+      paragraph_three:
+        'Vanderpoole ist hinterlistig! Er hat gültige Blöcke auf ungültigen Blöcken und ungültige Blöcke auf kurzen Ketten gültiger Blöcke abgebaut! Es ist ein Labyrinth, ein Minenfeld da draußen. Möglicherweise müssen Sie mehrere gültige Zweige im Auge behalten, während Sie den Baum durchqueren. Es wird gültige Blöcke mit gültigen Eltern geben, die nicht in der längsten Kette sind! Am Ende wird es nur ein gültiges Blatt geben, das höher ist als alle anderen.',
+      paragraph_four:
+        'Denken Sie daran: Von der JSON-API zurückgegebene Blockobjekte verfügen über die Eigenschaft „prev“, die den übergeordneten Block anhand seines Hashs identifiziert:',
+      heading_two: 'Ein Block ist NUR gültig, wenn:',
+      paragraph_five:
+        'Sein Coinbase-Ausgabewert entspricht der erwarteten Blocksubvention zuzüglich der gesamten Transaktionsgebühren im Block.',
+      heading_three: 'UND',
+      paragraph_six:
+        'Der Block ist ein untergeordneter Block eines anderen GÜLTIGEN Blocks. Dadurch wird eine GÜLTIGE KETTE sichergestellt.',
+      paragraph_seven:
+        'Gibt ein JSON-Objekt mit zwei Arrays mit der Bezeichnung „gültig“ und „ungültig“ zurück:',
+      success: 'Die Showtime-Funktion sieht toll aus. Gute Arbeit!',
+    },
+    outro_one: {
+      title: 'Andere',
+      nav_title: 'Kapitel abgeschlossen',
+      heading: 'Wir machen es live!',
+      paragraph_one:
+        'Sie haben die längste Kette gefunden und es allen bewiesen! Die Liste der ungültigen Blöcke, die Sie gefunden haben, ist beeindruckend lang. Vanderpoole unternahm große Anstrengungen, um die Leute dazu zu bringen, seine Blöcke mit Subventionen zu akzeptieren, aber er konnte nichts tun, um die Regeln von Bitcoin zu ändern. Wie wir festgestellt haben, bedeutet die Tatsache, dass ein Block Teil einer Kette ist, nicht unbedingt, dass er gültig ist. Jetzt sind Sie einen Schritt näher daran, Vanderpoole zu diskreditieren. Unnötig zu sagen, dass er den Rest von Frau Chunks Fragen nicht beantwortet hat.',
+    },
+    resources: {
+      building_blocks_three: {
+        tip: 'Probieren Sie zuerst diesen Befehl aus, um einen Eindruck von den verfügbaren Befehlen zu bekommen.',
+        rpc_heading: 'RPC-Befehle',
+        rpc_paragraph_one:
+          'RPC-Befehle sind eine Befehlsschnittstelle, die es einem Client ermöglicht, Anfragen an ein Programm zu stellen, wodurch eine Interaktion zwischen dem Client und dem Server entsteht. Diese Anfragen werden vom Client oder Anforderer zusammen mit allen Parametern gesendet, die der Client zum Ändern seiner Anfrage benötigt.',
+      },
+      building_blocks_four: {
+        block_data_heading: 'Daten blockieren',
+        block_data_paragraph_one:
+          'Im Kern ist Bitcoin ein Hauptbuch, eine Liste aller Transaktionen, die seit seiner Einführung jemals gesendet wurden. Jede Transaktion ist in Blöcken organisiert und jeder Block ist in der Reihenfolge vom Genesis-Block an organisiert.',
+      },
+      building_blocks_five: {
+        transaction_data_heading: 'Transaktionsdaten',
+        transaction_data_paragraph_one:
+          'Jede Transaktion enthält eine eigene Teilmenge an Informationen, um sie von anderen Transaktionen zu unterscheiden und deutlich zu machen, wie viele Bitcoins übertragen werden und welche Ein- und Ausgaben verwendet werden.',
+      },
+      building_blocks_six: {
+        block_subsidy_heading: 'Blocksubvention',
+        block_subsidy_paragraph_one:
+          'Die Blocksubvention ist die Menge an Bitcoin, die von der Coinbase für jeden neuen Block in Umlauf gebracht wird. Da insgesamt nur ca. 21 Millionen Bitcoins erstellt werden können, muss es eine abnehmende Gleichung geben, um eine Coinbase-Subvention zu ermöglichen, die den Betrag von 21 Millionen erreicht. Die folgende Gleichung veranschaulicht, was in Bitcoin steckt.',
+        block_subsidy_paragraph_two:
+          'Was bewirkt diese Gleichung? Nun, wir wissen, dass die Coinbase-Belohnung des Genesis-Blocks 50 Bitcoin betrug, und dies wird durch den Zähler des Bruchs auf der rechten Seite der Gleichung angezeigt. Der Nenner ist der Teil unserer Gleichung, der angibt, um wie viel die Belohnung bei jeder Halbierung verringert wird, in diesem Fall 2 oder um die Hälfte. Wir wissen auch, dass Bitcoin nur einzelne Blöcke als chronologisches System erkennt, also machen wir jede Halbierung 210.000 Blöcke lang. Schließlich wollen wir jede Halbierung jedes Mal verdoppeln, also wollen wir den Betrag verdoppeln, um den die Subvention bei jeder Halbierung halbiert wird, also potenzieren wir 2 hoch der aktuellen Halbierung „i“ zur letzten Halbierungsepoche 32 Iterationen in der Zukunft.',
+      },
+      building_blocks_seven: {
+        validating_heading: 'Blöcke validieren',
+        validating_paragraph_one:
+          'Die Validierung eines Blocks ist für die Stärke des Netzwerks unglaublich wichtig, da jeder Block auf den Transaktionen vorheriger Blöcke aufbaut. Wenn sich herausstellt, dass ein Block in der Vergangenheit ungültig war, kann dies enorme Konsequenzen haben, da eine große Kette von Blöcken mit einem zuvor ungültigen Block in Frage gestellt wird.',
+      },
+      building_blocks_eight: {
+        showtime_heading: 'Validierung der Kette',
+        showtime_paragraph_one:
+          'Die Validierung der Blockchain in Bitcoin ist entscheidend für die Aufrechterhaltung der Integrität und Sicherheit des gesamten Netzwerks. Jede Transaktion muss von Minern überprüft werden, um sicherzustellen, dass sie legitim ist und den vom Netzwerk festgelegten Konsensregeln entspricht. Dieser Validierungsprozess verhindert Doppelausgaben und Betrug und ermöglicht es den Benutzern, dem System zu vertrauen, ohne dass eine zentrale Autorität erforderlich ist. Darüber hinaus erhöht es die Transparenz, da alle validierten Transaktionen in einem öffentlichen Hauptbuch aufgezeichnet werden, sodass jeder den Transaktionsverlauf prüfen kann.',
+      },
+    },
   },
-
   chapter_nine: {
-    title: `Nicht rechnen, sondern prüfen.`,
+    title: 'Vertrauen Sie nicht, überprüfen Sie.',
+    paragraph_one:
+      'Gerade noch rechtzeitig haben Sie der Welt bewiesen, dass Vanderpoole versucht hat, das Bitcoin-Netzwerk mit ungültigen Blöcken zu verwirren. Während eine Werbepause ausgestrahlt wird, bereitet sich das Fernsehteam des Studios auf den nächsten Abschnitt vor.',
+    intro_one: {
+      title: 'Einleitung',
+      nav_title: 'Bedrohungen',
+      paragraph_one:
+        'Alle feiern, alle lächeln. Aber da ist ein Mann am Set, der nicht glücklich ist: ein großer, gut gekleideter, grauhaariger Mann, den man sofort erkennt. Die Menge teilt sich und man sieht ihn zum ersten Mal von Angesicht zu Angesicht: Vanderpoole!',
+      paragraph_two:
+        'Er hat die Fäuste geballt. Sie haben sein Geschäft ruiniert und den langjährigen Betrug seiner Familie aufgedeckt. Das Erste, was er sagt, ist die Drohung, Sie für den Rest Ihres Lebens jeden Tag zu verklagen, "mal unendlich".',
+    },
+    intro_two: {
+      title: 'Einleitung',
+      nav_title: 'Sich arrangieren',
+      paragraph_one:
+        'Während Vanderpoole schimpft, kommt ein Produzent herein und erzählt Ihnen, dass Zuschauer aus aller Welt Ihre Sache unterstützen möchten, indem sie Ihnen Bitcoins und Calzone spenden, aus... irgendeinem Grund! Deborah bittet Sie, ihren Zuschauern eine Wallet-Adresse mitzuteilen.',
+      paragraph_two:
+        'Das macht Vanderpoole noch wütender. Er verlangt, dass Sie die eingehenden Spenden mit ihm teilen, sonst wird er Sie in noch mehr Klagen ertränken, als ob es mehr als unendlich viele Klagen geben könnte.',
+      paragraph_three:
+        'Spenden mit Vanderpoole zu teilen, ergibt nicht viel Sinn. Das Geld kommt von Leuten, die Ihnen dafür danken möchten, dass Sie Vanderpooles Bemühungen, Bitcoin zu unterminieren, aufgedeckt haben. Ihnen wird klar, dass es ihm bei dieser Forderung eher um Verluste als um Geld geht. Einen Moment lang tut er Ihnen sogar leid. Er hat sich selbst in eine Ecke manövriert, aus der es keinen Ausweg gibt.',
+      paragraph_four:
+        'Als ob sie Ihre Gedanken lesen könnte, greift Deborah Chunk ein. Sie fragt, ob es eine Wohltätigkeitsorganisation gibt, an die Vanderpoole einen Teil der Spenden fließen lassen möchte. Zu Ihrer Überraschung nennt er begeistert die Lil Bits Foundation, eine gemeinnützige Organisation, die sich der Hilfe für Kinder verschrieben hat.',
+      paragraph_five:
+        'Vanderpooles Hautfarbe beruhigt sich von Radieschenrot zu Rübenlila. Sie beginnen, einen Bitcoin-Skriptvertrag zwischen Ihnen und Vanderpoole zu erstellen. Er ist dafür verantwortlich, die Mittel an die Lil Bits Foundation zu überweisen. Aus diesem Skriptvertrag leiten Sie die Spendenadresse ab. Er behandelt Vanderpoole als nicht vertrauenswürdige Gegenpartei und stellt sicher, dass Sie beide Geld ausgeben können, wie und wann Sie es vereinbaren.',
+    },
+    opcodes_one: {
+      title: 'OpCodes',
+      nav_title: 'Bitcoin-Skript',
+      heading: 'Bitcoin-Skript',
+      paragraph_one:
+        'Wir haben das Bitcoin-Skript bereits in Kapitel 6 erwähnt, sind aber nicht näher darauf eingegangen, da die von Ihnen ausgegebenen Münzen durch einen einfachen Mechanismus gesperrt waren: eine einzelne Signatur und ein implizites Skript, das diese Signatur mit einem öffentlichen Schlüssel auswertete. Jetzt wird es interessanter.',
+      paragraph_two:
+        'Beim Ausgeben einer Bitcoin-Ausgabe gibt es zwei wichtige Teile: ein Skript und einen Stapel.',
+      paragraph_three:
+        'Wir werden die beiden Konzepte zunächst auf hoher Ebene untersuchen.',
+    },
+    opcodes_two: {
+      title: 'OpCodes',
+      nav_title: 'Bitcoin-Stapel',
+      heading: 'Der Stapel',
+      paragraph_one:
+        'Denken Sie an einen Stapel Bücher 📚. Wenn Sie ein Buch hinzufügen möchten, müssen Sie es oben auf den Stapel legen. Es gibt keinen anderen Ort, an den es gehen kann. Wenn Sie ein Buch lesen möchten, können Sie nur auf das Buch oben auf dem Stapel zugreifen. Selbst wenn Sie mehr als ein Buch möchten, müssen Sie oben auf dem Stapel beginnen und sich nach unten vorarbeiten. In der Computersprache ist ein Stapel wie ein Array von Datenelementen mit zwei Operationen:',
+      paragraph_two:
+        '<span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_PUSH</span> Fügen Sie ein Element oben auf dem Stapel hinzu.',
+      paragraph_three:
+        '<span className="text-[#3DCFEF] w-fit rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_POP</span> Entfernt das „oberste“ Element zur Verarbeitung vom Stapel.',
+      subheading_one: 'Beispiel:',
+      stack_list_one:
+        'Hier ist ein Stapel: <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">[]</span>',
+      stack_list_two:
+        'Drücken Sie die Zahl 1: <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">[1]</span>',
+      stack_list_three:
+        'Drücken Sie die Zahl 2: <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">[1, 2]</span>',
+      stack_list_four:
+        'Nimm das oberste Element vom Stapel: <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">[1]</span>',
+      paragraph_four:
+        'Beachten Sie, dass das erste Element, das auf den Stapel geschoben wird, das letzte Element ist, das vom Stapel genommen wird. Es ist also das letzte Element, das vom Skript verarbeitet wird. Aus diesem Grund wirkt der Stapel „verkehrt herum“ oder „rückwärts“, und das erste, was Sie auf dem Stapel sehen, ist wahrscheinlich die Lösung, die am Ende der Skriptverarbeitung benötigt wird.',
+      paragraph_five:
+        'Beim Ausgeben einer Bitcoin-Transaktionsausgabe werden die vom Ausgebenden benötigten Elemente im Zeugenabschnitt der Eingabe der ausgebenden Transaktion bereitgestellt (siehe Kapitel 6) und diese Elemente werden auf den Stapel geschoben, bevor die Skriptverarbeitung beginnt. Wir werden diese Elemente als ANFANGSSTAPEL bezeichnen. Sie sind wichtig, weil sie buchstäblich die Daten sind, die ein Skript freischalten und das Ausgeben von Münzen ermöglichen!',
+    },
+    opcodes_three: {
+      title: 'OpCodes',
+      nav_title: 'OpCodes',
+      heading: 'OpCodes',
+      paragraph_one:
+        'Ein Skript ist eine lineare Reihe von Befehlen, die nacheinander ausgeführt werden und Elemente auf dem Stapel manipulieren. Wenn das Ende des Skripts erreicht ist, muss GENAU EIN VON NULL (NICHT FALSCH) ABGESEHENES ELEMENT auf dem Stapel übrig sein, sonst ist die gesamte Operation ungültig und damit auch Ihre Bitcoin-Transaktion. Es gibt über 100 Befehle in der Bitcoin-Skriptsprache, sogenannte „Opcodes“. Wir werden für diese Herausforderung nur eine Handvoll davon verwenden.',
+      paragraph_two:
+        'Lassen Sie uns ein Beispiel demonstrieren, bei dem wir einen Bitcoin mit der Rechenaufgabe 1 + 2 = ? sperren. Wer die Antwort auf diese Rechenaufgabe kennt, kann die Coins ausgeben.',
+      paragraph_three: 'Das Skript würde folgendermaßen aussehen:',
+      paragraph_four:
+        '<span className="flex items-center text-[#3DCFEF] w-fit rounded-sm px-1.5 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_1 OP_2 OP_ADD OP_EQUAL</span>',
+      paragraph_five:
+        'Dieses Skript wird gehasht und bech32-codiert in eine Adresse, an die jemand Münzen senden kann.',
+    },
+    opcodes_four: {
+      title: 'OpCodes',
+      nav_title: 'Die Stack-Lösung',
+      heading: 'Die Stack-Lösung',
+      paragraph_one:
+        'Die Stapellösung würde so aussehen und die Ausgabetransaktion muss alle diese Elemente enthalten. Sie kommen in den Zeugenabschnitt der Eingabe, die versucht, diese Münzen auszugeben. Gehen wir das Ganze durch:',
+      table_one: {
+        headings: {
+          item_one: 'Schritt',
+          item_two: 'Stapel',
+          item_three: 'Skriptausführung',
+        },
+      },
+      subheading_one: 'Erläuterung',
+      stack_list_one:
+        'init: Der Output der Finanzierungstransaktionen und der Input der Ausgabentransaktionen werden zusammengeführt.',
+      stack_list_two:
+        'Schritt 1: <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_1</span>schiebt „1“ auf den Stapel.',
+      stack_list_three:
+        'Schritt 2: <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_2</span>schiebt „2“ auf den Stapel.',
+      stack_list_four:
+        'Schritt 3: <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_ADD</span> nimmt zwei Elemente vom Stapel, addiert sie und schiebt die Summe zurück auf den Stapel.',
+      stack_list_five:
+        'Schritt 4: <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_EQUAL</span> nimmt zwei Elemente vom Stapel, vergleicht sie und schiebt ein boolesches Ergebnis zurück auf den Stapel.',
+      paragraph_two:
+        'Jetzt haben wir das Ende des Skripts erreicht und es befindet sich nur noch ein einziges WAHRES Element auf dem Stapel – die Münzen sind ausgegeben!',
+      paragraph_three:
+        'Wenn wir dieses Beispiel mit einer 4 auf dem Stapel beginnen würden, könnten wir die Münzen nicht ausgeben, da OP_EQUAL als FALSE ausgewertet würde. Für diese Herausforderungen verwenden wir eine sehr begrenzte Anzahl von Opcodes, die wir nach Kategorien einführen.',
+    },
+    opcodes_five: {
+      title: 'OpCodes',
+      nav_title: 'Grundlegende Arithmetik berechnen',
+      heading: 'Grundlegende Arithmetik',
+      paragraph_one:
+        'Bitcoin-Skripte können einfache mathematische Operationen ausführen. Sie könnten Münzen mithilfe einfacher Mathematik sperren, aber dann könnte jeder, der rechnen kann, die Münzen ausgeben! Mit anderen Worten: Versuchen Sie dies nicht im Mainnet.',
+      subheading_one:
+        'Opcodes, die Ganzzahlen oder beliebige Daten auf den Stapel übertragen',
+      opconstants_list_one_heading:
+        '<span className="flex items-center text-[#3DCFEF] w-fit rounded-sm px-1.5 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_0</span>',
+      opconstants_list_one_paragraph: 'Schiebt die Zahl 0 auf den Stapel.',
+      opconstants_list_two_heading:
+        '<span className="flex items-center text-[#3DCFEF] w-fit rounded-sm px-1.5 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_1</span>',
+      opconstants_list_two_paragraph: 'Schiebt die Zahl 1 auf den Stapel.',
+      opconstants_list_three_heading:
+        '<span className="flex items-center text-[#3DCFEF] w-fit rounded-sm px-1.5 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_2</span>',
+      opconstants_list_three_paragraph: 'Schiebt die Zahl 2 auf den Stapel.',
+      opconstants_list_four_heading:
+        '<span className="flex items-center text-[#3DCFEF] w-fit rounded-sm px-1.5 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_3</span>',
+      opconstants_list_four_paragraph: 'Schiebt die Zahl 3 auf den Stapel.',
+      opconstants_list_five_heading:
+        '<span className="flex items-center text-[#3DCFEF] w-fit rounded-sm px-1.5 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_DUP</span>',
+      opconstants_list_five_paragraph:
+        'Schiebt ein Duplikat des obersten Stapelelements auf den Stapel.',
+      opconstants_list_six_heading:
+        '<span className="flex items-center text-[#3DCFEF] w-fit rounded-sm px-1.5 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_PUSH</span>',
+      opconstants_list_six_paragraph:
+        'Legt den folgenden Skriptwert auf den Stapel. Beispielwerte sind SIG(alice), PUBKEY(alice), HASH256(secret), secret. Kleingeschriebene Zeichenfolgen stellen reale Daten dar und die anderen Opcodes in diesem Interpreter verarbeiten sie, als wären sie tatsächliche Schlüssel, Signaturen, Hash-Digests und Urbilder.',
+      subheading_two: 'Opcodes, die Arithmetik ausführen',
+      oparithmetic_list_one_heading:
+        '<span className="flex items-center text-[#3DCFEF] w-fit rounded-sm px-1.5 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_ADD</span>',
+      oparithmetic_list_one_paragraph:
+        'Nimmt zwei Elemente vom Stapel, addiert sie und schiebt ihre Summe zurück auf den Stapel.',
+      oparithmetic_list_two_heading:
+        '<span className="flex items-center text-[#3DCFEF] w-fit rounded-sm px-1.5 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_EQUAL</span>',
+      oparithmetic_list_two_paragraph:
+        'Nimmt zwei Elemente vom Stapel, vergleicht ihre Gleichheit und schiebt einen Booleschen Wert zurück auf den Stapel.',
+      oparithmetic_list_three_heading:
+        '<span className="flex items-center text-[#3DCFEF] w-fit rounded-sm px-1.5 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_EQUALVERIFY</span>',
+      oparithmetic_list_three_paragraph:
+        'Wie OP_EQUAL, löst jedoch einen Fehler aus und stoppt die Skriptausführung sofort, wenn die beiden Elemente nicht gleich sind.',
+      paragraph_two:
+        'Geben Sie den anfänglichen Stapel an, der aus dem Skript ausgegeben werden soll.',
+    },
+    opcodes_six: {
+      title: 'OpCodes',
+      nav_title: 'Mit Kryptographie dekodieren',
+      heading: 'Einfache Kryptographie',
+      paragraph_one:
+        'Wir haben uns in früheren Kapiteln mit „Pay to Public Key Hash“ befasst. Dies ist das Bitcoin-Skript, das explizit in Millionen von Transaktionsausgaben geschrieben wurde, bevor Segregated Witness aufkam und es verkürzte. Münzen werden durch den Hash eines öffentlichen Schlüssels gesperrt. Der Ausgeber muss den öffentlichen Schlüssel offenlegen, der zu diesem Hash passt, und dann eine durch diesen öffentlichen Schlüssel verifizierte Signatur bereitstellen.',
+      subheading_one: 'Opcodes für einfache Kryptographie',
+      opcryptography_list_one_heading:
+        '<span className="flex items-center text-[#3DCFEF] w-fit rounded-sm px-1.5 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm h-fit">OP_HASH256</span>',
+      opcryptography_list_one_paragraph:
+        'Holt ein Element vom Stapel, berechnet den Double-SHA256-Digest und schiebt diesen Digest zurück auf den Stapel. In unserer Übung wird diese Operation durch Strings symbolisiert. Beispiel: Das Skript OP_1 OP_HASH256 erzeugt den Stapel [HASH256(1)]',
+      opcryptography_list_two_heading:
+        '<span className="flex items-center text-[#3DCFEF] w-fit rounded-sm px-1.5 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm h-fit">OP_CHECKSIG</span>',
+      opcryptography_list_two_paragraph:
+        'Holt zwei Elemente vom Stapel. Das erste Element, das es herausholt, muss ein öffentlicher Schlüssel im Format PUBKEY(...) sein. Das zweite Element muss eine Signatur im Format SIG(...) sein. Wenn die Zeichenfolgen in den Klammern in beiden Elementen gleich sind, betrachten wir dies als eine gültige ECDSA-Signatur und legen TRUE zurück auf den Stapel, andernfalls FALSE.',
+      paragraph_two:
+        'Geben Sie den anfänglichen Stapel an, der aus dem Skript ausgegeben werden soll.',
+    },
+    opcodes_seven: {
+      title: 'OpCodes',
+      nav_title: 'Multisig',
+      heading: 'Multisig',
+      paragraph_one:
+        'Richtlinien für mehrere Signaturen stellen eine Liste öffentlicher Schlüssel und eine Anzahl von Signaturen bereit, die für eine gültige Ausgabe erforderlich sind. Sie können als „m-von-n“ beschrieben werden, was bedeutet, dass „m Signaturen aus dieser Liste von n öffentlichen Schlüsseln erforderlich sind“. Die öffentlichen Schlüssel und die m- und n-Werte sind normalerweise im Sperrskript enthalten und der Ausgeber muss nur die richtige Anzahl von Signaturen bereitstellen.',
+      paragraph_two:
+        'Holocat erscheint mit einer aufgezeichneten Nachricht von Satoshi Nakamoto!',
+      paragraph_three:
+        'Hallo. Ich habe versehentlich einen Fehler geschrieben, als ich <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_CHECKMULTISIG</span> implementiert habe. Es entfernt ein zusätzliches Element vom Stapel, das überhaupt nicht verwendet wird. Also, äh, ups. Entschuldigung. Dieser Code ist konsenskritisch, daher wird jede <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_CHECKMULTISIG</span>-Operation in der Vergangenheit, Gegenwart und Zukunft von Bitcoin gezwungen sein, ein „Dummy“-Element einzuschließen. Vergessen Sie es nicht, sonst können Sie Ihre Multisig-Münzen nicht ausgeben!',
+    },
+    opcodes_eight: {
+      title: 'OpCodes',
+      nav_title: 'Signieren mit mehreren Schlüsseln',
+      heading:
+        '<span className="flex items-center text-[#3DCFEF] w-fit rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-1">OP_CHECKMULTISIG</span>',
+      subheading_one:
+        'Verarbeitet m-von-n-Multisignaturen, indem dieser Algorithmus befolgt wird.',
+      multisig_list_one:
+        'Holt eine einzelne Ganzzahl vom Stapel. Dies ist der <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">n</span>-Wert.',
+      multisig_list_two:
+        'Entfernt <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">n</span> Elemente aus dem Stapel. Dabei handelt es sich voraussichtlich um öffentliche Schlüssel im Format <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">PUBKEY(...)</span>',
+      multisig_list_three:
+        'Holt eine einzelne Ganzzahl vom Stapel. Dies ist der <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">m</span>-Wert.',
+      multisig_list_four:
+        'Entfernt <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">m</span> Elemente aus dem Stapel. Es wird erwartet, dass es sich dabei um Signaturen im Format <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">SIG(...)</span> handelt.',
+      multisig_list_five:
+        'Entfernen Sie ohne jeden Grund ein zusätzliches Element aus dem Stapel.',
+      multisig_list_six:
+        'Durchlaufen Sie jeden öffentlichen Schlüssel: Überprüfen Sie den Schlüssel anhand der Signatur ganz oben auf dem Stapel. Wenn diese gültig ist, entfernen Sie sowohl den Schlüssel als auch die Signatur und fahren Sie mit dem nächsten öffentlichen Schlüssel fort. Wenn dieser nicht gültig ist, entfernen Sie nur den öffentlichen Schlüssel und fahren Sie mit dem nächsten öffentlichen Schlüssel fort (der zunächst mit der gleichen Signatur ganz oben überprüft wird).',
+      multisig_list_seven:
+        'Wenn alle öffentlichen Schlüssel getestet wurden und noch Signaturen übrig sind, schlägt der Vorgang fehl.',
+      multisig_list_eight:
+        'Sobald alle Signaturen entfernt wurden, kann der Vorgang vorzeitig erfolgreich beendet werden, auch wenn noch weitere öffentliche Schlüssel übrig sind.',
+      paragraph_one:
+        'Beachten Sie, dass m <= n. Es kann mehr öffentliche Schlüssel als Signaturen geben, aber nie mehr Signaturen als öffentliche Schlüssel. Beachten Sie auch, dass die Schlüssel und Signaturen in derselben Reihenfolge sein MÜSSEN, selbst wenn einige Schlüssel nicht zum Signieren verwendet werden.',
+      paragraph_two:
+        'Geben Sie den anfänglichen Stapel an, der aus dem Skript ausgegeben werden soll.',
+    },
+    opcodes_nine: {
+      title: 'OpCodes',
+      nav_title: 'Warten Sie mit dem Entsperren',
+      heading: 'Zeitschlösser',
+      paragraph_one:
+        'Bereits im letzten Jahrhundert wurde in einem Dokument mit dem Titel BIP 65 ein neuer Opcode für Bitcoin vorgeschlagen, der schließlich den Konsensregeln hinzugefügt wurde. Er wird verwendet, um zu fordern, dass die nLocktime einer Transaktion einen vom Skript angegebenen Wert erreicht oder überschreitet. Die Konsensregeln von Bitcoin verbieten bereits die Aufnahme einer Transaktion in einen Block, wenn die Höhe dieses Blocks größer als die nLocktime der Transaktion ist. Mit anderen Worten: Dieser Opcode macht eine Transaktion unbrauchbar, bis die Blockchain irgendwann in der Zukunft eine bestimmte Höhe erreicht. Da er mit einem Soft Fork hinzugefügt wurde, wird NICHTS vom Stack entfernt, was bedeutet, dass die meisten Anwendungen auch ein <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_DROP</span> erfordern. Wenn der Opcode feststellt, dass es zu früh ist, diese Transaktion in einen Block aufzunehmen, wird die Skriptauswertung sofort mit einem Fehler beendet.',
+      subheading_one: 'Opcodes, die Zeitsperren blockieren',
+      optimelock_list_one_heading:
+        '<span className="flex items-center text-[#3DCFEF] w-fit rounded-sm px-1.5 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_DROP</span>',
+      optimelock_list_one_paragraph:
+        'Nimmt ein Element vom Stapel und ignoriert es.',
+      optimelock_list_two_heading:
+        '<span className="flex items-center text-[#3DCFEF] w-fit rounded-sm px-1.5 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_CHECKLOCKTIMEVERIFY</span>',
+      optimelock_list_two_paragraph:
+        'Liest (holt nicht heraus) das oberste Stapelelement und interpretiert es als Blockhöhe. Wenn das vom Operationscode verwendete Höhenargument nicht mindestens gleich der Höhe des NÄCHSTEN Blocks ist, ist die Operation ungültig.',
+      paragraph_two:
+        'Geben Sie den anfänglichen Stapel an, der aus dem Skript ausgegeben werden soll.',
+    },
+    opcodes_ten: {
+      title: 'OpCodes',
+      nav_title: 'Bauen Sie eine Logik auf',
+      heading: 'Konditionale',
+      paragraph_one:
+        'Wie jede andere gute Programmiersprache hat Bitcoin-Skript logische Zweige! Der Pfad durch die Zweige wird normalerweise vom Spender gewählt, um auszuwählen, welche Kombination von Authentifizierungsbedingungen er erfüllen muss.',
+      paragraph_two:
+        '<span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_IF</span> <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_ELSE</span> <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_ENDIF</span> Logische Verzweigungen.',
+      paragraph_three:
+        '<span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_IF</span> nimmt einen Wert vom Stapel und wertet ihn als Booleschen Wert aus. Wenn dies zutrifft, wird die Codeausführung bis <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_ELSE</span> fortgesetzt und dann zu <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_ENDIF</span> gesprungen, andernfalls wird zu <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_ELSE</span> gesprungen und die Ausführung bis <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_ENDIF</span> fortgesetzt. Logische Zweige können verschachtelt sein, aber jedes <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_IF</span> muss mit einem <span className="text-[#3DCFEF] rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_ENDIF</span> gepaart werden, um jeden Zweig zu schließen, andernfalls gibt der Interpreter einen Fehler aus und das Skript schlägt fehl.',
+      paragraph_four:
+        'Geben Sie den anfänglichen Stapel an, der aus dem Skript ausgegeben werden soll.',
+    },
+    proposal_one: {
+      title: 'Fortschrittlich',
+      nav_title: 'Zurück zur Geschichte',
+      heading: 'Zurück zur Geschichte!',
+      paragraph_one:
+        'Gute Arbeit! Wir haben die meisten Opcodes durchgegangen, die Sie beim Erstellen von Skripten für grundlegende Transaktionen benötigen. Jetzt testen wir sie.',
+      paragraph_two:
+        'Stellen Sie für jeden Vertragsvorschlag, den Sie besprechen, ein Bitcoin-Skript und einen gültigen Ausgabenstapel bereit.',
+    },
+    proposal_two: {
+      title: '2 von 2 Multisig',
+      nav_title: 'Gemeinsam unterschreiben',
+      heading: '2 von 2 Multisig',
+      paragraph_one:
+        'Das erste, was Vanderpoole vorschlägt, ist ein 2-von-2-Multisig. Alle Spenden werden zwischen Ihnen und der Lil Bits Foundation 50/50 aufgeteilt. Dies wird von Ihnen beiden verwaltet, wobei jeder von Ihnen alle Ausgabentransaktionen von der Spendenadresse aus unterschreibt. Das bedeutet, dass Sie allen Abhebungen von der Spendenadresse zustimmen müssen.',
+      paragraph_two:
+        'Vanderpoole gibt Ihnen seinen öffentlichen Schlüssel, er lautet PUBKEY(vanderpoole), und Ihrer ist PUBKEY(me).',
+      paragraph_three:
+        'Geben Sie den anfänglichen Stapel an, der aus dem Skript ausgegeben werden soll.',
+      next_step_message:
+        'Sieht gut aus! Versuchen wir es jetzt mit Ihrer eigenen Signatur.',
+    },
+    proposal_three: {
+      title: 'Bedingt zeitgesperrte Transaktion',
+      nav_title: 'Lass ihn warten',
+      heading: 'Bedingt zeitgesperrte Transaktion',
+      paragraph_one:
+        'Moment mal, das ergibt doch keinen Sinn – du willst doch nicht ewig mit ihm zu tun haben! Der neue Deal ist, dass du alle Spenden für die nächsten zwei Stunden bekommst, während du noch im Fernsehen bist. Die Lil Bits Foundation bekommt alles, was danach reinkommt. Du siehst dir den Bitcoin-Block an der Wand im Studio an und stimmst zu, dass Blockhöhe 6930300 wahrscheinlich in etwa zwei Stunden geschürft sein wird.',
+      paragraph_two:
+        'Denken Sie daran, dass Vanderpooles öffentlicher Schlüssel PUBKEY(vanderpoole) ist und Ihrer PUBKEY(me).',
+      paragraph_three:
+        'Geben Sie den anfänglichen Stapel an, der aus dem Skript ausgegeben werden soll.',
+      next_step_message:
+        'Sieht gut aus! Versuchen wir es jetzt mit Ihrer eigenen Signatur.',
+    },
+    proposal_four: {
+      title: 'Geheime Preimage-gesperrte Transaktion',
+      nav_title: 'Arbeiten mit einem Orakel',
+      heading: 'Geheime Preimage-gesperrte Transaktion',
+      paragraph_one:
+        'Vanderpoole ändert seine Meinung erneut. Wegen der Unbekannten gefällt ihm der Deal nicht. Er beschließt, dass die Lil Bits-Stiftung die ersten 1,0 BTC der Gesamtspenden erhält und Sie den Rest später ausgeben können.',
+      paragraph_two:
+        'Es gibt keine Möglichkeit, den Gesamtsaldo mehrerer UTXOs in einem Bitcoin-Skript zu überprüfen, daher einigen Sie sich auf ein unvoreingenommenes Orakel eines Drittanbieters: Deborah Chunk! Sie überwacht den Gesamtbetrag der Spenden in der Blockchain und verkündet live im Fernsehen das Preimage eines Hash-Werts, den Sie im Skript festlegen, sobald dieser mindestens 1,0 BTC beträgt.',
+      paragraph_three: {
+        a: 'Sie generiert privat einen sicheren, zufälligen Nonce und übergibt Ihnen dann den Hash-Digest: <span className="text-[#3DCFEF] w-fit rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">HASH256(FD3771E8)</span>. Sie können alle Münzen ausgeben, die Sie erhalten, sobald sie dieses Geheimnis preisgibt, und nicht eine',
+        b: 'eine Sekunde früher!',
+      },
+      paragraph_four:
+        'Denken Sie daran, dass Vanderpooles öffentlicher Schlüssel PUBKEY(vanderpoole) ist und Ihrer PUBKEY(me).',
+      paragraph_five:
+        'Geben Sie den anfänglichen Stapel an, der aus dem Skript ausgegeben werden soll.',
+      tooltip_one: {
+        question: 'Was ist ein Satoshi?',
+        link: 'https://chat.bitcoinsearch.xyz/?author=holocat&question=What%2520is%2520a%2520satoshi%253F',
+        highlighted: 'Satoshi - Die wunderbare Welt des Wahnsinns',
+      },
+      next_step_message:
+        'Mal sehen, ob wir unsere Signatur mit dem Urbild richtig verwendet haben.',
+    },
+    outro_one: {
+      title: 'Andere',
+      nav_title: 'Kapitel abgeschlossen',
+      heading: "So geht's!",
+      paragraph_one:
+        'Die Spenden wurden nun an Sie und die Lil Bits Foundation verteilt und viele Zuschauer danken Ihnen, dass Sie Licht auf Vanderpooles Aktionen geworfen haben. Obwohl die dezentrale Natur von Bitcoin es schwierig macht, das Netzwerk zu überholen, hält das Leute wie ihn nicht davon ab, es zu versuchen. Sie sind erleichtert, dass die Wahrheit endlich ans Licht gekommen ist, besonders nach all den Anstrengungen, die es gekostet hat, hierher zu gelangen.',
+    },
+    resources: {
+      opcodes_five: {
+        arithmetic_heading: 'Arithmetische Opcodes',
+        arithmetic_paragraph:
+          'In Bitcoin-Skripten benötigen Rechenoperationen wie in der Mathematik einige Eingaben, um mathematische Operationen durchzuführen. In tatsächlichen Bitcoin-Skripten sind die Eingaben auf vorzeichenbehaftete 32-Bit-Ganzzahlen beschränkt, aber die Ausgabe kann überlaufen.',
+        spoiler:
+          'Geben Sie im Anfangsstapel zwei Ganzzahlen ein, die die Summe 3 ergeben',
+      },
+      opcodes_six: {
+        cryptography_heading: 'Kryptografische Opcodes',
+        cryptography_paragraph:
+          'Diese Opcodes sind bei alltäglichen Transaktionen wichtig, da sie sicherstellen, dass die Ausgaben nur mit der Unterschrift des Besitzers dieses UTXO ausgegeben werden können. Beachten Sie, dass es keine formalen Kategorien von Opcodes gibt und dass sie nur durch ihre Hex-Code-Darstellung organisiert sind.',
+        spoiler:
+          'Das Skript prüft eine Signatur anhand eines gehashten öffentlichen Schlüssels. Setzen Sie zuerst einen Signaturschlüssel und dann einen öffentlichen Schlüssel',
+      },
+      opcodes_eight: {
+        multisig_heading: 'Multisig-Opcodes',
+        multisig_paragraph:
+          '<span className="text-[#3DCFEF] rounded-sm px-1.5 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_CHECKMULTISIG</span> weist einen bemerkenswerten Fehler auf, der erfordert, dass der Stapel oben auf dem Stapel einen weiteren, nicht verwendeten Wert enthält, der nichts mit dem eigentlichen Multisig zu tun hat.',
+        spoiler:
+          'Es handelt sich um ein Multisig-Skript, das zwei Signaturen erfordert, und der erste Wert im Stapel ist ein Platzhalter für eine Eigenart im CHECKMULTISIG-Vorgang.',
+      },
+      opcodes_nine: {
+        timelock_heading: 'Timelock-Opcodes',
+        timelock_paragraph:
+          'Bitcoin-Skripte können die aktuelle Blockhöhe lesen, sodass Transaktionen in Zukunft basierend auf Bitcoin-Blöcken gesperrt werden können. Die genaue Semantik des tatsächlichen <span className="text-[#3DCFEF] rounded-sm px-1.5 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_CHECKLOCKTIMEVERIFY</span> finden Sie',
+        timelock_link:
+          '<Link target="_blank" href="https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki" className="underline">hier</Link>.',
+        spoiler:
+          'Das Skript sperrt die Ausgaben bis zu einer bestimmten Blockhöhe und überprüft dann die Signatur im Anfangsstapel.',
+      },
+      opcodes_ten: {
+        conditionals_heading: 'Opcode-Logik',
+        conditionals_paragraph:
+          'Bedingte Opcodes ermöglichen einige grundlegende Verzweigungen der Programmierlogik. Während die bedingte Logik eine breite Palette zusätzlicher Möglichkeiten im Bitcoin-Skript ermöglicht, ist sie im Vergleich zu einer herkömmlichen Programmiersprache immer noch begrenzt.',
+        spoiler:
+          'Die Summe der ersten beiden Werte im Anfangsstapel ist falsch, daher folgt das Skript dem OP_ELSE-Zweig.',
+      },
+      proposal_two: {
+        making_script_heading: 'Skript erstellen',
+        making_script_paragraph:
+          'Denken Sie daran, dass Skripte nur validiert werden können, wenn sie mit einem einzigen Wahrheitswert auf dem Stapel enden. Einige Versionen erlauben jeden Wahrheitswert, aber unser Skript-Editor lässt nur Werte zu, die gleich 1 oder „true“ sind.',
+        tip: 'Vergessen Sie nicht den Fehler in <span className="text-[#3DCFEF] rounded-sm px-1.5 h-[28px] font-mono bg-[#0000004D] m-0.5 text-sm">OP_CHECKMULTISIG</span>, der den zusätzlichen, ungenutzten Wert auf dem Stapel erfordert!',
+        spoiler:
+          'Skripthinweis: Bei dieser Multisig-Anordnung müssen beide Teilnehmer unterschreiben. Das Skript gibt an, dass zwei Signaturen erforderlich sind, und enthält beide öffentlichen Schlüssel.\nStack-Hinweis: Um das Skript zu erfüllen, müssen Sie beide Signaturen angeben. Die 0 auf dem Stack steht für ein bestimmtes Verhalten der CHECKMULTISIG-Operation.',
+      },
+      proposal_three: {
+        tip: 'Lassen Sie uns darüber nachdenken, eine Bedingung mit einer Zeitsperre zu kombinieren, um Vanderpooles Unterschrift von Ihrer zu trennen.',
+        spoiler:
+          'Skripthinweis: Das Skript erlaubt Ausgaben unter zwei Bedingungen: vor Block 6930300 oder danach. Vor dem Block kann Vanderpoole ausgeben; nach dem Block können Sie.\n\nStapelhinweis: Um vor dem angegebenen Block auszugeben, verwendet Vanderpoole seine Signatur. Nach dem Block verwenden Sie Ihre Signatur und müssen eine 0 angeben, da das Skript die Sperrzeitüberprüfung überschritten hat.',
+      },
+      proposal_four: {
+        tip: 'Das Urbild wird nach einer unbekannten Zeitspanne angezeigt, die Verwendung von Zeitsperren ist daher nicht erforderlich.',
+        spoiler:
+          'Skripthinweis: Das Skript erlaubt Ausgaben unter zwei Bedingungen: vor oder nach der Offenlegung des Geheimnisses. Vor der Sperre kann Vanderpoole ausgeben; nach der Sperre können Sie beide.\n\nStapelhinweis: Um auszugeben, bevor das Geheimnis offengelegt wird, verwendet Vanderpoole seine Signatur. Nachdem das Geheimnis offengelegt wurde, verwenden Sie Ihre Signatur, einen Hash des Geheimnisses, und geben eine 0 an, da das Skript die nicht offengelegte Überprüfung abgeschlossen hat.',
+      },
+    },
   },
-
   chapter_ten: {
     title: '10 Milliarden Verbindungen',
+    paragraph_one:
+      'Das ON-AIR-Licht im Fernsehstudio wird dunkel. Bühnenarbeiter schalten ihre 3D-Kameras aus und verlassen nach einem langen und ereignisreichen Tag das Studio. Mika 3000 wartet dort auf Sie.',
+    intro_one: {
+      title: 'Feier',
+      nav_title: 'Feier',
+      paragraph_one:
+        '—MIKA 3000: „Du hast es geschafft! Du hast es wirklich geschafft! Lass uns etwas trinken und feiern.“',
+      paragraph_two:
+        'Sie gehen zu einer nahegelegenen Bar namens The Public Key Pub. Der Barkeeper, ein freundlicher Typ mit dem Namensschild Laszlo, heißt Sie beide willkommen.',
+      paragraph_three:
+        '—MIKA 3000: „Ich weiß nicht, warum, aber ich hätte total Lust auf eine Calzone.“',
+      paragraph_four:
+        '—LASZLO: „So etwas gibt es bei uns nicht, aber mein Ururgroßvater hat dafür gesorgt, dass die Pizza hier die beste ist. Manche würden sagen, 10.000 Bitcoin sind gut.“',
+      paragraph_five: {
+        a: '—MIKA 3000: „10.000 Bitcoin? Moment mal … heißt du Laszlo, weil du von',
+        b: '?"',
+      },
+      paragraph_six: '—LASZLO: „Der Einzig Wahre.“',
+      tooltip_one: {
+        question: 'Welche Bedeutung haben der Laszlo- und Pizzatag?',
+        link: 'https://chat.bitcoinsearch.xyz/?author=holocat&question=What%2520is%2520the%2520significance%2520of%2520Laszlo%2520and%2520pizza%2520day%253F',
+        highlighted: 'DER Laszlo',
+      },
+    },
+    intro_two: {
+      title: 'Getränke holen',
+      nav_title: 'Getränke holen',
+      paragraph_one:
+        '—MIKA 3000: „Das ist so cool. Solange es nicht 10.000 Bitcoin sind, nehmen wir eine dieser Pizzen und ein paar Lightning Lemonades. Schade nur wegen der Calzone.“',
+      paragraph_two:
+        'Mika 3000 und Laszlo holen ihre solarbetriebenen ePhone Infinities heraus und beginnen, auf die Tasten zu tippen.',
+      paragraph_three:
+        '—MIKA 3000: „Oh oh. Dein kleiner Stunt da hinten hat die Miner-Gebühren ziemlich in die Höhe getrieben. Das Bitcoin-Netzwerk erlebt einen Aktivitätsschub und die Transaktionsgebühren gehen durch die Decke! Wir werden dafür außerhalb der Kette zahlen müssen.“',
+    },
+    intro_three: {
+      title: 'Außerhalb der Kette?',
+      nav_title: 'Außerhalb der Kette?',
+      paragraph_one:
+        'Seit „Satoshi“ sich erstmals gemeldet hat, mussten Sie nur mit On-Chain-Transaktionen arbeiten. So haben Sie Ihre Mining-Belohnungen eingefordert und Geld an Mika 3000 überwiesen. Diese On-Chain-Transaktionen sind jedoch nicht ideal für den häufigen, alltäglichen Gebrauch, da der Blockplatz begrenzt ist und die Miner-Gebühren variieren können.',
+      paragraph_two:
+        'Wie ist es dann möglich, dass Menschen Bitcoin täglich auf eine skalierbare Weise nutzen können? Die Antwort sind Off-Chain-Zahlungen, etwas, das Sie wahrscheinlich schon millionenfach gesehen haben: Ein orangefarbenes Taxi, das seine Passagiere aus dem Wagen wirft und davonrast, jemand, der sein Abendessen an einem Halal-Stand kauft, ein Kind, das mit seinem Holohund und einem Karton Digimilch aus einem Geschäft kommt. Und so weiter. Die Anwendungsfälle von Geld sind nahezu unendlich.',
+      paragraph_three:
+        'Obwohl Bitcoin nicht dafür ausgelegt ist, ein solches Aktivitätsvolumen allein zu bewältigen, ist dies mit Off-Chain-Zahlungen möglich.',
+      paragraph_four:
+        '—DU: „Das ist überhaupt kein Problem, Mika 3000. Ich kann damit umgehen. Ich werde es beweisen, indem ich mit einer Off-Chain-Zahlung ein Bier von Laszlo kaufe.“',
+    },
+    opening_a_channel_one: {
+      title: 'Die anfänglichen Mittel',
+      nav_title: 'Die anfänglichen Mittel',
+      heading_one: 'Die anfänglichen Mittel',
+      paragraph_one:
+        'Sie haben einen bestätigten UTXO in der Blockchain für 101.000 Satoshis. Es scheint ziemlich einfach zu sein, eine Off-Chain-Zahlung vorzunehmen, oder?',
+    },
+    opening_a_channel_two: {
+      title: 'Die Off-Chain-Transaktion',
+      nav_title: 'Die Off-Chain-Transaktion',
+      heading_one: 'Die Off-Chain-Transaktion',
+      paragraph_one:
+        'Lassen Sie uns eine gültige Bitcoin-Transaktion erstellen, aber anstatt sie an das Netzwerk zu senden, senden wir sie direkt an Laszlo! Laszlo sollte Ihnen für diese Transaktion ein Bier geben, da er weiß, dass er das Geld tatsächlich hat, auch wenn die Transaktion nicht gesendet oder bestätigt wurde.',
+      paragraph_two:
+        'Denken Sie daran, wir schreiben das Jahr 2140! Ein SHA-256 Stout kostet 0,0001000 BTC.',
+      heading_two: 'Hinweise',
+      off_chain_list_one:
+        'Geben Sie die beiden Ausgabebeträge ein, 1000 Satoshis für Laszlo und den Rest für Ihr Wechselgeld.',
+      off_chain_list_two:
+        '<span className="font-bold">NB</span>: Um das Geld zu erhalten, muss Laszlo diese Transaktion an das Netzwerk senden und die Gebühren berücksichtigen. Lassen Sie uns 1000 Sats für Miner-Gebühren beiseitelegen.',
+      off_chain_list_three: 'Schreiben Sie die beiden Ausgabeskripte',
+      off_chain_list_four:
+        'Unterschreiben Sie die Eingabe durch Klicken auf „Unterschreiben“',
+      hint_one:
+        'Laszlo gibt Ausgabe 0 mit <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base"> SIG(LASZLO)</span> aus',
+      hint_two:
+        'Sie geben Ausgabe 1 mit <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base"> SIG(YOU)</span> aus',
+    },
+    opening_a_channel_three: {
+      title: 'Vertrauensproblem bei Off-Chain-Zahlungen',
+      nav_title: 'Vertrauensproblem bei Off-Chain-Zahlungen',
+      paragraph_one:
+        '—LASZLO: „Moment mal, das ergibt doch keinen Sinn – du kannst den Ertrag ja jederzeit ausgeben. Du könntest dein Bier trinken und dir dann das ganze Geld zurückgeben, ohne dass ich etwas dafür bekäme!',
+      paragraph_two:
+        'Wenn Sie mit mir außerhalb der Kette Geld ausgeben möchten, brauche ich eine Garantie, dass Sie das Geld nicht selbst AUF der Kette verschieben können.“',
+    },
+    opening_a_channel_four: {
+      title: 'Multisig',
+      nav_title: 'Multisig',
+      heading_one: 'Multisig',
+      paragraph_one:
+        'Dieses Spiel muss mit einer 2-von-2-Multisig beginnen, die auf der Blockchain bestätigt wird. Sobald wir das haben, können wir einen Weg finden, diese einzelne On-Chain-Transaktion noch effektiver zu gestalten. So erreichen wir mehr mit weniger.',
+      multisig_one: 'Füllen Sie den Ausgabebetrag und das Ausgabeskript aus',
+      multisig_two:
+        'Unterschreiben Sie die Eingabe mit einem Klick auf „Signieren“',
+      heading_two: 'Hinweise',
+      hint_one_a:
+        'Sie und Laszlo möchten in Zukunft zusammenarbeiten, um Ausgabe 0 mit <br/> auszugeben',
+      hint_one_b:
+        '<span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base"> 0 SIG(LASZLO) SIG(YOU) </span>',
+    },
+    opening_a_channel_five: {
+      title: 'Rückerstattungsschutz bei Multisig',
+      nav_title: 'Rückerstattungsschutz bei Multisig',
+      paragraph_one:
+        '—LASZLO: „OK, danke, das ist ein guter Anfang. Aber was ist, wenn ich vom Tisch weggehe und Sie mich nie wiedersehen? Ich könnte diese Transaktion übertragen und Ihre 100.000 Satoshis würden in einem 2-Schlüssel-Multisig stecken bleiben, aus dem Sie sich nie wieder erholen könnten.',
+      paragraph_two:
+        'Tun Sie sich selbst einen Gefallen; führen Sie vor der Unterzeichnung eine Rückerstattung durch, damit Sie sicher sein können, dass Sie Ihr Geld zurückbekommen.“',
+    },
+    updating_the_state_one: {
+      title: 'Die Rückerstattung',
+      nav_title: 'Die Rückerstattung',
+      heading_one: 'Die Rückerstattung',
+      paragraph_one:
+        'Eine neue Registerkarte wird angezeigt: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base">Refund</span>. Dadurch wird eine weitere TX-Vorlage auf demselben Bildschirm gestartet, mit einem Pfeil vom <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base">Multi-Sig</span>-Ausgang zu diesem TX-Eingang.',
+      refund_list_one: 'Füllen Sie den Ausgabebetrag und das Ausgabeskript aus',
+      refund_list_two:
+        'Senden Sie es an Laszlo, indem Sie auf „Unterschreiben“ klicken. Dann kann er uns mitteilen, ob er es unterschreiben möchte.',
+      refund_list_three:
+        'Unterschreiben Sie es noch nicht selbst! Mal sehen, was Laszlo denkt, zuerst',
+      heading_two: 'Hinweise',
+      hint_one:
+        'Output 0 wird von Ihnen mit <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base"> SIG(YOU) </span> ausgegeben',
+    },
+    updating_the_state_two: {
+      title: 'Absicherung von Zahlungen',
+      nav_title: 'Absicherung von Zahlungen',
+      paragraph_one:
+        '—LASZLO: „OK, gut, ich unterschreibe das und schicke es Ihnen zurück, und dann können Sie die Finanzierungstransaktion unterzeichnen.',
+      paragraph_two:
+        'Aber Moment mal. Wenn ich das unterschreibe, sind wir wieder da, wo wir angefangen haben: Sie können diese Transaktion auch dann noch senden, wenn ich Ihnen ein Bier gebe, und ich werde dafür nicht bezahlt.',
+      paragraph_three:
+        'Bevor ich dies unterschreibe, benötige ich eine Garantie, dass Ihre vollständige Rückerstattungstransaktion widerrufen werden kann.',
+      paragraph_four:
+        'Sobald Sie mir das Bier bezahlt haben, sollten Sie das nicht mehr öffentlich machen können. Und wenn Sie versuchen, die widerrufene Transaktion öffentlich zu machen, darf ich ALLE 100.000 Satoshis behalten!"',
+    },
+    updating_the_state_three: {
+      title: 'Der Widerruf',
+      nav_title: 'Der Widerruf',
+      heading_one: 'Der Widerruf',
+      paragraph_one:
+        'Sie können die Ausgabe an sich selbst für Laszlo widerrufbar machen, indem Sie der Ausgabe von 100.000 Satoshi eine zusätzliche Bedingung hinzufügen. Der Logikzweig sollte es Laszlo ermöglichen, die Ausgabe mit seinem eigenen Schlüssel UND einem neuen privaten Schlüssel auszugeben, den Sie generieren. Um die Transaktion zu widerrufen, geben Sie Laszlo einfach den neuen privaten Schlüssel. Das ist eine sehr ungewöhnliche Vorgehensweise! Aber da dabei 100.000 Satoshis auf dem Spiel stehen, beweist es Laszlo, dass Sie es nach dem Widerruf NICHT senden werden.',
+      paragraph_two:
+        'Sie generieren ein neues Schlüsselpaar: einen privaten Schlüssel revocation_you_1 und PUBKEY(REVOCATION_YOU_1). Sie generieren jedes Mal ein neues Schlüsselpaar wie dieses, wenn Sie den Status des Zahlungskanals aktualisieren möchten.',
+      revocation_list_one:
+        'Fügen Sie dem Skript eine WENN-Bedingung hinzu, damit Laszlo die Ausgabe NUR ausgeben kann, wenn er AUCH den Widerrufsschlüssel hat (Sie halten den Schlüssel weiterhin geheim, bis es Zeit zum Widerrufen ist!)',
+      revocation_list_two:
+        'Klicken Sie auf „An Laszlo senden“, um es an Laszlo zu senden, damit er es unterschreiben kann.',
+      revocation_list_three: 'Unterschreiben Sie noch nicht selbst!',
+      heading_two: 'Hinweise',
+      paragraph_three: 'Ausgabe 0 wird entweder durch Folgendes ausgegeben:',
+      hint_one:
+        'Sie: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base"> SIG(SIE) 1 </span>',
+      hint_two:
+        'Laszlo: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base"> 0 SIG(REVOCATION_YOU_1) SIG(LASZLO) 0 </span>',
+    },
+    updating_the_state_four: {
+      title: 'Das Rennen um den Widerruf',
+      nav_title: 'Das Rennen um den Widerruf',
+      paragraph_one:
+        '—LASZLO: „Nun, das ist besser, aber mir ist gerade aufgefallen, dass es, selbst wenn ich den Widerrufsschlüssel habe, immer noch ein Wettrennen zwischen dir und mir sein wird, um diese Ausgabe auszugeben',
+      paragraph_two:
+        'Ich brauche einen ordentlichen Vorsprung, damit ich überhaupt merke, dass Sie mich betrogen haben. Dann kann ich die Bitcoins mit dem Widerrufsschlüssel abheben, bevor Sie Ihre volle Rückerstattung erhalten.“',
+    },
+    updating_the_state_five: {
+      title: 'Das Zeitschloss',
+      nav_title: 'Das Zeitschloss',
+      heading_one: 'Das Zeitschloss',
+      time_lock_list_one:
+        'Fügen Sie eine Verzögerung von 700 Blöcken hinzu, bevor Sie die Ausgabe ausgeben können',
+      time_lock_list_two:
+        'Klicken Sie auf „Signieren“, um es an Laszlo zu senden, damit er es unterschreiben kann.',
+      time_lock_list_three: 'Unterschreiben Sie noch nicht selbst!',
+      heading_two: 'Hinweise',
+      paragraph_one: 'Ausgabe 0 wird entweder durch Folgendes ausgegeben:',
+      hint_one:
+        'Sie, nach 700 Blöcken: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base"> SIG(YOU) 1 </span>',
+      hint_two:
+        'Laszlo: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base"> 0 SIG(REVOCATION_YOU_1) SIG(LASZLO) 0 </span> ',
+    },
+    updating_the_state_six: {
+      title: 'Kanal offen mit Laszlo',
+      nav_title: 'Kanal offen mit Laszlo',
+      paragraph_one:
+        'Dieses Mal, wenn Sie auf An Laszlo senden klicken, lächelt er und applaudiert! Er unterschreibt die untergeordnete Transaktion ([X] Laszlo). Jetzt können Sie die übergeordnete Transaktion unterschreiben und an die Blockchain senden: DER KANAL IST GEÖFFNET',
+      paragraph_two:
+        'Sie haben Laszlo dazu gebracht, Ihnen den Kauf von Getränken außerhalb der Kette zu erlauben, und haben dafür einen Kanal geöffnet!',
+    },
+    making_a_payment_one: {
+      title: 'Eine Zahlung vornehmen',
+      nav_title: 'Eine Zahlung vornehmen',
+      heading_one: 'Eine Zahlung vornehmen',
+      paragraph_one: 'Lassen Sie uns zusammenfassen:',
+      list_one:
+        'Sie haben 100000 Satoshis an einen 2-von-2-Multisig-Output zwischen Ihnen und Laszlo gesendet',
+      list_two:
+        'Sie verfügen offline über eine Transaktion, die diese Ausgabe ausgibt.',
+      list_three: 'Diese Offline-Ausgabe ermöglicht ENTWEDER',
+      list_three_sub_one:
+        'Sie erhalten Ihr gesamtes Geld nach 700 Blöcken zurück',
+      list_three_sub_two:
+        'Laszlo bekommt das gesamte Geld, wenn er den privaten Schlüssel revocation_you_1 von Ihnen bekommt',
+      list_four:
+        'Laszlo hat es bereits unterschrieben und Sie können es unterschreiben, wann immer Sie es senden möchten.',
+      list_five:
+        'Nachdem Laszlo die Offline-Untertransaktion signiert hatte, konnten Sie die übergeordnete Transaktion sicher signieren und übertragen.',
+      paragraph_two:
+        'Die bestätigte Transaktion, die die Multisig-Ausgabe finanziert hat, wird als Finanzierungstransaktion bezeichnet. Die Bestätigung in der Blockchain bedeutet, dass Ihr Kanal jetzt GEÖFFNET ist.',
+      paragraph_three:
+        'Die Offline-Transaktion, die diesen Output ausgibt, wird als Commitment-Transaktion bezeichnet. Eine Bestätigung in der Blockchain würde den Kanal SCHLIESSEN. Die erste Commitment-Transaktion ist Ihre vollständige Rückerstattung, da Sie noch keine Zahlungen an Laszlo geleistet haben.',
+      paragraph_four:
+        'Solange der Kanal GEÖFFNET ist, können Sie und Laszlo Offline-Zahlungen untereinander tätigen, indem Sie neue Verpflichtungstransaktionen aushandeln und alte widerrufen. Wenn Sie mehr Getränke kaufen, verringert sich Ihr „Rückerstattungsbetrag“ und Laszlos Ausgabebeträge steigen.',
+    },
+    making_a_payment_two: {
+      title: 'Kauf dir ein Bier!',
+      nav_title: 'Kauf dir ein Bier!',
+      heading_one: 'Kauf dir ein Bier!',
+      paragraph_one:
+        'Jetzt ist es endlich an der Zeit, Bitcoins außerhalb der Blockchain an Laszlo zu senden. Wir werden „einfach“ eine Ausgabe von 1.000 Satoshi für ihn in einer aktualisierten Commitment-Transaktion hinzufügen. Wir müssen außerdem versprechen, die alte Commitment-Transaktion, die Laszlo nichts eingebracht hat, niemals zu übertragen. Das ist garantiert, wenn wir ihm den Widerrufsschlüssel für diese alte Commitment-Transaktion senden, was wir als Nächstes tun werden.',
+      paragraph_two:
+        'Sie müssen einen weiteren Widerrufsschlüssel für diesen neuen Status generieren, falls Sie den Zyklus wiederholen möchten (Widerrufen Sie DIESE Transaktion für eine weitere neue Verpflichtung, bei der Laszlo für ein zweites Bier bezahlt wird). Es ist schließlich eine Party!',
+      paragraph_three:
+        'Sie generieren einen privaten Schlüssel <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base">revocation_you_2</span>',
+      list_one: 'Ziehen Sie 1000 Satoshis von Ihrer Ausgabe ab',
+      list_two:
+        'Fügen Sie der zweiten Ausgabe 1000 Satoshis hinzu und füllen Sie das Skript für Laszlo aus',
+      list_three:
+        'Klicken Sie auf „An Laszlo senden“, um es an Laszlo zu senden, damit er es unterschreiben kann.',
+      list_four: 'Unterschreiben Sie noch nicht selbst!',
+      heading_two: 'Hinweise',
+      paragraph_four: 'Ausgabe 0 wird entweder durch Folgendes ausgegeben:',
+      hint_one:
+        'Sie, nach 700 Blöcken: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base">SIG(SIE) 1 </span>',
+      hint_two:
+        'Laszlo: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base"> 0 SIG(REVOCATION_YOU_2) SIG(LASZLO) 0 </span>',
+      paragraph_five:
+        'Ausgabe 1 wird von Laszlo ausgegeben: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base"> SIG(LASZLO) </span>',
+    },
+    making_a_payment_three: {
+      title: 'Laszlos Blockchain-Dilemma',
+      nav_title: 'Laszlos Blockchain-Dilemma',
+      paragraph_one:
+        'Laszlo schaut sich diese Transaktion eine Sekunde lang an und schnappt sich ein Glas hinter der Bar, schenkt das Bier aber nicht ein',
+      paragraph_two:
+        '—LASZLO: „Warte. Wenn du diese Transaktion nicht unterschreibst, habe ich nichts. Du könntest mit diesem Bier verschwinden und ich könnte nichts in der Kette bestätigen. Vielleicht solltest du es zuerst unterschreiben und es mir dann schicken, damit wir beide eine Kopie haben?“',
+    },
+    making_a_payment_four: {
+      title: 'Holocats Warnung vor Vertrauenslosigkeit',
+      nav_title: 'Holocats Warnung vor Vertrauenslosigkeit',
+      paragraph_one:
+        'In diesem Moment materialisiert Holocat auf dem Tisch, stellt sich mit ausgestreckten Vorderpfoten auf die Hinterbeine und miaut.',
+      paragraph_two:
+        '—HOLOCAT: „Moment mal, du kannst Laszlo deine Unterschrift für diese Transaktion nicht geben! Wenn du das nächste Mal eine Zahlung tätigst, gibst du ihm den Widerrufsschlüssel revocation_you_2. Dann hat er alles, was er braucht, um alle 100.000 Satoshis zu stehlen!“',
+      paragraph_three:
+        'Jetzt wird es etwas komplizierter. Laszlo braucht etwas, bevor er Ihnen ein Bier geben kann und sicher sein kann, dass er dafür bezahlt wird. Aber er kann Ihre Transaktion nicht haben, weil er dann auf Ihr gesamtes Geld zugreifen würde! Laszlo ist ein toller Typ und seine Bar ist eine der besten der Stadt, aber es wäre trotzdem schön, wenn wir ihm nicht vertrauen müssten.',
+    },
+    making_a_payment_five: {
+      title: 'Asymmetrie',
+      nav_title: 'Asymmetrie',
+      heading_one: 'Asymmetrie',
+      paragraph_one:
+        'Wir wissen also, dass Laszlo die erste Transaktion unterzeichnen soll, aber wir wollen nicht, dass er unsere Unterschrift darunter hat. Wir müssen eine zweite Transaktion für ihn erstellen, die zwar unsere Unterschrift trägt, aber ohne dass die Möglichkeit besteht, dass er das ganze Geld ungerechterweise ausgibt.',
+      paragraph_two:
+        'Und wenn Laszlo seine eigene Verpflichtungstransaktion haben soll, wollen wir dann nicht auch, dass diese Transaktion widerruflich ist?! Tatsächlich wird Laszlos Verpflichtungstransaktion ein Spiegelbild Ihrer sein. Das widerrufliche Zeitsperrskript verwendet Laszlos ersten Widerrufsschlüssel PUBKEY(revocation_bob_1) und die hohe Rückerstattung geht ohne viel Aufhebens direkt an Sie.',
+      list_one:
+        'Füllen Sie die Beträge und Ausgabeskripts für Laszlos Verpflichtungstransaktion aus',
+      list_two:
+        'Unterschreiben Sie es und senden Sie es an Laszlo, der dann Ihre Verpflichtungstransaktion unterzeichnet und an Sie zurücksendet.',
+      heading_two: 'Hinweise',
+      paragraph_three: 'Ausgabe 0 wird entweder durch Folgendes ausgegeben:',
+      hint_one:
+        'Laszlo, nach 700 Blöcken: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base">SIG(LASZLO) 1 </span>',
+      hint_two:
+        'Sie <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base"> 0 SIG(REVOCATION_LASZLO_1) SIG(SIE) 0 </span>',
+      paragraph_four:
+        'Ausgabe 1 wird von Ihnen ausgegeben: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base"> SIG(SIE) </span>',
+    },
+    making_a_payment_six: {
+      title: 'Schließen Sie die Zahlung ab',
+      nav_title: 'Schließen Sie die Zahlung ab',
+      heading_one: 'Schließen Sie die Zahlung ab',
+      paragraph_one: 'Lassen Sie uns noch einmal kurz zusammenfassen.',
+      list_one: 'Eine 2 von 2 Ausgabe wird auf der Blockchain bestätigt',
+      paragraph_two:
+        'Es gibt mehrere Off-Chain-Transaktionen, die diese Ausgabe ausgeben:',
+      paragraph_three: 'Sie haben diese Transaktionen:',
+      paragraph_four: 'Verpflichtung 1 (Sie):',
+      commitment_one_you: {
+        list_one: 'Eingabe 0: signiert von Laszlo',
+        list_two:
+          'Ausgabe 0: 100000 Satoshis an Sie nach 700 Blöcken oder Laszlo mit Widerruf_Sie_1',
+      },
+      commitment_two_you: {
+        list_one: 'Eingabe 0: signiert von Laszlo',
+        list_two:
+          'Ausgabe 0: 99000 Satoshis an Sie nach 700 Blöcken oder Laszlo mit Widerruf_Sie_2',
+        list_three: 'Ausgabe 1: 1000 Satoshis an Laszlo',
+      },
+      paragraph_five: 'Verpflichtung 2 (Sie):',
+      paragraph_six: 'Laszlo hat diese Transaktion:',
+      paragraph_seven: 'Verpflichtung 2 (Laszlo):',
+      commitment_two_laszlo: {
+        list_one: 'Eingabe 0: von Ihnen signiert',
+        list_two:
+          'Ausgabe 0: 1000 Satoshis an Laszlo nach 700 Blöcken oder Sie mit Widerruf_laszlo_1',
+        list_three: 'Ausgabe 1: 99000 Satoshis für Sie',
+      },
+      paragraph_eight:
+        'Alle drei Transaktionen sind unterzeichnet und gültig, aber Laszlo hat Ihnen noch kein Bier gegeben. Warum nicht? Es bleibt nur noch eines zu tun ...',
+    },
+    making_a_payment_seven: {
+      title: '🍺 Ahhhhhhh, schön.',
+      nav_title: 'Ahhhhhh, schön.',
+      paragraph_one: '🍺 Ahhhhhhh, schön.',
+    },
+    making_a_payment_eight: {
+      title: 'Eine weitere Zahlung tätigen',
+      nav_title: 'Eine weitere Zahlung tätigen',
+      heading_one: 'Eine weitere Zahlung tätigen',
+      paragraph_one:
+        'Die Nacht ist noch jung und Sie fliegen mit Ihrem Budgetcopter noch nicht nach Hause. Haben Sie noch Zeit für ein Bier? Nachdem Sie und Laszlo nun Ihre asymmetrischen Transaktionen und einen Ablauf mit Widerrufsschlüsseln ausgearbeitet haben, lassen Sie uns das Protokoll noch ein paar Mal ausführen.',
+      paragraph_two:
+        'Auf dem Bildschirm werden die beiden Transaktionen angezeigt, die den aktuellen Status darstellen. Sie haben Laszlo 1.000 Satoshis gezahlt. Senden Sie eine weitere Zahlung von 1.000 Satoshis an Laszlo.',
+      list_one: 'Aktualisieren Sie die Beträge und Ausgabeskripte',
+      list_two:
+        'Unterschreiben Sie Laszlos Transaktion und senden Sie sie an ihn',
+      list_three:
+        'Laszlo wird seinen letzten Status widerrufen, indem er Ihnen <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base"> REVOCATION_LASZLO_1 </span> sendet.',
+      list_four:
+        'Senden Sie Ihre Transaktion an Laszlo, damit er sie unterzeichnen kann',
+      list_five:
+        'Sobald Sie Laszlos Unterschrift haben, senden Sie ihm Ihre <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base"> REVOCATION_YOU_1 </span>',
+      paragraph_three: 'Viel Spaß 🍺',
+      heading_two: 'Hinweise',
+      paragraph_four: 'Ausgabe 0 wird entweder durch Folgendes ausgegeben:',
+      hint_one:
+        'Sie, nach 700 Blöcken: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base"> SIG(YOU) 1 </span>',
+      hint_two:
+        'Laszlo: <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base"> 0 SIG(REVOCATION_YOU_3) SIG(LASZLO) 0 </span> ',
+      paragraph_five:
+        'Ausgabe 1 wird von Laszlo <span className="rounded-sm px-1.5 py-1 h-[28px] font-mono bg-[#0000004D] m-0.5 text-base"> SIG(LASZLO) </span> ausgegeben.',
+    },
+    outro_one: {
+      title: 'Andere',
+      nav_title: 'Die ganze Nacht durch',
+      paragraph_one:
+        'Das kannst du die ganze Nacht lang machen! Naja, bis deine 100.000 Satoshis alle an Laszlo geschickt wurden',
+      paragraph_two:
+        'Vergessen Sie nicht, etwas Wasser zu trinken! Es gibt auch Holodogs und Nachos.',
+    },
+    outro_two: {
+      title: 'Andere',
+      nav_title: 'Auf dem Weg nach Hause',
+      paragraph_one:
+        'Nach einem langen und seltsamen Tag bezahlen Sie Ihre Getränke und machen sich auf den Heimweg. Doch als Sie die Tür zu Ihrem 3D-gedruckten Bungalow öffnen, stellen Sie fest: oh Mist! Schon wieder Vanderpoole! Passiert das wirklich oder haben Sie eine Mempool-Margarita zu viel getrunken? Obwohl ihn von allen Seiten eine kleine Gruppe von Holocats flankiert, ist er nicht auf Streit aus.',
+      paragraph_two:
+        '—VANDERPOOLE: „Wir kennen uns nicht wirklich, obwohl, wie mein Großvater immer sagte, die Schicksale von Fremden oft miteinander verflochten sind. Du musst mir zuhören. Bei all dem Satoshi Nakamoto-Zeug habe ich versucht, das Geschäft meiner Familie zu retten. Du kannst dir nicht vorstellen, wie viel uns das Mining bedeutet hat. Ich schätze, ich war nicht bereit für Veränderungen und wollte, dass alles mehr oder weniger so bleibt, wie es ist.“',
+    },
+    outro_three: {
+      title: 'Andere',
+      nav_title: 'Bitcoin-Community',
+      paragraph_one:
+        'Sie fragen, warum ihm der Name Satoshi Nakamoto so viel bedeutet hat.',
+      paragraph_two:
+        '—VANDERPOOLE: „Es ist der einzige Name im Bitcoin-Bereich, der größer ist als Bitrey und Vanderpoole. Jemand, der den Namen Satoshi Nakamoto benutzte, sagte mir einmal, dass Bitcoin vor über einem Jahrhundert weit außerhalb der Kontrolle seines Schöpfers gelandet sei. Deshalb habe ich versucht, mir einen bekannteren Namen zu sichern, um den Namen Vanderpoole zu retten. Sie können den Nervenkitzel, neue Münzen zu prägen, nicht verstehen. Für mich war es damals magisch; für mich ist es heute noch magisch.“',
+      paragraph_three:
+        '—VANDERPOOLE: „Mir ist jetzt klar, dass Bitcoin nicht von den Anführern definiert wird, auch wenn ich Satoshis Urenkel wäre. Es wird von seiner Community definiert. Nicht einmal Satoshi könnte ändern, was aus Bitcoin geworden ist. Das war schon immer das, was Bitcoin großartig gemacht hat und warum die Millionen anderer Münzen, die nach dem Vorbild von Bitcoin geschaffen wurden, nie Bestand hatten.“',
+    },
+    outro_four: {
+      title: 'Andere',
+      nav_title: 'Vanderpooles Schurkerei',
+      paragraph_one:
+        'Vanderpoole nimmt deine Holokatze in die Hand und sie beginnt zu schnurren. Menschen sind kompliziert und niemand weiß das besser als Katzen, ob Holo oder nicht.',
+      paragraph_two:
+        '—HOLOCAT: „Sie sind kein Bösewicht, Mr. Vanderpoole. Aber vielleicht, nur vielleicht, haben Sie sich zu viele Gedanken darüber gemacht.“',
+      paragraph_three: '—VANDERPOOLE: Das ist die Wahrheit.',
+    },
+    outro_five: {
+      title: 'Andere',
+      nav_title: 'Du hast es geschafft!!!',
+      heading_one: 'Du hast es geschafft!!!',
+      paragraph_one:
+        'Wie Satoshi waren Sie ein Niemand, aber Ihre Ideen hatten Wert, also folgten Ihnen die Leute. Satoshi ist weg, aber sein Geist und seine Ideen leben weiter. Bewaffnet mit Ihren neu erworbenen Programmierkenntnissen als Bitcoin-Entwickler, einer gesunden Portion Bescheidenheit und etwas guter altmodischer Beharrlichkeit können Sie diesem eleganten System, das die Welt seit mehr als 100 Jahren unter erlaubnisfreiem, zensurresistentem Geld vereint, einen bleibenden Stempel aufdrücken. Neue Abenteuer erwarten Sie im Code und auf dem offenen Markt der Ideen. Bitcoin überlebt nur, weil Leute wie Sie beitragen, was sie können. Deshalb sind wir alle Satoshi.',
+    },
+    outro_six: {
+      title: 'Mehr als Satoshi retten',
+      nav_title: 'Über die Rettung von Satoshi hinausgehen',
+      heading: 'Bitcoin braucht immer noch Ihre Hilfe …',
+      paragraph_one:
+        'Auch wenn das Jahr 2140 noch weit entfernt scheint, bleibt die Mission von Bitcoin zeitlos: Geld zu schaffen, das fair, offen und ehrlich ist. Um diese Vision zu erreichen, sind jedoch die Anstrengungen aller erforderlich – auch Ihre.',
+      paragraph_two:
+        'Sie haben gezeigt, dass Sie Bitcoin verstehen. Jetzt ist der perfekte Zeitpunkt, dieses Wissen in die Tat umzusetzen, indem Sie zu einer der wichtigsten Technologien aller Zeiten beitragen.',
+      paragraph_three:
+        'Das <Link className="underline" href="https://bitcoindevs.xyz/">Bitcoin Dev Project</Link> ist hier, um zukünftige Generationen von Open-Source-Mitwirkenden anzuleiten. Ein Bitcoin-Held von heute zu werden, ist nur einen Klick entfernt.',
+      paragraph_four: 'Wir sind alle Satoshi.',
+    },
+    resources: {
+      output_zero_sig: 'Ausgabe 0 Signatur',
+      output_one_sig: 'Ausgabe 1 Signatur',
+      sats_distribution:
+        'Denken Sie daran, dass Laszlo nur genug Sats für das Bier erhalten sollte. Außerdem müssen wir einige Sats für die Gebühren zurücklegen, falls unser Kanal geschlossen wird!',
+    },
   },
-
-  ///CHALLENGE PAGE
   challenge_list: {
-    coming_soon: 'Kommt demnächst. Bleib dran.',
+    coming_soon: 'Kommt bald. Bleib dran.',
   },
-
   chapter: {
-    chapter_locked_one: 'Vollende das Kapitel',
-    chapter_locked_two: 'zur Freischaltung.',
-    coming_soon: 'Kommt demnächst. Bleib dran.',
+    chapter_locked_one: 'Kapitel abschließen',
+    chapter_locked_two: 'zum Entsperren.',
+    coming_soon: 'Kommt bald. Bleib dran.',
     description:
-      'Entdecke die Geheimnisse von Satoshi und lerne mehr über das Bitcoin-Netzwerk während der Reise.',
+      'Erkunden Sie die Geheimnisse von Satoshi und erfahren Sie dabei mehr über Bitcoin.',
   },
-
   hero: {
-    title: 'Rette Satoshi',
-    description:
-      'Code dir den Weg durch die Geheimnisse des Bitcoin-Netzwerks.',
+    title: 'Satoshi retten',
+    description: 'Lösen Sie mit Ihrem Code die Geheimnisse von Bitcoin.',
     start_journey: 'Start',
-    tell_more: 'Zeig mir mehr',
+    tell_more: 'Erzähl mir mehr',
   },
-
   footer: {
-    paragraph_one: 'Eine open-source Entwicklung von der Bitcoin Community.',
-    link: 'Sieh dir den Code an',
+    paragraph_one: 'Eine Open-Source-Produktion der Bitcoin-Community.',
+    link: 'Überprüfen Sie den Code',
   },
-
   navbar: {
-    intro: 'Intro',
+    intro: 'Einleitung',
     chapter: 'Kapitel',
     chapter_complete: 'Kapitel abgeschlossen',
     challenge: 'Herausforderung',
-    help_tooltip: 'Brauchst Du Hilfe?',
+    help_tooltip: 'Brauchen Sie Hilfe?',
   },
-
   modal_signin: {
-    heading: 'Anmelden',
-    paragraph_one:
-      'Gib unten Deinen privaten Schlüssel ein, um Dein Konto und Deinen Fortschritt wiederherzustellen.',
-    prompt: 'Gib deinen privaten Schlüssel ein',
-    confirm: 'Anmelden',
-    create_account: 'Du hast noch kein Konto?',
+    heading: 'anmelden',
+    pre_signin_paragraph_one:
+      'Geben Sie unten Ihren privaten Schlüssel ein, um Ihr Konto wiederherzustellen und fortzufahren.',
+    post_signin_paragraph_one:
+      'Schön, dass du zurückkommst, um Satoshi zu retten! Von hier aus kannst du direkt zu deiner letzten Lektion gehen.',
+    prompt: 'Geben Sie Ihren privaten Schlüssel ein',
+    confirm: 'anmelden',
+    create_account: 'Sie haben noch kein Konto?',
+    login: 'Einloggen',
+    welcome_back: 'Willkommen zurück!',
+    progress_redirect: 'Bring mich dorthin, wo ich aufgehört habe',
   },
-
   modal_logout: {
-    heading: 'Du bist angemeldet',
+    heading: 'Sie sind angemeldet',
     paragraph_one:
-      'Deine Sitzung bleibt aktiv, bis Du dich über den Button unten abmeldest.',
+      'Ihre Sitzung bleibt aktiv, bis Sie sich mit der Schaltfläche unten abmelden.',
+    private_key: 'Ihr privater Schlüssel',
     signout: 'Abmelden',
   },
-
   modal_signup: {
-    heading: 'Deinen Fortschritt speichern',
+    heading: 'Speichern Sie Ihren Fortschritt',
     paragraph_one:
-      'Kopiere und speichere einen einfachen Code, um Deinen Fortschritt in diesem Browser zu speichern und zu laden. Wenn Du bereits einen Code hast, lade Deinen Fortschritt hier.',
+      'Kopieren und speichern Sie einen einfachen Code, um Ihren Fortschritt in diesem Browser zu speichern und zu laden. Wenn Sie bereits einen Code haben, laden Sie Ihren Fortschritt hier.',
     subheading_one: 'Wähle einen Avatar',
-    subheading_two: 'Sichere Deinen persönlichen Code',
+    subheading_two: 'Sichern Sie Ihren privaten Schlüssel',
     generate:
-      'Alles bereit? Code kopiert und gesichert? Vergewissere dich, denn wenn Du ihn verlierst, kann er nicht wiederhergestellt werden.',
+      'Alles klar? Code kopiert und gesichert? Das sollten Sie unbedingt tun, denn bei Verlust lässt er sich nicht wiederherstellen.',
     confirm: 'Erledigt',
     acknowledged:
-      'Ich bestätige, dass ich diesen privaten Schlüssel gespeichert habe und weiß, dass ich ihn in Zukunft für Herausforderungen benötigen werde.',
+      'Ich bestätige, dass ich diesen privaten Schlüssel gespeichert habe und weiß, dass ich ihn für zukünftige Herausforderungen benötigen werde.',
   },
-
+  difficulty_selection: {
+    NORMAL:
+      'Aktivieren Sie den Schwermodus, um den Schwierigkeitsgrad der Herausforderungen zu erhöhen.',
+    HARD: 'Deaktivieren Sie den Schwermodus, um den Schwierigkeitsgrad der Herausforderungen zu verringern.',
+  },
+  social: {
+    twitter_share: 'Teilen über X',
+    nostr_share: 'Teilen Sie über unsere',
+    sharing: 'Teilen…',
+    shared: 'Geteilt!',
+    share_error: 'Teilen fehlgeschlagen',
+  },
   disclaimer: {
-    description: `Wir freuen uns, dass Du in diese Welt hinein tauchst. Beachte, dass einige Herausforderungen grundlegende Programmierkenntnisse erfordern (Tipps sind verfügbar). Probiere sie aus und teile uns Deine <Link href="https://docs.google.com/forms/d/e/1FAIpQLSf1xpNqUYJyvYL5IZDnxy78273pkqzfYW2Hf91H4Do4KHgy9g/viewform?usp=sf_link" className="underline">Erfahrungen</Link> mit.`,
+    description:
+      'Wir freuen uns, wenn Sie loslegen. Beachten Sie, dass einige Herausforderungen grundlegende Programmierkenntnisse erfordern (Tipps sind verfügbar). Probieren Sie es aus und teilen Sie uns Ihr <Link href="https://docs.google.com/forms/d/e/1FAIpQLSf1xpNqUYJyvYL5IZDnxy78273pkqzfYW2Hf91H4Do4KHgy9g/viewform?usp=sf_link" className="underline">Feedback</Link> mit.',
   },
-
+  opcode: {
+    run: 'Ausführen des Skripts',
+    reset: 'Zurücksetzen',
+  },
+  status_bar: {
+    begin_message:
+      'Schließen Sie die obige Herausforderung ab, um fortzufahren …',
+    error_message: 'Hm...das stimmt noch nicht ganz...',
+    in_progress_message: 'Sieht bisher gut aus ...',
+    success_message: 'Gut gemacht!',
+    next_step_message:
+      'Sieht gut aus. Fahren wir nun mit dem nächsten Schritt fort.',
+    try_again: 'Versuchen Sie es erneut',
+    next: 'Nächste',
+  },
   hasher: {
-    placeholder: 'Tippe hier...',
-    return_hash:
-      'Nachfolgend siehst du Deine Eingabe umgewandelt in einen Hash',
+    placeholder: 'Hier eingeben...',
+    return_hash: 'Unten sehen Sie Ihre Eingabe in einen Hash umgewandelt',
   },
-
   hashrate: {
     start: 'Start',
     running: 'Läuft',
-    blocks_found: 'Blöcke gefunden',
+    blocks_found: 'Gefundene Blöcke',
     hashrate: 'Hashrate',
-    partial_solutions: 'Teilweise Lösungen',
+    partial_solutions: 'Teillösungen',
   },
-
   runner: {
-    run: 'Starte das Skript',
+    run: 'Ausführen des Skripts',
     running: 'Läuft',
     pause: 'Pause',
     result: 'Ergebnis',
-    evaluation: 'Evaluation',
-    script_output: 'Skript Ausgabe',
-    waiting: 'Warte auf Deinen Input von oben...',
+    computing: 'Computer...',
+    evaluation: 'Auswertung',
+    script_output: 'Skriptausgabe',
+    waiting: 'Warte auf Ihre Eingabe oben ...',
+    poor: 'Dies ist ein gültiger Code, aber nicht ganz das, wonach wir suchen. Versuchen Sie es erneut.',
+    good: 'Gute Arbeit, es ist nicht ganz perfekt, aber immer noch richtig. Arbeiten Sie weiter oder machen Sie weiter, Sie haben die Wahl.',
+    success: 'Tolle Arbeit, Ihr Code sieht großartig aus!',
+    language_tabs: {
+      locked: 'Sprache deaktiviert, da Sie dieses Kapitel in',
+      reset: 'Setzen Sie das Terminal zurück',
+    },
   },
   notfound: {
     first: 'Hmm...wo sind wir?',
-    second: 'Es ist nicht ganz klar wo oder was für ein Ort das ist.',
-    third: 'Wir mögen uns in Raum (und Zeit) verloren haben.',
-    back_safety: 'Zurück Richtung Sicherheit',
+    second: 'Es ist nicht ganz klar, wo oder was dieser Ort ist.',
+    third: 'Wir haben uns möglicherweise im Raum (oder in der Zeit) verloren.',
+    back_safety: 'Zurück in Sicherheit',
   },
   error: {
-    first: 'Etwas ist falsch!',
+    first: 'Irgendwas stimmt nicht!',
     second:
-      'Holokatze hat wohl wieder ein paar Kabel angeknabbert. Böse Katze!',
-    reload: 'Erneut versuchen',
+      'Holocat hat vielleicht wieder an einigen Kabeln gekaut. Böse Katze!',
+    reload: 'Wiederholen',
   },
   help_page: {
-    main_heading: 'Ressourcen zum Lernen',
+    main_heading: 'Lernressourcen',
     main_subheading:
-      'Welche hilfreichen Informationen und Ressourcen können wir für das weitere Lernen zur Verfügung stellen?',
+      'Welche hilfreichen Informationen und Ressourcen können wir für weiteres Lernen bereitstellen?',
     tips_heading: 'Tipps',
     tips_subheading:
-      'Welche spezifischen Tipps können/ wollen wir den Lernenden geben, wenn sie nicht weiterkommen?',
-    spoilers_heading: 'Spoilers',
+      'Welche konkreten Tipps können/wollen wir Lernenden geben, wenn sie nicht weiterkommen?',
+    spoilers_heading: 'Spoiler',
     spoilers_confirm: 'Ja, ich möchte die Lösung sehen',
-    solution_one: 'Lösung für den ersten Teil dieser Aufgabe',
-    solution_two: 'Lösung für den zweiten Teil dieser Aufgabe',
-    solution_three: 'Lösung für den dritten Teil dieser Aufgabe',
-    solution_four: 'Lösung für den vierten Teil dieser Aufgabe',
-    solution_five: 'Lösung für den fünften Teil dieser Aufgabe',
-    solution_six: 'Lösung für den sechsten Teil dieser Aufgabe',
-    solution_seven: 'Lösung für den siebten Teil dieser Aufgabe',
-    solution_eight: 'Lösung für den achten Teil dieser Aufgabe',
-    solution_nine: 'Lösung für den neunten Teil dieser Aufgabe',
-    solution_ten: 'Lösung für den zehnten Teil dieser Aufgabe',
+    pseudo_confirm: 'Ja, ich möchte den Pseudocode sehen',
+    solution: 'Lösung für diese Herausforderung',
+    pseudo_solution: 'Pseudocode-Lösung für diese Herausforderung',
+    solution_one: 'Lösung zum ersten Teil dieser Herausforderung',
+    feedback:
+      'Ihr Feedback ist wertvoll und hilft uns, unsere Arbeit weiter zu verbessern. Bitte geben Sie uns Feedback über <a href="https://docs.google.com/forms/d/e/1FAIpQLSf1xpNqUYJyvYL5IZDnxy78273pkqzfYW2Hf91H4Do4KHgy9g/viewform" target="_blank" rel="noreferrer">diesen Link</a>.',
+    help_suggestion:
+      'Wenn Sie nicht weiterkommen, drücken Sie die Schaltfläche "?" in der oberen rechten Ecke. Sie erhalten hilfreiche Ressourcen und Tipps.',
   },
 }
+
 export default translations


### PR DESCRIPTION
Update German translations: Change 'holocat' to 'Holokatze' in text while preserving 'holocat' in URLs
