### PR TITLE
fix: avoid document usage during SSR in public-key-2 lesson

### DIFF
--- a/content/lessons/chapter-4/public-key-2.tsx
+++ b/content/lessons/chapter-4/public-key-2.tsx
@@ -1,8 +1,8 @@
 'use client'
-
+import dynamic from 'next/dynamic'
 import { useMediaQuery, useTranslations } from 'hooks'
 import { HolocatQuestion, TextImage } from 'ui'
-import Lottie from 'react-lottie'
+const Lottie = dynamic<any>(() => import('react-lottie'), { ssr: false })
 import Animation1 from 'public/assets/animations/Animation1.json'
 import focusellipse from 'public/assets/images/focus-ellipse.png'
 import Circle from 'shared/icons/Circle'


### PR DESCRIPTION
## 🐛 Fix: ReferenceError: document is not defined during `yarn build`

### 📝 Summary

This PR resolves a build failure (`ReferenceError: document is not defined`) that occurred during the static prerendering phase of `yarn build`. This error was caused by the `react-lottie` library attempting to access browser-specific APIs (like `document`) when executed on the Next.js server.

The fix ensures that the `Lottie` component, which depends on browser APIs, is only imported and rendered on the client side.

### 🔍 Root Cause

The `Lottie` component was imported statically, forcing it to be executed during the server-side rendering (SSR) or prerendering phase, where the DOM object (`document`) does not exist.

### 🛠️ Changes Implemented

The `react-lottie` library is now imported dynamically using `next/dynamic` with Server-Side Rendering explicitly disabled (`ssr: false`).

The minimal patch changes are:

1.  **Added** `import dynamic from 'next/dynamic'`.
2.  **Replaced** the static import `import Lottie from 'react-lottie'` with:
    ```javascript
    const Lottie = dynamic(() => import('react-lottie'), { ssr: false })
    ```

This ensures the animation library is deferred until the browser environment is available.

### ✅ Testing Steps and Verification

1.  Clone the repository and switch to this branch.
2.  Install dependencies: `yarn install`
3.  Run the production build command: `yarn build`
4.  **Expected result:** The build should complete successfully without encountering the `ReferenceError: document is not defined` error.

#### Successful Build Log (After Fix):

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fcfd4274-9f7d-4303-85c3-cd392a145eb7" />

@satsie , @GBKS  review this PR

Closes #1317 and  #1316 
