### PR TITLE
Fix incorrect crypto module import

### DIFF
--- a/content/lessons/chapter-5/validate-signature-1.tsx
+++ b/content/lessons/chapter-5/validate-signature-1.tsx
@@ -29,7 +29,7 @@ export default function PublicKey3({ lang }) {
       name: 'encode_message',
       args: ['text'],
     },
-    defaultCode: `const { Hash } = require('crypto');
+    defaultCode: `const { createHash } = require('crypto');
 // Provided by Vanderpoole
 let text = "I am Vanderpoole and I have control of the private key Satoshi\\n"
 text += "used to sign the first-ever Bitcoin transaction confirmed in block #170.\\n"

--- a/content/lessons/chapter-5/validate-signature-3.tsx
+++ b/content/lessons/chapter-5/validate-signature-3.tsx
@@ -33,7 +33,7 @@ console.log("KILL")
         end: 95,
       },
     ],
-    defaultCode: `const { Hash } = require('crypto')
+    defaultCode: `const { createHash } = require('crypto')
 const secp256k1 = require('@savingsatoshi/secp256k1js')
 // View the library source code
 // https://github.com/saving-satoshi/secp256k1js/blob/main/secp256k1.js


### PR DESCRIPTION
## Summary
- Changed `const { Hash } = require('crypto')` to `const { createHash } = require('crypto')` in chapter-5 validate-signature lessons
- `Hash` is not exported by Node.js crypto module - `createHash` is the correct function to use

## Files Changed
- `content/lessons/chapter-5/validate-signature-1.tsx`
- `content/lessons/chapter-5/validate-signature-3.tsx`

## Test plan
- [x] Verified the correct Node.js crypto API usage
- [ ] Test the lesson code snippets work properly

Fixes #1385