### PR TITLE
Ch9 clarify instructions and fix table headings all locales

### DIFF
--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -2043,8 +2043,8 @@ const translations = {
       table_one: {
         headings: {
           item_one: `Step`,
-          item_two: `Stack`,
-          item_three: `Script Execution`,
+          item_two: `Script Execution`,
+          item_three: `Stack`,
         },
       },
       subheading_one: `Explanation`,
@@ -2162,7 +2162,8 @@ const translations = {
       heading: `Conditional time locked transaction`,
       paragraph_one: `Wait a minute, that doesn't make sense—you don't want to deal with him forever! The new deal is you get all donations for the next two hours while you are still on TV. The Lil Bits Foundation gets anything that comes in afterwards. You look at the bitcoin block clock on the wall in the studio and agree that block height 6930300 will probably be mined in about two hours.`,
       paragraph_two: `Remember Vanderpoole's public key is PUBKEY(vanderpoole) and yours is PUBKEY(me).`,
-      paragraph_three: `Provide the initial stack to spend from the script.`,
+      paragraph_three: `First, provide the input values (initial stack) needed for you to spend this script.
+In the next step, provide the script that allows Vanderpoole to spend it, and adjust the block height accordingly.`,
       next_step_message: `Looks good! Now lets try with your own signature.`,
     },
     proposal_four: {

--- a/i18n/locales/fr.ts
+++ b/i18n/locales/fr.ts
@@ -2443,8 +2443,8 @@ const translations = {
       table_one: {
         headings: {
           item_one: 'Step',
-          item_two: 'Stack',
-          item_three: 'Script Execution',
+          item_two: 'Script Execution',
+          item_three: 'Stack',
         },
       },
       subheading_one: 'Explanation',
@@ -2611,7 +2611,8 @@ const translations = {
       heading: 'Conditional time locked transaction',
       paragraph_one: `Wait a minute, that doesn't make sense—you don't want to deal with him forever! The new deal is you get all donations for the next two hours while you are still on TV. The Lil Bits Foundation gets anything that comes in afterwards. You look at the bitcoin block block on the wall in the studio and agree that block height 6930300 will probably be mined in about two hours.`,
       paragraph_two: `Remember Vanderpoole's public key is PUBKEY(vanderpoole) and yours is PUBKEY(me).`,
-      paragraph_three: 'Provide the initial stack to spend from the script.',
+      paragraph_three:
+        'First, provide the input values (initial stack) needed for you to spend this script.In the next step, provide the script that allows Vanderpoole to spend it, and adjust the block height accordingly.',
       next_step_message: 'Looks good! Now lets try with your own signature.',
     },
     proposal_four: {

--- a/i18n/locales/ko.ts
+++ b/i18n/locales/ko.ts
@@ -2032,8 +2032,8 @@ const translations = {
       table_one: {
         headings: {
           item_one: `단계`,
-          item_two: `스택 상태`,
-          item_three: `스크립트 실행`,
+          item_two: `스크립트 실행`,
+          item_three: `스택 상태`,
         },
       },
       subheading_one: `설명`,
@@ -2151,7 +2151,8 @@ const translations = {
       heading: `조건부 시간 잠금 트랜잭션`,
       paragraph_one: `잠깐만, 가만히 생각해 보니… 그 사람하고 평생 엮이고 싶진 않습니다! 그래서 새 제안을 합니다: 지금부터 2시간 동안 방송이 나가는 동안 들어오는 기부금은 전부 당신이 받고, 이후에 들어오는 기부금은 Lil Bits 재단이 가져가게 됩니다. 스튜디오 벽에 걸린 블록 타이머를 보니, 블록 높이 6930300쯤이 2시간 후에 생성될 것으로 보입니다. 그걸 기준으로 삼기로 합니다.`,
       paragraph_two: `참고로 반더풀의 공개키는 PUBKEY(vanderpoole)이고, 당신의 공개키는 PUBKEY(me)입니다.`,
-      paragraph_three: `이 조건부 트랜잭션에서 코인을 쓰기 위한 초기 스택을 입력해주세요.`,
+      paragraph_three: `먼저, 이 조건부 트랜잭션에서 당신이 코인을 쓰기 위해 필요한 입력 값(초기 스택)을 입력하세요.
+다음 단계에서는 Vanderpoole이 코인을 쓸 수 있도록 하는 스크립트를 제공하고, 블록 높이를 적절히 조정하세요.`,
       next_step_message: `좋습니다! 이번엔 당신 서명으로도 한 번 해봅시다.`,
     },
     proposal_four: {

--- a/i18n/locales/pt.ts
+++ b/i18n/locales/pt.ts
@@ -2480,8 +2480,8 @@ const translations = {
       table_one: {
         headings: {
           item_one: 'Etapa',
-          item_two: 'Pilha',
-          item_three: 'Execução de scripts',
+          item_two: 'Execução de scripts',
+          item_three: 'Pilha',
         },
       },
       subheading_one: 'Explicação',
@@ -2649,7 +2649,8 @@ const translations = {
       heading: 'Transação condicional com bloqueio de tempo',
       paragraph_one: `Espere um minuto, isso não faz sentido - você não quer lidar com ele para sempre! O novo acordo é que você receberá todas as doações pelas próximas duas horas enquanto ainda estiver na TV. A Lil Bits Foundation fica com tudo o que entrar depois disso. Vocês olham para o bloco de bitcoin na parede do estúdio e concordam que o bloco de altura 6930300 provavelmente será minerado em cerca de duas horas.`,
       paragraph_two: `Lembre-se de que a chave pública de Vanderpoole é PUBKEY(vanderpoole) e a sua é PUBKEY(me).`,
-      paragraph_three: 'Forneça a pilha inicial para gastar com o script.',
+      paragraph_three:
+        'Primeiro, forneça os valores de entrada (pilha inicial) necessários para você gastar este script.Na próxima etapa, forneça o script que permite que Vanderpoole gaste, e ajuste a altura do bloco conforme necessário.',
       next_step_message:
         'Parece bom! Agora vamos tentar com sua própria assinatura.',
     },


### PR DESCRIPTION
## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title
- [x] Clean commit history

## Description

### This PR improves clarity and usability in Chapter 9 by addressing two related issues that could cause confusion for learners.

### 1. Clarified spending instructions

- The assignment text has been reworded to clearly explain the two-step flow: refer  #1383
#### Before
`Provide the initial stack to spend from the script.`
#### After:
```
First, provide the input values (initial stack) required for you to spend this script.
In the next step, provide the script that allows Vanderpoole to spend it, and adjust the block height accordingly.
```
<img width="1366" height="768" alt="Screenshot (182)" src="https://github.com/user-attachments/assets/25b7d326-f3c6-493b-a616-9dc66a517c64" />

**This helps prevent users from getting stuck due to the previously unclear instruction and makes it more obvious when the block height becomes editable.**

### 2. Fixed table heading order:  refer: #1391 

#### Before
```
table_one: {
        headings: {
          item_one: `Step`,
          item_two: `Stack`,
          item_three: `Script Execution`,
        },
      },
```
#### After:
``` 
table_one: {
        headings: {
          item_one: `Step`,
          item_two: `Script Execution`,
          item_three: `Stack`,
        },
      },

```

- The table headings for the script execution walkthrough were corrected to match the English reference:
-Script Execution
-Stack

Previously, these headings were swapped in some locales, which could lead to misunderstanding when reading the step-by-step execution tables.

@benalleng @satsie Please check this out , and can be merged This PR closes #1383 #1391 