### PR TITLE
Fix locale format for Chinese language entry:(zh_cn → zh-CN)

### DIFF
--- a/i18n/config.ts
+++ b/i18n/config.ts
@@ -11,7 +11,7 @@ export const i18n = {
     { locale: 'vi', label: 'Tiếng Việt' },
     { locale: 'ko', label: '한국어' },
     { locale: 'ja', label: '日本語' },
-    { locale: 'zh_cn', label: '中文' }
+    { locale: 'zh-CN', label: '中文' }
   ],
 } as const
 


### PR DESCRIPTION
## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title
- [x] Clean commit history


## Description

While fixing localization and translation issues across multiple locales, an invalid locale identifier was discovered in the i18n configuration. The Chinese locale was defined as zh_cn, which is not a valid BCP-47 language tag. This caused runtime failures in parts of the application that rely on JavaScript’s Intl APIs.

The locale has been corrected to the standards-compliant form zh-CN, ensuring proper internationalization behavior and compatibility with all Intl-based formatting.

## Error

At runtime, the application threw the following error:
`
RangeError: Incorrect locale information provided`


This error occurs when an invalid locale string (such as zh_cn) is passed to Intl internally (e.g., through date, number, or message formatting libraries). Because Intl strictly validates locale identifiers, the invalid format caused the application to crash.

## Resolution

Replaced the invalid locale code zh_cn with the correct, standards-compliant zh-CN

Restored compatibility with Intl APIs

Prevented future runtime errors related to locale parsing
