### PR TITLE
Clarify integer return type in CH5VLS2

### DIFF
--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -940,8 +940,8 @@ const translations = {
       },
       python: {
         paragraph_two: {
-          post_link: `Complete the function <span className=" text-green">decode_sig()</span>.`,
-          return: `It should return a tuple with the (r, s) values.`,
+          post_link: `Complete the function <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">decode_sig()</span>.`,
+          return: `It should return a tuple with the (r, s) values as integers.`,
         },
       },
       success: `Nicely Done`,

--- a/i18n/locales/fr.ts
+++ b/i18n/locales/fr.ts
@@ -1165,8 +1165,9 @@ const translations = {
       python: {
         paragraph_two: {
           post_link:
-            'Complete the function <span className=" text-green">decode_sig()</span>.',
-          return: 'It should return a tuple with the (r, s) values.',
+            'Complete the function <span className="text-green p-1 font-mono bg-[#0000004D] m-0.5 text-sm">decode_sig()</span>.',
+          return:
+            'It should return a tuple with the (r, s) values as integers.',
         },
       },
       success: 'Nicely Done',


### PR DESCRIPTION
Closes #1420 

I have updated the instructions for `/chapter-5/validate-signature-2` with Python selected to clearly state that the return value should be a tuple of integers.

I also fixed the styling of the `decode_sig()` text to match the styling when JS is selected.

## Before

<img width="1476" height="805" alt="image" src="https://github.com/user-attachments/assets/de0c9c0f-41ed-441d-9252-bd3087dfb5b0" />

## After

<img width="1478" height="715" alt="image" src="https://github.com/user-attachments/assets/e11addbd-0eae-4465-a20d-baed897eca25" />

## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title
- [x] Clean commit history
