### PR TITLE
fix: Chapter 6 in-out-2 long unwrapped address

### DIFF
--- a/content/lessons/chapter-6/in-out-2.tsx
+++ b/content/lessons/chapter-6/in-out-2.tsx
@@ -20,7 +20,7 @@ export default function IntOut2({ lang }) {
         {t('chapter_six.in_out_two.paragraph_one')}
       </p>
       <CodeExample
-        className="mt-4 font-space-mono"
+        className="mt-4 w-full whitespace-pre-wrap break-all font-space-mono"
         code={`bc1qgghq08syehkym52ueu9nl5x8gth23vr8hurv9dyfcmhaqk4lrlgs28epwj`}
         language="shell"
       />


### PR DESCRIPTION
…flow

## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title
- [x] Clean commit history

## To Reproduce
Steps to reproduce the behavior:

1. Open https://savingsatoshi.com/en/chapters/chapter-6/in-out-2
2. Switch the browser to mobile view or open the page on a mobile device
3. Scroll down to the code example containing a long Bitcoin address
4. Observe the layout overflow and incorrect rendering on mobile


## Desktop
N/A (issue does not occur on desktop)

## Smartphone
- **Device:** iPhone 14 Pro Max  
- **OS:** iOS 15  
- **Browser:** Brave,Chrome  
- **Version:** 15.x  

## Fixes an Android/ios viewport overflow (can be seen in the screenshot)

## before:
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/7e5ff876-2d3e-463e-a302-c66d908bc869" />

## After:
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/569f8854-61e3-4c70-a478-2a7f644eb24f" />


@0tuedon 
a small fix, but important, can be merged