### PR TITLE
Fix incorrect wording on CH6 Prepare the message

### DIFF
--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -924,7 +924,7 @@ const translations = {
         pre_link: `Then we will`,
         highlighted: `double SHA-256 hash`,
         question: `Why do we double hash in bitcoin?`,
-        post_link: `that blob of data, and convert that hash into an integer. Complete the function <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">encode_message()</span>. It should return a 32-byte hex value.`,
+        post_link: `that blob of data. Complete the function <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">encode_message()</span>. It should return a 32-byte hex value.`,
       },
       success: `Nicely Done`,
     },

--- a/i18n/locales/fr.ts
+++ b/i18n/locales/fr.ts
@@ -1145,7 +1145,7 @@ const translations = {
         highlighted: 'double SHA-256 hash',
         question: 'Why do we double hash in bitcoin?',
         post_link:
-          'that blob of data, and convert that hash into an integer. Complete the function <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">encode_message()</span>. It should return a 32-byte hex value.',
+          'that blob of data. Complete the function <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">encode_message()</span>. It should return a 32-byte hex value.',
       },
       success: 'Nicely Done',
     },


### PR DESCRIPTION
Closes #1418 

On `/chapter-5/validate-signature-1`, the copy below is not accurate. 
> Then we will double SHA-256 hash that blob of data, and convert that hash into an integer. Complete the function encode_message(). It should return a 32-byte hex value.

I have updated it to remove the portion about converting to an integer because that is not necessary.
> Then we will double SHA-256 hash that blob of data. Complete the function encode_message(). It should return a 32-byte hex value.

<img width="1441" height="708" alt="image" src="https://github.com/user-attachments/assets/d5b3bf97-e709-45cb-a645-aa2a3d0ab621" />


## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title
- [x] Clean commit history
