### PR TITLE
BOSS Challenge 2026 - Call BOSS bot to generate next clue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
 NEXT_PUBLIC_API_ENDPOINT=<url-of-your-locally-running-backend|https://api.savingsatoshi.com>
 NEXT_PUBLIC_WS_ENDPOINT=<url-of-your-locally-running-backend|wss://api.savingsatoshi.com>
+NEXT_PUBLIC_BOSSBOT_API_ENDPOINT=something
+NEXT_PUBLIC_BOSSBOT_AUTH=something
+
+# If running the backend locally, the env vars will look something like this:
+# NEXT_PUBLIC_API_ENDPOINT=http://localhost:8000
+# NEXT_PUBLIC_WS_ENDPOINT=http://localhost:8000

--- a/api/bossbot/generateInvite.ts
+++ b/api/bossbot/generateInvite.ts
@@ -1,0 +1,25 @@
+const BASE_URL = process.env.NEXT_PUBLIC_BOSSBOT_API_ENDPOINT
+const AUTH_TOKEN = process.env.NEXT_PUBLIC_BOSSBOT_AUTH
+
+export default async function generateInvite(privateKey: string) {
+  const body = {
+    key: privateKey,
+  }
+
+  try {
+    const res = await fetch(`${BASE_URL}/generate-invite`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${AUTH_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    })
+
+    return res
+  } catch (errors) {
+    console.error('Error calling BOSS Bot API')
+    console.error(errors)
+    return undefined
+  }
+}

--- a/api/bossbot/index.ts
+++ b/api/bossbot/index.ts
@@ -1,0 +1,1 @@
+export { default as generateInvite } from './generateInvite'

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,3 +1,4 @@
 export * as auth from './auth'
 export * as progress from './progress'
 export * as local from './local'
+export * as bossbot from './bossbot'

--- a/content/lessons/chapter-10/outro-6.tsx
+++ b/content/lessons/chapter-10/outro-6.tsx
@@ -1,9 +1,13 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { useTranslations } from 'hooks'
 import { ChapterIntro } from 'ui'
 import { Button } from 'shared'
 import { useSaveAndReturn } from 'hooks'
