### PR TITLE
NIP-05 support: add _ entry

### DIFF
--- a/public/.well-known/nostr.json
+++ b/public/.well-known/nostr.json
@@ -1,5 +1,6 @@
 {
   "names": {
+    "_": "6134ec21da95eebc6c3d733f3824de41c0b38eaf1781fb40a2776b96d3ccdd32",
     "savingsatoshi": "6134ec21da95eebc6c3d733f3824de41c0b38eaf1781fb40a2776b96d3ccdd32"
   }
 }


### PR DESCRIPTION
By adding an entry for `_`, we can use just savingsatoshi.com as the identifier (instead of savingsatoshi@savingsatoshi.com)

NIP-05 documentation: https://github.com/nostr-protocol/nips/blob/master/05.md#showing-just-the-domain-as-an-identifier