### PR TITLE
Fixing spoiler hint typo chapter 9 block to secret

### DIFF
--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -2233,7 +2233,7 @@ Stack Hint: To spend before the specified block, you use your signature. After t
       },
       proposal_four: {
         tip: `The preimage will be revealed after an unknown amount of time so no need for using timelocks.`,
-        spoiler: `Script Hint: The script allows spending under two conditions: before the secret has been revealed or after. Before the block, Vanderpoole can spend; after the block, you both can.
+        spoiler: `Script Hint: The script allows spending under two conditions: before the secret has been revealed or after. Before the secret, Vanderpoole can spend; after the secret, you both can.
 
 Stack Hint: To spend before the secret is revealed, Vanderpoole uses his signature. After the secret is revealed, you use your signature, a hash of the secret, and provide a 0 because the script has moved past the unrevealed verification.`,
       },

--- a/i18n/locales/fr.ts
+++ b/i18n/locales/fr.ts
@@ -2693,7 +2693,7 @@ const translations = {
       },
       proposal_four: {
         tip: 'The preimage will be revealed after an unknown amount of time so no need for using timelocks.',
-        spoiler: `Script Hint: The script allows spending under two conditions: before the secret has been revealed or after. Before the block, Vanderpoole can spend; after the block, you both can.
+        spoiler: `Script Hint: The script allows spending under two conditions: before the secret has been revealed or after. Before the secret, Vanderpoole can spend; after the secret, you both can.
   
   Stack Hint: To spend before the secret is revealed, Vanderpoole uses his signature. After the secret is revealed, you use your signature, a hash of the secret, and provide a 0 because the script has moved past the unrevealed verification.`,
       },

--- a/i18n/locales/pt.ts
+++ b/i18n/locales/pt.ts
@@ -2732,8 +2732,7 @@ Dica da pilha: Para gastar antes do bloco especificado, você usa sua assinatura
       },
       proposal_four: {
         tip: 'A pré-imagem será revelada após um período de tempo desconhecido, portanto, não há necessidade de usar relógios de ponto.',
-        spoiler: `Dica de script: O script permite gastar em duas condições: antes ou depois de o segredo ser revelado. Antes do bloqueio, Vanderpoole pode gastar; depois do bloqueio, vocês dois podem.
-
+        spoiler: `Dica de script: O script permite gastar em duas condições: antes ou depois de o segredo ser revelado. Antes do segredo, Vanderpoole pode gastar; depois do segredo, vocês dois podem.
 Dica da pilha: Para gastar antes de o segredo ser revelado, Vanderpoole usa sua assinatura. Depois que o segredo é revelado, você usa sua assinatura, um hash do segredo e fornece um 0 porque o script passou da verificação não revelada.`,
       },
     },


### PR DESCRIPTION
## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title
- [x] Clean commit history

## Fix:
### Fix wording in Proposal Four hint to reference secret-based conditions instead of block.

## Description:
This PR corrects the hint text for Proposal Four in Chapter 9 – Work with an Oracle. The original script hint incorrectly included a reference to “before the block / after the block,” which does not reflect the actual script logic. In Proposal Four,

## Before (Incorrect): chapters/chapter-9/proposal-4
spoiler: Script Hint: The script allows spending under two conditions: before the secret has been revealed or after. Before the **block**, Vanderpoole can spend; after the **block**, you both can. 
- **chapters/chapter-9/proposal-4**
<img width="843" height="228" alt="image" src="https://github.com/user-attachments/assets/c47e8cd1-f24a-4d83-911e-0b0ee5997656" />


## After:
spoiler: Script Hint: The script allows spending under two conditions: before the secret has been revealed or after. Before the **secret**, Vanderpoole can spend; after the **secret**, you both can.



@satsie    Closes #1340 