### PR TITLE
Deprecate crypto.Hash function in favor of createHash

### DIFF
--- a/content/lessons/chapter-6/hard/put-it-together-3.tsx
+++ b/content/lessons/chapter-6/hard/put-it-together-3.tsx
@@ -158,7 +158,7 @@ console.log('KILL')
       name: 'put-it-together-3-hard',
       args: ['args'],
     },
-    defaultCode: `const {Hash} = require('crypto');
+    defaultCode: `const {createHash} = require('crypto');
 
 ${prevData.data.slice(0, -2)}
   digest(input_index) {

--- a/content/lessons/chapter-6/normal/put-it-together-1.tsx
+++ b/content/lessons/chapter-6/normal/put-it-together-1.tsx
@@ -146,7 +146,7 @@ console.log('KILL')
       name: 'put-it-together-1',
       args: ['args'],
     },
-    defaultCode: `const {Hash} = require('crypto');
+    defaultCode: `const {createHash} = require('crypto');
 
 class Transaction {
   constructor() {

--- a/content/resources/chapter-6/put-it-together-1-normal.tsx
+++ b/content/resources/chapter-6/put-it-together-1-normal.tsx
@@ -22,7 +22,7 @@ const javascriptChallenge = {
   },
   defaultCode: `  digest(input_index) {
     const dsha256 = (data) => {
-      return Hash('sha256').update(Hash('sha256').update(data).digest()).digest();
+      return createHash('sha256').update(createHash('sha256').update(data).digest()).digest();
     };
 
     // Start with an empty 4-byte Buffer

--- a/content/resources/chapter-6/put-it-together-3-hard.tsx
+++ b/content/resources/chapter-6/put-it-together-3-hard.tsx
@@ -22,7 +22,7 @@ const javascriptChallenge = {
   },
   defaultCode: `  digest(input_index) {
     const dsha256 = (data) => {
-      return Hash('sha256').update(Hash('sha256').update(data).digest()).digest();
+      return createHash('sha256').update(createHash('sha256').update(data).digest()).digest();
     };
 
     // Start with an empty 4-byte Buffer


### PR DESCRIPTION
This is a long needed change as `createHash` has been around for a while and `Hash` is ultimately an old method. This PR does not do anything to check node versions only to replace the `Hash` function with `createHash`.

> Need to do more investigation. The solution is to likely fix the answer code, and it might make sense to upgrade NodeJS on our repl containers. Not sure what version it's running right now.

![image](https://github.com/user-attachments/assets/341e2668-2c0d-4919-898a-a93df143851a)

We must uses latest or something, I can't remember


Closes #1261 

[Preview](https://saving-satoshi-git-fork-benalleng-deprecat-6017c5-savingsatoshi.vercel.app/en/chapters/chapter-6/in-out-5?dev=true)