+import { useAtom } from 'jotai'
+import { accountAtom } from 'state/state'
+import { generateInvite } from 'api/bossbot'
 
 export const metadata = {
   title: 'chapter_ten.outro_six.title',
@@ -14,6 +18,35 @@ export const metadata = {
 export default function Outro6({ lang }) {
   const saveAndReturn = useSaveAndReturn()
   const t = useTranslations(lang)
+  const [account] = useAtom(accountAtom)
+  const [copied, setCopied] = useState(false)
+
+  const copy = (text) => {
+    navigator.clipboard.writeText(text)
+
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const [xorInvite, setXorInvite] = useState('')
+
+  useEffect(() => {
+    async function callBOSSBot() {
+      if (account) {
+        const res = await generateInvite(account.private_key)
+        if (res && res.status == 200) {
+          const resJson = await res.json()
+          setXorInvite(resJson.data)
+        } else {
+          setXorInvite(
+            'Error generating invite. Please contact the BOSS Challenge administrator.'
+          )
+        }
+      }
+    }
+
+    callBOSSBot()
+  }, [account])
 
   return (
     <ChapterIntro className="my-8" heading={t('chapter_ten.outro_six.heading')}>
@@ -24,6 +57,30 @@ export default function Outro6({ lang }) {
       <p className="mt-8 text-lg md:text-xl">
         {t('chapter_ten.outro_six.paragraph_two')}
       </p>
+
+      <div className="mt-8 bg-[#00000033] px-5 py-1">
+        <p className="mt-3 text-lg md:text-xl">
+          {t('chapter_ten.outro_six.boss_instructions')}
+        </p>
+
+        <p className="mt-8 text-lg md:text-xl">
+          {t('chapter_ten.outro_six.boss_instructions_two')}
+        </p>
+
+        <pre className="mb-5 mt-8 flex flex-col rounded-md border-2 border-dotted border-white/25 p-4">
+          <code className="mb-2 whitespace-pre-wrap break-all text-base">
+            {xorInvite}
+          </code>
+          <Button
+            round
+            size="tiny"
+            style="w-full"
+            onClick={() => copy(xorInvite)}
+          >
+            {copied ? t('shared.copy_acknowledged') : t('shared.copy')}
+          </Button>
+        </pre>
+      </div>
 
       <p className="mt-8 text-lg md:text-xl">
         {t('chapter_ten.outro_six.paragraph_three')}

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -81,3 +81,4 @@ Let us know [in Discord](https://discord.gg/DC8Dys4G3h) or [GitHub](https://gith
 - Thanks to [joinmarket-webui/jam](https://github.com/joinmarket-webui/jam) for much of the work on this very README and their intellectual work on building a robust and accessible contribution method for internationalization.
 
 - Contributors like you that are adding new languages and making Saving Satoshi what it is!
+

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -2552,8 +2552,10 @@ Stack Hint: To spend before the secret is revealed, Vanderpoole uses his signatu
       nav_title: `Moving beyond Saving Satoshi`,
       heading: `Bitcoin still needs your help...`,
       paragraph_one: `Although 2139 may seem distant, Bitcoin's mission remains timeless: to create money that is fair, open, and honest. However, achieving this vision will require everyone's efforts—including yours.`,
-      paragraph_two: `You've shown that you understand bitcoin. Now is the perfect time to turn that knowledge into action by contributing to one of the most important technologies ever.`,
-      paragraph_three: `The <Link className="underline" href="https://bitcoindevs.xyz/">Bitcoin Dev Project</Link> is here to guide future generations of open-source contributors. Becoming a present day bitcoin hero today is just one click away.`,
+      paragraph_two: `Your adventures have demonstrated your willingness to defend bitcoin's fundamental principles, but this is just the start of a longer journey. Now is the perfect time to turn your budding knowledge into action though meaningful contribution`,
+      boss_instructions: `If you were brought to Saving Satoshi by the <Link className="underline" href="https://learning.chaincode.com">₿OSS Challenge</Link>, here's your next clue. Using the same private key you have been playing the game with, perform an XOR operation on this hex-encoded secret message.`,
+      boss_instructions_two: `<span className="italic">Hint: your private key is also in hex format</span>`,
+      paragraph_three: `Ready for more? The <Link className="underline" href="https://bitcoindevs.xyz/">Bitcoin Dev Project</Link> is here to guide future generations of open-source contributors. Becoming a present day bitcoin hero today is just one click away.`,
       paragraph_four: `We are all Satoshi.`,
     },
     tab_data: {


### PR DESCRIPTION
Call the BOSS bot to generate a new clue for the user at the end of the game.

I will need to set the following environment variables/secrets before this goes live. Does this happen in Vercel? Right now the preview link doesn't work because these env vars are not set. I just requested access to the Saving Satoshi Vercel.
- `NEXT_PUBLIC_BOSSBOT_API_ENDPOINT`
- `NEXT_PUBLIC_BOSSBOT_AUTH`

We should merge this by the end of the month so that we can cut a new release and have this go live on December 1. BOSS Challenge announcement is Dec 2 in Mauritius, which is sometime around 2am EST on Dec 2.

Test instructions:
- Go to `/en/chapters/chapter-10/outro-6` [Preview link](https://saving-satoshi-git-fork-satsie-bc-ending-bossbot-savingsatoshi.vercel.app/en/chapters/chapter-10/outro-6?dev=true)
- Verify that you get the clue. XOR the clue with your private key and check that it decrypts.

<img width="1053" height="809" alt="Screenshot from 2025-11-25 23-38-32" src="https://github.com/user-attachments/assets/b76628c4-f842-4413-b3ec-4229f66fa4dc" />


