### PR TITLE
Implement Global Toast Notifications for Network and Server Errors (#1421)

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -4,6 +4,7 @@ import AccountModal from 'components/Modals/Account'
 import SignInModal from 'components/Modals/SignIn'
 import SignUpModal from 'components/Modals/SignUp'
 import HelpModal from 'components/Modals/Help'
+import { ToastContainer } from 'components/ToastContainer'
 import { useAtom, useSetAtom } from 'jotai'
 import { useEffect } from 'react'
 import { useAuthFunctions } from 'state/AuthFunctions'
@@ -45,6 +46,7 @@ export default function Layout({ children }: { children?: React.ReactNode }) {
         onClose={() => close(Modal.Account)}
       />
       <HelpModal state={modals[Modal.Help]} onClose={() => close(Modal.Help)} />
+      <ToastContainer />
     </>
   )
 }

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { motion, AnimatePresence } from 'framer-motion'
+import { ToastItem } from 'state/toastState'
+import { clsx } from 'clsx'
+
+interface ToastProps {
+    toast: ToastItem
+    onClose: (id: string) => void
+}
+
+export const Toast = ({ toast, onClose }: ToastProps) => {
+    const isError = toast.type === 'error'
+    const isSuccess = toast.type === 'success'
+
+    return (
+        <motion.div
+            initial={{ opacity: 0, y: 50, scale: 0.3 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.5, transition: { duration: 0.2 } }}
+            layout
+            className={clsx(
+                'relative flex min-w-[300px] max-w-md items-center justify-between gap-4 overflow-hidden rounded-lg border px-4 py-3 shadow-2xl backdrop-blur-md',
+                {
+                    'border-red/50 bg-red/10 text-white': isError,
+                    'border-green/50 bg-green/10 text-white': isSuccess,
+                    'border-white/20 bg-white/5 text-white': !isError && !isSuccess,
+                }
+            )}
+        >
+            <div className="flex items-center gap-3">
+                {isError && (
+                    <svg
+                        className="h-5 w-5 text-red"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                    >
+                        <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                        />
+                    </svg>
+                )}
+                {isSuccess && (
+                    <svg
+                        className="h-5 w-5 text-green"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                    >
+                        <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                        />
+                    </svg>
+                )}
+                <span className="text-sm font-medium tracking-wide">
+                    {toast.message}
+                </span>
+            </div>
+            <button
+                onClick={() => onClose(toast.id)}
+                className="rounded-full p-1 transition-colors hover:bg-white/10"
+            >
+                <svg
+                    className="h-4 w-4 opacity-70"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                >
+                    <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M6 18L18 6M6 6l12 12"
+                    />
+                </svg>
+            </button>
+            {/* Progress bar for auto-dismiss */}
+            {toast.duration && toast.duration > 0 && (
+                <motion.div
+                    initial={{ width: '100%' }}
+                    animate={{ width: 0 }}
+                    transition={{ duration: toast.duration / 1000, ease: 'linear' }}
+                    className={clsx('absolute bottom-0 left-0 h-1', {
+                        'bg-red': isError,
+                        'bg-green': isSuccess,
+                        'bg-white/30': !isError && !isSuccess,
+                    })}
+                />
+            )}
+        </motion.div>
+    )
+}

--- a/components/ToastContainer.tsx
+++ b/components/ToastContainer.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useAtom } from 'jotai'
+import { AnimatePresence } from 'framer-motion'
+import { toastsAtom } from 'state/toastState'
+import { Toast } from './Toast'
+import { useToast } from 'state/ToastFunctions'
+
+export const ToastContainer = () => {
+    const [toasts] = useAtom(toastsAtom)
+    const { remove } = useToast()
+
+    return (
+        <div className="fixed bottom-6 right-6 z-[9999] flex flex-col gap-3">
+            <AnimatePresence mode="popLayout">
+                {toasts.map((toast) => (
+                    <Toast key={toast.id} toast={toast} onClose={remove} />
+                ))}
+            </AnimatePresence>
+        </div>
+    )
+}

--- a/state/ToastFunctions.ts
+++ b/state/ToastFunctions.ts
@@ -1,0 +1,63 @@
+import { useSetAtom } from 'jotai'
+import { toastsAtom, ToastType } from './toastState'
+import { uuid } from 'utils'
+import { store } from './state'
+
+export const toast = {
+    success: (message: string, duration = 5000) => {
+        const id = uuid()
+        store.set(toastsAtom, (prev) => [
+            ...prev,
+            { id, message, type: 'success', duration },
+        ])
+        if (duration > 0) setTimeout(() => toast.remove(id), duration)
+    },
+    error: (message: string, duration = 5000) => {
+        const id = uuid()
+        store.set(toastsAtom, (prev) => [
+            ...prev,
+            { id, message, type: 'error', duration },
+        ])
+        if (duration > 0) setTimeout(() => toast.remove(id), duration)
+    },
+    info: (message: string, duration = 5000) => {
+        const id = uuid()
+        store.set(toastsAtom, (prev) => [
+            ...prev,
+            { id, message, type: 'info', duration },
+        ])
+        if (duration > 0) setTimeout(() => toast.remove(id), duration)
+    },
+    remove: (id: string) => {
+        store.set(toastsAtom, (prev) => prev.filter((t) => t.id !== id))
+    },
+}
+
+export const useToast = () => {
+    const setToasts = useSetAtom(toastsAtom)
+
+    const show = (message: string, type: ToastType = 'info', duration = 5000) => {
+        const id = uuid()
+        setToasts((prev) => [...prev, { id, message, type, duration }])
+
+        if (duration > 0) {
+            setTimeout(() => {
+                remove(id)
+            }, duration)
+        }
+    }
+
+    const remove = (id: string) => {
+        setToasts((prev) => prev.filter((toast) => toast.id !== id))
+    }
+
+    return {
+        success: (message: string, duration?: number) =>
+            show(message, 'success', duration),
+        error: (message: string, duration?: number) =>
+            show(message, 'error', duration),
+        info: (message: string, duration?: number) =>
+            show(message, 'info', duration),
+        remove,
+    }
+}

