### PR TITLE
Fix hard mode redirecting incorrectly after normal chapter completed

### DIFF
--- a/hooks/useProceed.ts
+++ b/hooks/useProceed.ts
@@ -1,13 +1,13 @@
 'use client'
 
-import { useRouter, usePathname } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 import { useLocalizedRoutes, usePathData } from 'hooks'
 import useEnvironment from './useEnvironment'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import {
-  getLessonById,
   getLessonKey,
   getNextLessonUsingChapterIdAndLessonName,
+  isLessonCompletedUsingId,
   markLessonAsCompleteAtom,
   nextLessonPathAtom,
   progressToNextLessonAtom,
@@ -30,14 +30,19 @@ export default function useProceed() {
   )
   const currentLessonId = getLessonKey(chapterId, lessonName)
   const markLessonAsComplete = useSetAtom(markLessonAsCompleteAtom)
-  const currentLesson = getLessonById(currentLessonId, courseProgress)
+  const isCurrentLessonCompleted = currentLessonId
+    ? isLessonCompletedUsingId(currentLessonId, courseProgress)
+    : false
 
   const Proceed = () => {
+    if (!nextLessonUsingCurrentRoute) return
     let route
-    if (!currentLesson?.completed && nextLessonUsingCurrentRoute) {
+    if (!isCurrentLessonCompleted) {
       route =
         routes.chaptersUrl + nextLessonUsingCurrentRoute?.path + queryParams
-      markLessonAsComplete(currentLessonId)
+      if (currentLessonId) {
+        markLessonAsComplete(currentLessonId)
+      }
     } else {
       route =
         routes.chaptersUrl + nextLessonUsingCurrentRoute?.path + queryParams


### PR DESCRIPTION
This PR is an alternate solution to resolve issue #1342. I took a different approach than what was proposed in #1368.

After investigating the bug, I believe I have discovered the root cause. For chapters with difficulty, there are two tracks that share some of the same lessons. If you complete all of chapter 6 in normal mode, all of it's lessons in the normal difficulty will be marked as completed. Now if you try to start the hard track, you would be allowed to view the first intro page, but when you clicked continue you'd be redirected to chapter 7.

The real bug is when you click **Continue** on Chapter 6 Intro 1, the app **fails to mark `CH6INT1` complete in the HARD track** before navigating to Intro 2.

That happened because `useProceed()` was checking whether the current lesson was completed like this:

- It called `getLessonById('CH6INT1', courseProgress)`
- But for difficulty chapters, `getLessonById` searches **all difficulties** and returns the **first** matching lesson ID.
- Since `CH6INT1` exists in both NORMAL and HARD and NORMAL comes first, it was “seeing” the **NORMAL** `CH6INT1` (already completed), and therefore skipping `markLessonAsComplete()` and calling `progressToNextLesson()` instead.
- Then Intro 2 loads, `isLessonUnlockedUsingId` checks HARD lessons, sees `CH6INT1` still incomplete → Intro 2 is locked → the page guard redirects you to `currentLessonComputedAtom` (which, since chapter 6 is marked `completed: true`, becomes Chapter 7).

To fix this, I updated the `useProceed` hook to handle the difficulty tracks correctly. I changed the completion check to use `isLessonCompletedUsingId(currentLessonId, courseProgress)` (which uses `selectedDifficulty`), so Intro 1 HARD gets marked complete and Intro 2 becomes unlocked. You will no longer be redirected to chapter 7.
