### PR TITLE
fix(i18n): Correct Spanish translation errors in es.ts

### DIFF
--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -24,7 +24,7 @@ const translations = {
   about: {
     title: `Info`,
     mobile_title: `De qué se trata`,
-    subtitle: `El año es 2139. Faltan dos semanas para que se extraiga el último bitcoin. Durante meses, un reloj ha hecho tic-tac en el la Plaza Satoshi.`,
+    subtitle: `El año es 2139. Faltan dos semanas para que se extraiga el último bitcoin. Durante meses, un reloj ha hecho tic-tac en la Plaza Satoshi.`,
     intro: `El mundo espera el último bloque. Entonces, de repente, la red se detiene. <br><br>Recibes un holocat (es como cualquier otro e-holograma, pero éste tiene forma de gato) de alguien que usa el nombre de Satoshi Nakamoto. Abres el holocat tocándole la nariz con curiosidad por escuchar lo que tiene que decir...`,
 
     project: {
@@ -130,7 +130,7 @@ const translations = {
       paragraph_one: `Hay otra forma de ocultar mensajes secretos en las transacciones. Bitcoin tiene un tipo especial de código llamado OP_RETURN que permite a los usuarios adjuntar mensajes a las salidas de las transacciones. Veamos si podemos encontrar uno`,
       paragraph_two: `1. Haz clic <Link href="https://blockstream.info/tx/ff9148605a772a51cba39004df5fb042d40515967a3e38ff5294cfd017c452a9?expand" className="underline">aquí</Link> para ver una transacción específica.`,
       paragraph_three: `2. Abre los detalles y busca la parte que es de tipo "OP_RETURN".`,
-      párrafo_cuarto: `3. Ahora encuentra el campo "SCRIPTPUBKEY (ASM)". ¿Ves la parte "OP_RETURN OP_PUSHBYTES_33"? Esto se llama opcodes. En realidad nos interesa lo que viene después de ellos`,
+      paragraph_four: `3. Ahora encuentra el campo "SCRIPTPUBKEY (ASM)". ¿Ves la parte "OP_RETURN OP_PUSHBYTES_33"? Esto se llama opcodes. En realidad nos interesa lo que viene después de ellos`,
       paragraph_five: `4. Copia la larga cadena de números después de "OP_RETURN OP_PUSHBYTES_33" y pégala debajo. `,
       input_challenge_label: `Introduce el tipo de OP_RETURN`,
     },
@@ -260,7 +260,7 @@ const translations = {
       paragraph_one:
         'Para derivar una clave pública a partir de una clave privada, realizamos una operación de curva elíptica repetidamente con el punto generador (descubre por qué). El punto generador es un punto específico en la curva. Su valor es parte del estándar secp256k1 y siempre es el mismo:',
       paragraph_two:
-        'La operación de curva elíptica es similar a la adición y, por lo tanto, su repetición es similar a la multiplicación. Utilizamos el símbolo * para describir el algoritmo (aprende más), donde k es la clave privada y P es la clave pública correspondiente:Mathematical operations on an elliptic curve are similar to addition. Therefore, repetition of those opertaions is similar to multiplication. We use the * symbol to describe the algorithm (learn more), where `k` is the private key and `P` is the corresponding public key:',
+        'La operación de curva elíptica es similar a la adición y, por lo tanto, su repetición es similar a la multiplicación. Utilizamos el símbolo * para describir el algoritmo (aprende más), donde k es la clave privada y P es la clave pública correspondiente:',
       paragraph_three:
         'Completa la función privatekey_to_publickey() de modo que devuelva la clave pública derivada de una clave privada dada.',
     },
@@ -371,13 +371,13 @@ const translations = {
     heading: `Carga tu progreso`,
     paragraph_one: `Introduce tu código personal a continuación para restaurar el progreso de tus capítulos y desafíos, así como tu avatar.`,
     clear: `¿Aún no tienes un código?`,
-    prompt: `Introduzca tu código`,
-    confirm: `Cargar mis progreso`,
+    prompt: `Introduce tu código`,
+    confirm: `Cargar mi progreso`,
     paragraph_two: `Lo siento, ese no es el código correcto para el progreso almacenado en este navegador.`,
     paragraph_three: `¿Aún no tienes código o quieres empezar de nuevo?`,
     quit: `Borra el progreso de guardado.`,
     success: `Progreso cargado`,
-    success_message: `Everything is ready to continue with the chapter`,
+    success_message: `Todo está listo para continuar con el capítulo`,
   },
 
   modal_logout: {
@@ -389,7 +389,7 @@ const translations = {
   modal_signup: {
     heading: `¿Quieres guardar tu progreso?`,
     paragraph_one: `Copia y guarda un sencillo código para guardar y cargar tu progreso en cualquier dispositivo y navegador. Si ya tienes un código, carga tu progreso aquí`,
-    subtítulo_uno: `Elige un avatar`,
+    subheading_one: `Elige un avatar`,
     subheading_two: `Haz una copia de seguridad de tu código personal`,
     paragraph_two: `¿Todo listo? ¿Código copiado y copia de seguridad? Asegúrate de hacerlo, ya que no se puede recuperar si lo pierdes`,
     confirm: `He copiado y hecho una copia de seguridad de mi código`,


### PR DESCRIPTION
## Description
This PR fixes several errors in the Spanish translation file.

## Changes
- Fixed duplicate article "en el la" → "en la" in `about.subtitle`
- Fixed incorrect key name `párrafo_cuatro` → `paragraph_four`
- Removed untranslated English text in `public_key_three.paragraph_two`
- Fixed verb conjugation `Introduzca` → `Introduce` for consistency with informal "tú" usage
- Fixed agreement error `Cargar mis progreso` → `Cargar mi progreso`
- Translated `success_message` from English to Spanish
- Fixed incorrect key name `subtítulo_uno` → `subheading_one`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Translation improvement