### PR TITLE
Add word break keep-all to topbar to prevent korean text from wrapping

### DIFF
--- a/components/Topbar.tsx
+++ b/components/Topbar.tsx
@@ -95,7 +95,7 @@ export default function Topbar() {
                     ? routes.chaptersUrl
                     : routes.aboutUrl
                 }
-                className="mr-2 text-center font-nunito text-lg text-white text-opacity-75 transition duration-150 ease-in-out hover:text-opacity-100 sm:text-xl"
+                className="mr-2 break-keep text-center font-nunito text-lg text-white text-opacity-75 transition duration-150 ease-in-out hover:text-opacity-100 sm:text-xl"
               >
                 {t(`shared.${item.title}`)}
               </Link>


### PR DESCRIPTION
By using wrod-break: keep-all we can prevent character based languages like korean, japanese, and chinese from wrapping while keeping the wrap behavior on languages where the text is actually 2 words.

Should unblock #1276 