--- a/state/toastState.ts
+++ b/state/toastState.ts
@@ -1,0 +1,12 @@
+import { atom } from 'jotai'
+
+export type ToastType = 'success' | 'error' | 'info'
+
+export interface ToastItem {
+  id: string
+  type: ToastType
+  message: string
+  duration?: number
+}
+
+export const toastsAtom = atom<ToastItem[]>([])

--- a/utils/fetch.ts
+++ b/utils/fetch.ts
@@ -1,15 +1,32 @@
 import { url } from 'utils'
 import { FetchOptions } from 'types'
 import { SAVING_SATOSHI_TOKEN } from 'config/keys'
+import { toast } from 'state/ToastFunctions'
 
 const defaultHeaders = {
   'Content-Type': 'application/json',
 }
 
-export async function get(options: FetchOptions) {
+function handleErrors(errors: any) {
+  if (Array.isArray(errors)) {
+    errors.forEach((err) => {
+      const message =
+        typeof err === 'string' ? err : err.message || 'An error occurred'
+      toast.error(message)
+    })
+  } else if (typeof errors === 'string') {
+    toast.error(errors)
+  } else if (errors && typeof errors === 'object') {
+    toast.error(errors.message || 'An error occurred')
+  } else {
+    toast.error('An unexpected error occurred')
+  }
+}
+
+async function request(method: string, options: FetchOptions) {
   try {
     const fetchOptions: any = {
-      method: 'GET',
+      method,
       headers: {
         ...defaultHeaders,
         ...options.headers,
@@ -23,83 +40,49 @@ export async function get(options: FetchOptions) {
       }
     }
 
+    if (options.body && method !== 'GET') {
+      fetchOptions.body = JSON.stringify(options.body)
+    }
+
     const res = await fetch(url(options.url), fetchOptions)
+
+    if (!res.ok) {
+      const errorText = await res.text()
+      try {
+        const errorJson = JSON.parse(errorText)
+        handleErrors(errorJson.errors || errorJson.error || res.statusText)
+      } catch {
+        handleErrors(res.statusText || `Server error: ${res.status}`)
+      }
+      return null
+    }
+
     const json = await res.json()
 
     if (json.errors) {
-      throw json.errors
+      handleErrors(json.errors)
+      return null
     }
 
     return json
   } catch (ex) {
+    if (ex instanceof TypeError && ex.message === 'Failed to fetch') {
+      toast.error('Network error: please check your connection')
+    } else {
+      console.error(ex)
+    }
     throw ex
   }
+}
+
+export async function get(options: FetchOptions) {
+  return request('GET', options)
 }
 
 export async function post(options: FetchOptions) {
-  try {
-    const fetchOptions: any = {
-      method: 'POST',
-      headers: {
-        ...defaultHeaders,
-        ...options.headers,
-      },
-    }
-
-    if (options.includeToken) {
-      const token = window.localStorage.getItem(SAVING_SATOSHI_TOKEN)
-      if (token) {
-        fetchOptions.headers['Authorization'] = `Bearer ${token}`
-      }
-    }
-
-    if (options.body) {
-      fetchOptions.body = JSON.stringify(options.body)
-    }
-
-    const res = await fetch(url(options.url), fetchOptions)
-    const json = await res.json()
-
-    if (json.errors) {
-      throw json.errors
-    }
-
-    return json
-  } catch (ex) {
-    throw ex
-  }
+  return request('POST', options)
 }
 
 export async function put(options: FetchOptions) {
-  try {
-    const fetchOptions: any = {
-      method: 'PUT',
-      headers: {
-        ...defaultHeaders,
-        ...options.headers,
-      },
-    }
-
-    if (options.includeToken) {
-      const token = window.localStorage.getItem(SAVING_SATOSHI_TOKEN)
-      if (token) {
-        fetchOptions.headers['Authorization'] = `Bearer ${token}`
-      }
-    }
-
-    if (options.body) {
-      fetchOptions.body = JSON.stringify(options.body)
-    }
-
-    const res = await fetch(url(options.url), fetchOptions)
-    const json = await res.json()
-
-    if (json.errors) {
-      throw json.errors
-    }
-
-    return json
-  } catch (ex) {
-    throw ex
-  }
+  return request('PUT', options)
 }


### PR DESCRIPTION
This PR adds toast notifications to show clear error feedback to users.

Previously, network failures and server errors were either silent or only visible in the console. With this change, users now see immediate feedback when actions like sign-in or saving progress fail.

The toast system covers:

Network connectivity errors

4xx and 5xx API errors

Validation messages returned by the API

Toasts are managed globally, triggered from the fetch utility, and automatically dismiss after a short delay (or can be closed manually).
