### PR TITLE
Fix typo in output comment for derive-message-7.tsx

### DIFF
--- a/content/resources/chapter-5/derive-message-7.tsx
+++ b/content/resources/chapter-5/derive-message-7.tsx
@@ -33,7 +33,7 @@ const javascript = {
   // msg += number of outputs;
   // msg += output #0 value (10 BTC or 1,000,000,000 satoshis);
   // msg += output #0 scriptPubKey (Hal Finney's public key plus OP_CHECKSIG);
-  // msg += outut #1 value (40 BTC or 4,000,000,000 satoshis);
+  // msg += output #1 value (40 BTC or 4,000,000,000 satoshis);
   // msg += output #1 scriptPubKey (Satoshi's own public key again, for change);
   // msg += locktime;
   // SIGHASH type
@@ -65,7 +65,7 @@ const python = {
     # msg += number of outputs
     # msg += output #0 value (10 BTC or 1,000,000,000 satoshis)
     # msg += output #0 scriptPubKey (Hal Finney's public key plus OP_CHECKSIG)
-    # msg += outut #1 value (40 BTC or 4,000,000,000 satoshis)
+    # msg += output #1 value (40 BTC or 4,000,000,000 satoshis)
     # msg += output #1 scriptPubKey (Satoshi's own public key again, for change)
     # msg += locktime
     # SIGHASH type


### PR DESCRIPTION
Fixed type for 'output' in chapter 5 where it said "outut #1 value (40 BTC or 4,000,000,000 satoshis)"
