### PR TITLE
Fixing text overflow on chapter 5 and 6

### DIFF
--- a/content/lessons/chapter-2/outro-1.tsx
+++ b/content/lessons/chapter-2/outro-1.tsx
@@ -24,21 +24,21 @@ export default function Outro1({ lang }) {
       theme={metadata.secondaryTheme}
       gradientTheme={metadata.gradientTheme}
     >
-      <h1 className="text-5xl font-bold text-white">
+      <h1 className="text-4xl font-bold text-white">
         {t('chapter_two.outro_one.heading')}
       </h1>
-      <p className="mt-4 font-nunito text-2xl text-white">
+      <p className="mt-4 font-nunito text-xl text-white">
         {t('chapter_two.outro_one.paragraph_one')}
       </p>
-      <p className="mt-4 font-nunito text-2xl text-white">
+      <p className="mt-4 font-nunito text-xl text-white">
         {t('chapter_two.outro_one.paragraph_two')}
       </p>
 
-      <p className="mt-4 font-nunito text-2xl text-white">
+      <p className="mt-4 font-nunito text-xl text-white">
         {t('chapter_two.outro_one.paragraph_three')}
       </p>
 
-      <p className="mt-4 font-nunito text-2xl text-white">
+      <p className="mt-4 font-nunito text-xl text-white">
         {t('chapter_two.outro_one.paragraph_four')}
       </p>
     </ChapterEnd>

--- a/content/lessons/chapter-2/outro-1.tsx
+++ b/content/lessons/chapter-2/outro-1.tsx
@@ -24,21 +24,21 @@ export default function Outro1({ lang }) {
       theme={metadata.secondaryTheme}
       gradientTheme={metadata.gradientTheme}
     >
-      <h1 className="text-4xl font-bold text-white">
+      <h1 className="text-2xl sm:text-3xl lg:text-4xl xl:text-4xl font-bold text-white">
         {t('chapter_two.outro_one.heading')}
       </h1>
-      <p className="mt-4 font-nunito text-xl text-white">
+      <p className="mt-4 font-nunito text-base sm:text-lg lg:text-xl text-white">
         {t('chapter_two.outro_one.paragraph_one')}
       </p>
-      <p className="mt-4 font-nunito text-xl text-white">
+      <p className="mt-4 font-nunito text-base sm:text-lg lg:text-xl text-white">
         {t('chapter_two.outro_one.paragraph_two')}
       </p>
 
-      <p className="mt-4 font-nunito text-xl text-white">
+      <p className="mt-4 font-nunito text-base sm:text-lg lg:text-xl text-white">
         {t('chapter_two.outro_one.paragraph_three')}
       </p>
 
-      <p className="mt-4 font-nunito text-xl text-white">
+      <p className="mt-4 font-nunito text-base sm:text-lg lg:text-xl text-white">
         {t('chapter_two.outro_one.paragraph_four')}
       </p>
     </ChapterEnd>

--- a/content/lessons/chapter-5/outro-1.tsx
+++ b/content/lessons/chapter-5/outro-1.tsx
@@ -24,10 +24,10 @@ export default function Outro1({ lang }) {
       theme={metadata.secondaryTheme}
       gradientTheme={metadata.gradientTheme}
     >
-      <h1 className="text-5xl font-bold text-white">
+      <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-white">
         {t('chapter_five.outro_one.heading')}
       </h1>
-      <p className="mt-4 font-nunito text-xl text-white">
+      <p className="mt-4 font-nunito text-lg sm:text-xl lg:text-xl text-white">
         {t('chapter_five.outro_one.paragraph_one')}
       </p>
     </ChapterEnd>

--- a/content/lessons/chapter-5/outro-1.tsx
+++ b/content/lessons/chapter-5/outro-1.tsx
@@ -27,7 +27,7 @@ export default function Outro1({ lang }) {
       <h1 className="text-5xl font-bold text-white">
         {t('chapter_five.outro_one.heading')}
       </h1>
-      <p className="mt-4 font-nunito text-2xl text-white">
+      <p className="mt-4 font-nunito text-xl text-white">
         {t('chapter_five.outro_one.paragraph_one')}
       </p>
     </ChapterEnd>


### PR DESCRIPTION
## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title
- [x] Clean commit history

## Changes:

 **Previously, font sizes were defined using fixed Tailwind classes, which applied the same size across all screen widths. This caused layout and readability issues on different sized screens.  `<h1 className="text-5xl font-bold">`**

**These have now been updated to use responsive Tailwind classes, allowing text to scale appropriately across different screen sizes while preserving the original desktop design.`<h1 className="text-2xl sm:text-3xl lg:text-4xl xl:text-5xl font-bold">` .**

**Similar for Paragraphs**

# Before:
<img width="1366" height="704" alt="Screenshot (65)" src="https://github.com/user-attachments/assets/95b9e28a-e6b1-4a69-8c20-3b31e59f5b77" />


# After:
<img width="1366" height="647" alt="image" src="https://github.com/user-attachments/assets/a75fb7a8-feef-4451-8183-eebe190e71f1" />


# Before:
<img width="1366" height="768" alt="Screenshot (195)" src="https://github.com/user-attachments/assets/daf473b8-99eb-40df-b2e5-221f1fa6ed1d" />


# After:
<img width="1366" height="648" alt="image" src="https://github.com/user-attachments/assets/08d260a7-7b74-476c-a1ee-7cd2aa4265f7" />
