### PR TITLE
Fixing confusing hint in put-it-together-2.tsx

### DIFF
--- a/content/lessons/chapter-6/normal/put-it-together-2.tsx
+++ b/content/lessons/chapter-6/normal/put-it-together-2.tsx
@@ -216,7 +216,7 @@ ${combinedCode.slice(0, -2)}
     //   r = x(R) mod n
     //   s = (r * a + m) / k mod n
     //   Extra Bitcoin rule from BIP 146:
-    //     if s > n / 2 then s = n - s mod n
+    //     if s > n / 2 then s = n - s
     //   return (r, s)
     // Hints:
     //   n = the order of the curve secp256k1.ORDER


### PR DESCRIPTION
## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed: Only hint comments were modified.
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title:  This PR is not related to an existing issue.
- [x] Clean commit history: Yes

## Changes made
The hint comment describing the math in this lesson is confusing and can lead to users spending more time on the challenge.

Hint comment:
```Javascript
//   Extra Bitcoin rule from BIP 146:
//     if s > n / 2 then s = n - s mod n
```

Spoiler solution:
```Javascript
    if (s > (secp256k1.ORDER / BigInt(2)))
      s = secp256k1.ORDER - s;
```

BIP 146 Doc: [LOW_S](https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki#:~:text=We%20require%20that%20the%20S%20value%20inside%20ECDSA%20signatures%20is%20at%20most%20the%20curve%20order%20divided%20by%202):
<img width="1027" height="163" alt="image" src="https://github.com/user-attachments/assets/db323fa8-7682-4e88-8d29-84fbff3c05fb" />
