### PR TITLE
fix: Chapters page error

### DIFF
--- a/content/chapters/chapter-3/index.tsx
+++ b/content/chapters/chapter-3/index.tsx
@@ -31,6 +31,6 @@ export const metadata = {
     'split-1',
     'split-2',
   ],
-  outros: ['tabconf-clue-1', 'outro-1'],
+  outros: ['outro-1'],
   challenges: ['solo-1', 'pool-1', 'coop-1', 'split-1'],
 }

--- a/content/chapters/chapter-4/index.tsx
+++ b/content/chapters/chapter-4/index.tsx
@@ -28,6 +28,6 @@ export const metadata = {
     'address-2',
     'address-3',
   ],
-  outros: ['outro-1'],
+  outros: ['tabconf-clue-1', 'outro-1'],
   challenges: ['public-key-1', 'address-1'],
 }


### PR DESCRIPTION
This fixes the [comment mentioned](https://github.com/saving-satoshi/saving-satoshi/pull/1299#pullrequestreview-3325664861) by @benalleng about errors on the chapters list page, this is due to not adding our tabconf page on the chapters metadata