### PR TITLE
Fix misleading instructions on CH4 - Get a P2WPKH address

### DIFF
--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -685,7 +685,7 @@ const translations = {
       title: `Address`,
       nav_title: `Get a P2WPKH address`,
       paragraph_one: `There are multiple types of bitcoin addresses. In the previous exercise, we created a 20-byte compressed public key hash. Now, we would like to encode that hash into a Pay-to-Witness-Public-Key-Hash (p2wpkh) address on the Testnet network.`,
-      paragraph_two: `First we need to append a witness version number of '0' to the hash. These resulting 21 bytes are known as the <span className="font-bold">witness program</span>.`,
+      paragraph_two: `First, note that for a p2wpkh address the witness version is '0', and the witness program is the 20-byte public key hash from the previous step.`,
       paragraph_three: `Then, the witness program is encoded into a human-friendly format called <Link href="https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#user-content-Specification" target="_blank" className="underline">bech32</Link>. Doing this appends a human-readable prefix and a checksum to the data.`,
       paragraph_four: `The prefix is determined by the network:`,
       table_heading: {
@@ -702,7 +702,7 @@ const translations = {
       },
       paragraph_five: `Since we're making a Testnet address, we will be using the 'tb' prefix.`,
       paragraph_six: `After the data has been encoded to bech32, we are left with a bitcoin address!`,
-      paragraph_seven: `Complete the function to create a bech32 address from a compressed public key hash. Start by making the witness program, then convert the program to an address by using the bech32 library that has already been imported for you.`,
+      paragraph_seven: `Complete the function to create a bech32 address from a compressed public key hash. Use the bech32 library that has already been imported for you, with the 'tb' prefix, witness version 0, and the 20-byte hash.`,
       paragraph_eight: `You may need to dig into the bech32 library and read the code to find the right functions to use:\n`,
       paragraph_eight_javascript: `<Link href="https://github.com/saving-satoshi/bech32js/blob/main/bech32.js" target="_blank" className="underline">JavaScript: @savingsatoshi/bech32js</Link>\n`,
       paragraph_eight_python: `<Link href="https://github.com/saving-satoshi/bech32py/blob/main/bech32py/bech32.py" target="_blank" className="underline">Python: savingsatoshi_bech32py</Link>`,

--- a/i18n/locales/fr.ts
+++ b/i18n/locales/fr.ts
@@ -843,7 +843,7 @@ const translations = {
       paragraph_one:
         'There are multiple types of bitcoin addresses. In the previous exercise, we created a 20-byte compressed public key hash. Now, we would like to encode that hash into a Pay-to-Witness-Public-Key-Hash (p2wpkh) address on the Testnet network.',
       paragraph_two:
-        'First we need to append a witness version number of `0` to the hash. These resulting 21 bytes are known as the <span className="font-bold">witness program</span>.',
+        "First, note that for a p2wpkh address the witness version is '0', and the witness program is the 20-byte public key hash from the previous step.",
       paragraph_three:
         'Then, the witness program is encoded into a human-friendly format called <Link href="https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#user-content-Specification" target="_blank" className="underline">bech32</Link>. Doing this appends a human-readable prefix and a checksum to the data.',
       paragraph_four: 'The prefix is determined by the network:',
@@ -864,7 +864,7 @@ const translations = {
       paragraph_six:
         'After the data has been encoded to bech32, we are left with a bitcoin address!',
       paragraph_seven:
-        'Complete the function to create a bech32 address from a compressed public key hash. Start by making the witness program, then convert the program to an address by using the bech32 library that has already been imported for you.',
+        "Complete the function to create a bech32 address from a compressed public key hash. Use the bech32 library that has already been imported for you, with the 'tb' prefix, witness version 0, and the 20-byte hash.",
       paragraph_eight:
         'You may need to dig into the bech32 library and read the code to find the right functions to use:\n',
       paragraph_eight_javascript:


### PR DESCRIPTION
Closes #1417

On `/chapter-4/address-3`, there are misleading instructions that can be confusing. It makes it seem like the user must append the version before encoding which isn't correct. The `bech32` encoder will do the concatenation for them. They just need to supply the parameters correctly.

I have updated the copy to be a bit more clear about what the user is expected to do.

### Before

<img width="1438" height="1202" alt="image" src="https://github.com/user-attachments/assets/e09a3790-067f-4c97-b3c7-33351a3b63d3" />

### After

<img width="1441" height="1198" alt="image" src="https://github.com/user-attachments/assets/efbe3ece-d4bd-46e8-b042-8479f1b2651c" />

## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title
- [x] Clean commit history
