### PR TITLE
fix: window resize causes page refresh and state loss

### DIFF
--- a/ui/lesson/Lesson.tsx
+++ b/ui/lesson/Lesson.tsx
@@ -37,12 +37,15 @@ export default function Lesson({
 
   return (
     <LessonContext.Provider value={context}>
-      {direction === LessonDirection.Horizontal && (
-        <div className="flex grow flex-col md:flex-row">{props.children}</div>
-      )}
-      {direction === LessonDirection.Vertical && (
-        <div className="flex w-full grow flex-col">{props.children}</div>
-      )}
+      <div
+        className={
+          direction === LessonDirection.Horizontal
+            ? 'flex grow flex-col md:flex-row'
+            : 'flex w-full grow flex-col'
+        }
+      >
+        {props.children}
+      </div>
     </LessonContext.Provider>
   )
 }


### PR DESCRIPTION
When resizing the browser window, users would lose progress and the current state would reset, as described in https://github.com/saving-satoshi/saving-satoshi/issues/1338#issue-3733566358 

The issue was that the `Lesson` component rendered two separate `<div>` elements based on screen size. When the window was resized, React unmounted one `<div>` and mounted the other, which reset all child component state.

This was fixed by using a single `<div>` with a conditional className

Closes https://github.com/saving-satoshi/saving-satoshi/issues/1338