### PR TITLE
Adding confirmation dialog for "Reset Terminal" button

### DIFF
--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -2709,6 +2709,10 @@ Stack Hint: To spend before the secret is revealed, Vanderpoole uses his signatu
     language_tabs: {
       locked: `Language disabled since you've started this chapter in`,
       reset: `Reset the terminal`,
+      reset_confirm_title: `Are you sure?`,
+      reset_confirm_message: `This will erase any code you have written for this exercise.`,
+      reset_confirm_yes: `Yes, reset`,
+      reset_confirm_no: `Cancel`,
     },
   },
   notfound: {

--- a/ui/lesson/ScriptingChallenge/LanguageTabs.tsx
+++ b/ui/lesson/ScriptingChallenge/LanguageTabs.tsx
@@ -1,7 +1,10 @@
 import clsx from 'clsx'
+import { useState } from 'react'
 import { chapters } from 'content'
 import { useLang, usePathData, useTranslations } from 'hooks'
 import Icon from 'shared/Icon'
+import Button from 'shared/Button'
+import Modal from 'components/Modals/Modal'
 import { EditorLanguages, LessonView, PlainEditorLanguages } from 'types'
 import { useLessonContext, Tooltip } from 'ui'
 import { languageMeta } from './config'
@@ -26,6 +29,7 @@ export default function LanguageTabs({
   const t = useTranslations(lang)
   const isActive = activeView === LessonView.Code
   const pathData = usePathData()
+  const [showResetConfirm, setShowResetConfirm] = useState(false)
 
   const handleClick = (value) => {
     onChange(value)
@@ -117,7 +121,10 @@ export default function LanguageTabs({
             className="flex h-full w-full justify-center no-underline"
             content={<span>{t('runner.language_tabs.reset')}</span>}
           >
-            <div className="hover:cursor-pointer" onClick={() => onRefresh()}>
+            <div
+              className="hover:cursor-pointer"
+              onClick={() => setShowResetConfirm(true)}
+            >
               <Icon
                 icon="refresh"
                 className="h-full w-full object-contain p-2.5 text-white text-opacity-40"
@@ -126,6 +133,36 @@ export default function LanguageTabs({
           </Tooltip>
         </div>
       )}
+
+      <Modal
+        active={showResetConfirm}
+        onRequestClose={() => setShowResetConfirm(false)}
+      >
+        <h3 className="mb-2 text-xl font-bold">
+          {t('runner.language_tabs.reset_confirm_title')}
+        </h3>
+        <p className="mb-6 text-white/80">
+          {t('runner.language_tabs.reset_confirm_message')}
+        </p>
+        <div className="flex justify-end gap-3">
+          <Button
+            onClick={() => setShowResetConfirm(false)}
+            style="outline"
+            size="small"
+          >
+            {t('runner.language_tabs.reset_confirm_no')}
+          </Button>
+          <Button
+            onClick={() => {
+              onRefresh?.()
+              setShowResetConfirm(false)
+            }}
+            size="small"
+          >
+            {t('runner.language_tabs.reset_confirm_yes')}
+          </Button>
+        </div>
+      </Modal>
     </div>
   )
 }

--- a/ui/lesson/ScriptingChallenge/LanguageTabs.tsx
+++ b/ui/lesson/ScriptingChallenge/LanguageTabs.tsx
@@ -1,12 +1,13 @@
 import clsx from 'clsx'
 import { useState } from 'react'
-import { chapters } from 'content'
+import { chapters, lessons } from 'content'
 import { useLang, usePathData, useTranslations } from 'hooks'
 import Icon from 'shared/Icon'
 import Button from 'shared/Button'
 import Modal from 'components/Modals/Modal'
 import { EditorLanguages, LessonView, PlainEditorLanguages } from 'types'
 import { useLessonContext, Tooltip } from 'ui'
+import { themeSelector } from 'lib/themeSelector'
 import { languageMeta } from './config'
 
 export default function LanguageTabs({
@@ -30,6 +31,13 @@ export default function LanguageTabs({
   const isActive = activeView === LessonView.Code
   const pathData = usePathData()
   const [showResetConfirm, setShowResetConfirm] = useState(false)
+
+  const theme = themeSelector(
+    lessons,
+    pathData.lessonId,
+    chapters,
+    pathData.chapterId
+  )
 
   const handleClick = (value) => {
     onChange(value)
@@ -137,6 +145,7 @@ export default function LanguageTabs({
       <Modal
         active={showResetConfirm}
         onRequestClose={() => setShowResetConfirm(false)}
+        theme={theme}
       >
         <h3 className="mb-2 text-xl font-bold">
           {t('runner.language_tabs.reset_confirm_title')}


### PR DESCRIPTION
This PR fixes [#1058](https://github.com/saving-satoshi/saving-satoshi/issues/1058)

## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed.
- [x] Title clearly describes the changes.
- [x] Issue is referenced in the PR description (Fixes #1058).
- [x] Commit history is clean.

## Summary
- Added a confirmation dialog before triggering “Reset terminal” so accidental clicks don’t wipe progress.
- Reused the shared `Modal `and `Button` components for consistent styling and accessibility.
- Added the English strings for this dialog; other locales currently fall back to English and still need native translations.

## Note
- Translations for non-English locales are still needed; native speakers are encouraged to add them in follow-up PRs.

