### PR TITLE
ch6 put-it-together-2-hard: inherit language from previous lesson

### DIFF
--- a/content/lessons/chapter-6/hard/put-it-together-2.tsx
+++ b/content/lessons/chapter-6/hard/put-it-together-2.tsx
@@ -13,7 +13,7 @@ export const metadata = {
 
 export default function PutItTogetherTwoHard({ lang }) {
   const t = useTranslations(lang)
-  const { isLoading, detectedLanguage } = usePrevLessonLanguage('CH6INO4')
+  const { isLoading, detectedLanguage } = usePrevLessonLanguage('CH6PUT1_HARD')
   const defaultLanguage = getLanguageString(detectedLanguage)
   const javascript = {
     program: `//BEGIN VALIDATION BLOCK


### PR DESCRIPTION
### Background

This is a follow up to [my review comment in #1416 ](https://github.com/saving-satoshi/saving-satoshi/pull/1416/changes#r2670566264)

### Why this change?

I strongly feel `usePreviousLessonLanguage()` should be looking at the most recent exercise to figure out what language to default the current exercise to. For put-it-together-2-hard (`CH6PUT2_HARD`) that would be put-it-together-1-hard (`CH6PUT1_HARD`). 

While it should never happen because we don't allow users to switch languages midway through the chapter, if there was a bug that caused the user to switch languages (like https://github.com/saving-satoshi/saving-satoshi/issues/1380 !), we would have an edge case where the language switch would not be picked up in put-it-together-2. This is arguably not a bad thing but the behavior would be inconsistent and thus more difficult to diagnose.

### What's wrong with how it was?

I don't see a strong case for setting this value to `CH6INO4` because:

- The default, preloaded code does not come from a previously submitted solution, nevermind the previously submitted solution for `CH6INO4`
- If a user is playing hard mode they never encounter `CH6INO4`, they instead play through `CH6INO4_HARD`

I think `CH6INO4` may have been here because it was leftover from before hard mode was introduced to Chapter 6. It  could have been a situation where the normal mode lesson file was copied and this value was never updated. If it's helpful I have all the challenges for Chapter 6 [mapped out here](https://github.com/saving-satoshi/saving-satoshi/issues/1074) (both normal and hard mode).

While it seems trivial to open a PR for this I just know I would be that person in the future that gets completely thrown off by seeing `CH6INO4` in this file when it has nothing to do with the lesson.

### Testing

To test I played https://saving-satoshi-pi8ehiuka-savingsatoshi.vercel.app/en/chapters/chapter-6/put-it-together-1-hard and confirmed that Python was still my default language for the next lesson.