### PR TITLE
fix(ch10): improve spacing and button sizes in TransactionChallenge

### DIFF
--- a/ui/lesson/TransactionsChallenge/index.tsx
+++ b/ui/lesson/TransactionsChallenge/index.tsx
@@ -456,9 +456,9 @@ const TransactionChallenge: FC<ITransactionProps> = ({
                     (step === 1 &&
                       nextTransactionTab === tabData[0] &&
                       !noSignature)) && (
-                    <div className="flex flex-col gap-4 px-[30px] py-[15px]">
+                    <div className="flex flex-col gap-4 px-6 py-4">
                       <div className="flex flex-col">
-                        <Text>Signatures</Text>
+                        <Text className="mb-2">Signatures</Text>
                         <div className="flex flex-col gap-2 md:flex-row md:gap-10">
                           <div className="flex items-center gap-2.5">
                             <div className="h-[30px] w-[30px]">
@@ -468,7 +468,7 @@ const TransactionChallenge: FC<ITransactionProps> = ({
                             <SignatureButton
                               returnSuccess={success}
                               onClick={handleYouSign}
-                              classes=" max-w-[max-content] rounded-[3px] px-2.5 text-base py-1"
+                              classes=" max-w-[max-content] rounded-[3px] px-4 py-2 text-base"
                               disabled={
                                 signatures.you === 'signed' ||
                                 disableSign ||
@@ -493,7 +493,7 @@ const TransactionChallenge: FC<ITransactionProps> = ({
                                 disabled={true}
                                 returnSuccess={success}
                                 laszloWillNotSign={laszloWillNotSign}
-                                classes=" max-w-[max-content] rounded-[3px] px-2.5 text-base py-1"
+                                classes=" max-w-[max-content] rounded-[3px] px-4 py-2 text-base"
                               >
                                 Sign
                               </SignatureButton>
@@ -503,7 +503,7 @@ const TransactionChallenge: FC<ITransactionProps> = ({
                       </div>
                       {!/^(multisig)$/.test(currentTransactionTab) && (
                         <div className="flex flex-col">
-                          <Text>Options</Text>
+                          <Text className="mb-2">Options</Text>
                           <Tooltip
                             id="broadcast-button"
                             position="bottom"
@@ -515,7 +515,7 @@ const TransactionChallenge: FC<ITransactionProps> = ({
                           >
                             <Button
                               disabled={true}
-                              classes="max-w-[max-content] rounded-[3px] px-2.5 text-base py-1"
+                              classes="max-w-[max-content] rounded-[3px] px-4 py-2 text-base"
                             >
                               Broadcast Transaction
                             </Button>


### PR DESCRIPTION
## Summary

This pull request updates the UI for Chapter 10’s `TransactionsChallenge` to match the expected spacing and button sizing shown in the design references and wireframes.

The previous layout had:
- Too little spacing below the "Signatures" and "Options" section titles.
- Buttons that appeared smaller than intended due to tight `px-2.5 py-1` padding.

Both issues are now corrected with local, targeted changes (no global component modifications).

---

## What was changed

- Increased horizontal and vertical padding for the action buttons (`SignatureButton` and `Button`) within this challenge.
- Added `mb-2` margin to section titles ("Signatures", "Options") to improve vertical spacing.
- Replaced fixed pixel padding (`px-[30px] py-[15px]`) with standard Tailwind spacing (`px-6 py-4`) for consistency.
- Ensured all changes are isolated to:  
  `ui/lesson/TransactionsChallenge/index.tsx`

---

## Screenshots
<img width="375" height="189" alt="image" src="https://github.com/user-attachments/assets/3c7a93e1-88c8-44be-93b2-77e43f241bd5" />


---

## Why this fix is correct

- Matches the spacing and sizing shown in the Chapter 10 wireframes.
- Does not modify global shared components (`Button`, `SignatureButton`), avoiding regressions elsewhere.
- Fully contained and safe for merge.

---

## Related Issue
Fixes: #1213 

---

## Checklist

- [x] Build runs locally without errors  
- [x] Prettier and ESLint pass  
- [x] Only the intended file was modified  
- [x] Design matches the chapter wireframes  
