### PR TITLE
Fix: sequence size and column order (chapter-6 & chapter-9)

### DIFF
--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1656,7 +1656,7 @@ const translations = {
             item_one: `The sequence value of the single input being signed`,
             item_two: `sequence`,
             item_three: `int`,
-            item_four: `8`,
+            item_four: `4`,
           },
           row_eight: {
             item_one: `The dSHA256 of all outputs, serialized`,
@@ -2043,8 +2043,8 @@ const translations = {
       table_one: {
         headings: {
           item_one: `Step`,
-          item_two: `Stack`,
-          item_three: `Script Execution`,
+          item_two: `Script Execution`,
+          item_three: `Stack`,
         },
       },
       subheading_one: `Explanation`,

--- a/i18n/locales/fr.ts
+++ b/i18n/locales/fr.ts
@@ -2443,8 +2443,8 @@ const translations = {
       table_one: {
         headings: {
           item_one: 'Step',
-          item_two: 'Stack',
-          item_three: 'Script Execution',
+          item_two: `Script Execution`,
+          item_three: `Stack`,
         },
       },
       subheading_one: 'Explanation',

--- a/i18n/locales/ko.ts
+++ b/i18n/locales/ko.ts
@@ -1645,7 +1645,7 @@ const translations = {
             item_one: `The sequence value of the single input being signed`,
             item_two: `sequence`,
             item_three: `int`,
-            item_four: `8`,
+            item_four: `4`,
           },
           row_eight: {
             item_one: `The dSHA256 of all outputs, serialized`,


### PR DESCRIPTION
Hey, just finished the challenge for BOSS, and wanted to contribute by fixing some issues I encountered while going through

**Wrong sequence size in the serialization table:**  #1392 

![correct value](https://github.com/user-attachments/assets/0386028e-8af2-4aa3-a808-23fdf0349cb3)

**Wrong columns order in table:** #1391

![good order](https://github.com/user-attachments/assets/cb328d29-1f06-495f-826f-e6ab5fc149ce)

Thanks.