### PR TITLE
Loss of progress when going back to previous lesson

### DIFF
--- a/api/local/getProgress.ts
+++ b/api/local/getProgress.ts
@@ -1,18 +1,16 @@
-import { defaultProgressState } from 'state/progressState'
 import { CourseProgress } from 'types'
 
-export default async function getProgressLocal(): Promise<CourseProgress> {
+export default async function getProgressLocal(): Promise<CourseProgress | null> {
   try {
     const localStorageProgress = localStorage.getItem('SavingSatoshiProgress')
 
     if (!localStorageProgress) {
-      throw new Error('Could not read progress from LocalStorage')
-    } else {
-      const res = JSON.parse(localStorageProgress)
-      return res
+      return null
     }
+
+    return JSON.parse(localStorageProgress)
   } catch (errors) {
     console.error(errors)
-    return defaultProgressState
+    return null
   }
 }

--- a/api/local/setProgress.ts
+++ b/api/local/setProgress.ts
@@ -2,9 +2,10 @@ import { CourseProgress } from 'types'
 
 export default async function setProgress(progress: CourseProgress) {
   try {
-    localStorage.setItem('SavingSatoshiProgress', JSON.stringify(progress))
+    const serialized = JSON.stringify(progress)
+    localStorage.setItem('SavingSatoshiProgress', serialized)
   } catch (errors) {
-    console.error(errors)
+    console.error('Failed to save progress to localStorage:', errors)
     return undefined
   }
 }

--- a/api/progress/getProgress.ts
+++ b/api/progress/getProgress.ts
@@ -1,8 +1,7 @@
-import { defaultProgressState } from 'state/progressState'
 import { CourseProgress } from 'types'
 import { get } from 'utils'
 
-export default async function getProgress(): Promise<CourseProgress> {
+export default async function getProgress(): Promise<CourseProgress | null> {
   try {
     const res = await get({
       url: '/v1/progress',
@@ -12,6 +11,6 @@ export default async function getProgress(): Promise<CourseProgress> {
     return res.progress_state
   } catch (errors) {
     console.error(errors)
-    return defaultProgressState
+    return null
   }
 }

--- a/api/progress/setProgress.ts
+++ b/api/progress/setProgress.ts
@@ -15,7 +15,7 @@ export default async function setProgress(
 
     return res
   } catch (errors) {
-    console.error(errors)
+    console.error('Failed to save progress to backend:', errors)
     return undefined
   }
 }

--- a/hooks/useProceed.ts
+++ b/hooks/useProceed.ts
@@ -3,14 +3,12 @@
 import { useRouter } from 'next/navigation'
 import { useLocalizedRoutes, usePathData } from 'hooks'
 import useEnvironment from './useEnvironment'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import {
   getLessonKey,
   getNextLessonUsingChapterIdAndLessonName,
   isLessonCompletedUsingId,
   markLessonAsCompleteAtom,
-  nextLessonPathAtom,
-  progressToNextLessonAtom,
   syncedCourseProgressAtom,
 } from 'state/progressState'
 
@@ -19,9 +17,7 @@ export default function useProceed() {
   const router = useRouter()
   const { isDevelopment } = useEnvironment()
   const routes = useLocalizedRoutes()
-  const nextLessonPath = useAtomValue(nextLessonPathAtom)
-  const [courseProgress, setCourseProgress] = useAtom(syncedCourseProgressAtom)
-  const progressToNextLesson = useSetAtom(progressToNextLessonAtom)
+  const courseProgress = useAtomValue(syncedCourseProgressAtom)
   const queryParams = isDevelopment ? '?dev=true' : ''
   const nextLessonUsingCurrentRoute = getNextLessonUsingChapterIdAndLessonName(
     chapterId,
@@ -48,7 +44,7 @@ export default function useProceed() {
         routes.chaptersUrl + nextLessonUsingCurrentRoute?.path + queryParams
       progressToNextLesson()
     }
-    console.log(route, nextLessonUsingCurrentRoute?.path)
+
     router.push(route, { scroll: true })
   }
 

--- a/hooks/useProceed.ts
+++ b/hooks/useProceed.ts
@@ -3,12 +3,14 @@
 import { useRouter } from 'next/navigation'
 import { useLocalizedRoutes, usePathData } from 'hooks'
 import useEnvironment from './useEnvironment'
-import { useAtomValue, useSetAtom } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import {
   getLessonKey,
   getNextLessonUsingChapterIdAndLessonName,
   isLessonCompletedUsingId,
   markLessonAsCompleteAtom,
+  nextLessonPathAtom,
+  progressToNextLessonAtom,
   syncedCourseProgressAtom,
 } from 'state/progressState'
 
@@ -17,7 +19,9 @@ export default function useProceed() {
   const router = useRouter()
   const { isDevelopment } = useEnvironment()
   const routes = useLocalizedRoutes()
-  const courseProgress = useAtomValue(syncedCourseProgressAtom)
+  const nextLessonPath = useAtomValue(nextLessonPathAtom)
+  const [courseProgress, setCourseProgress] = useAtom(syncedCourseProgressAtom)
+  const progressToNextLesson = useSetAtom(progressToNextLessonAtom)
   const queryParams = isDevelopment ? '?dev=true' : ''
   const nextLessonUsingCurrentRoute = getNextLessonUsingChapterIdAndLessonName(
     chapterId,
@@ -44,7 +48,7 @@ export default function useProceed() {
         routes.chaptersUrl + nextLessonUsingCurrentRoute?.path + queryParams
       progressToNextLesson()
     }
-
+    console.log(route, nextLessonUsingCurrentRoute?.path)
     router.push(route, { scroll: true })
   }
 

--- a/state/AuthFunctions.ts
+++ b/state/AuthFunctions.ts
@@ -26,9 +26,9 @@ export const useAuthFunctions = () => {
       const account = await getSession()
       setAccount(account)
 
-      // Load progress for the logged-in account
       const progress = await getProgress()
-      setCourseProgress(mergeProgressState(defaultProgressState, progress))
+      const finalProgress = progress || defaultProgressState
+      setCourseProgress(mergeProgressState(defaultProgressState, finalProgress))
 
       return true
     } catch (ex) {
@@ -43,7 +43,13 @@ export const useAuthFunctions = () => {
     window.location.pathname !== '/' &&
       router.push(routes.chaptersUrl, { scroll: true })
     await logout()
+
+    const progress = localStorage.getItem('SavingSatoshiProgress')
     localStorage.clear()
+    if (progress) {
+      localStorage.setItem('SavingSatoshiProgress', progress)
+    }
+
     setCourseProgress(defaultProgressState)
     setAccount(undefined)
   }

--- a/state/AuthFunctions.ts
+++ b/state/AuthFunctions.ts
@@ -27,8 +27,9 @@ export const useAuthFunctions = () => {
       setAccount(account)
 
       const progress = await getProgress()
-      const finalProgress = progress || defaultProgressState
-      setCourseProgress(mergeProgressState(defaultProgressState, finalProgress))
+      if (progress) {
+        setCourseProgress(mergeProgressState(defaultProgressState, progress))
+      }
 
       return true
     } catch (ex) {

--- a/state/progressState.ts
+++ b/state/progressState.ts
@@ -503,15 +503,16 @@ const combinedProgressAndAccountAtom = atom((get) => {
 })
 
 // Effect atom to sync course progress using atomEffect
-const syncCourseProgressEffectAtom = atomEffect((get, set) => {
+const syncCourseProgressEffectAtom = atomEffect((get) => {
   const { account, courseProgress, isAuthLoading, isProgressLoaded } = get(
     combinedProgressAndAccountAtom
   )
   if (isAuthLoading || !isProgressLoaded) return
+
+  setProgressLocal(courseProgress)
+
   if (account) {
     setProgress(courseProgress)
-  } else {
-    setProgressLocal(courseProgress)
   }
 })
 
@@ -931,18 +932,21 @@ export const loadProgressAtom = atom(null, async (get, set) => {
 
   set(isLoadingProgressAtom, true)
 
-  let progress = defaultProgressState
+  let progress: CourseProgress | null = null
+
   if (account) {
     progress = await getProgress()
   }
 
-  if (!progress || !account) {
+  if (!progress) {
     progress = await getProgressLocal()
   }
 
+  const finalProgress = progress || defaultProgressState
+
   set(
     syncedCourseProgressAtom,
-    mergeProgressState(defaultProgressState, progress)
+    mergeProgressState(defaultProgressState, finalProgress)
   )
   set(isProgressLoadedAtom, true)
   set(isLoadingProgressAtom, false)


### PR DESCRIPTION
This has been a long-standing issue dating back to #1124, appearing in different forms. This PR should close #1347, which describes the current version of the problem.

This  bug happens when a user goes back to a completed lesson and clicked Proceed. The app updated progress when it shouldn’t, causing progress to break. This PR fixes that by only updating progress for unfinished lessons, and keeps user progress untouched.

This will need some more test to confirm