### PR TITLE
fixing Typo in code template

### DIFF
--- a/content/lessons/chapter-5/validate-signature-1.tsx
+++ b/content/lessons/chapter-5/validate-signature-1.tsx
@@ -29,7 +29,7 @@ export default function PublicKey3({ lang }) {
       name: 'encode_message',
       args: ['text'],
     },
-    defaultCode: `const { Hash } = require('crypto');
+    defaultCode: `const crypto = require('crypto');
 // Provided by Vanderpoole
 let text = "I am Vanderpoole and I have control of the private key Satoshi\\n"
 text += "used to sign the first-ever Bitcoin transaction confirmed in block #170.\\n"

--- a/content/lessons/chapter-5/validate-signature-3.tsx
+++ b/content/lessons/chapter-5/validate-signature-3.tsx
@@ -33,7 +33,7 @@ console.log("KILL")
         end: 95,
       },
     ],
-    defaultCode: `const { Hash } = require('crypto')
+    defaultCode: `const crypto = require('crypto')
 const secp256k1 = require('@savingsatoshi/secp256k1js')
 // View the library source code
 // https://github.com/saving-satoshi/secp256k1js/blob/main/secp256k1.js

--- a/content/lessons/chapter-5/verify-signature-2.tsx
+++ b/content/lessons/chapter-5/verify-signature-2.tsx
@@ -44,7 +44,7 @@ console.log("KILL")
       name: 'msg_to_integer',
       args: [],
     },
-    defaultCode: `const {Hash} = require('crypto');
+    defaultCode: `const crypto = require('crypto');
 
 function msg_to_integer(msg) {
   // Given a hex string to sign, convert that string to a Buffer of bytes,


### PR DESCRIPTION
The code uses `const { Hash } = require('crypto');` which is incorrect.   It should use `const crypto = require('crypto');` or   
`{ createHash }` to work in Node.js.

This PR fixes the above mentioned Typo in all these 3 files of chapter 5:
- validate-signature-1
- validate-signature-3 
- verify-signature-2


## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title
- [x] Clean commit history
Closes #1385 