### PR TITLE
Prevent simple workarounds in CH5VLS4

### DIFF
--- a/content/lessons/chapter-5/validate-signature-4.tsx
+++ b/content/lessons/chapter-5/validate-signature-4.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import { useTranslations } from 'hooks'
 import { useState } from 'react'
+import { useTranslations } from 'hooks'
+import { useAtom } from 'jotai'
+import { getLanguageString } from 'lib/SavedCode'
+import { currentLanguageAtom } from 'state/state'
 import { EditorConfig } from 'types'
 import { LessonInfo, ScriptingChallenge, Text, Title } from 'ui'
-import { getLanguageString } from 'lib/SavedCode'
-import { useAtom } from 'jotai'
-import { currentLanguageAtom } from 'state/state'
 
 export const metadata = {
   title: 'chapter_five.validate_signature_four.title',
@@ -20,7 +20,12 @@ export default function ValidateSignature4({ lang }) {
   const [language, setLanguage] = useState(getLanguageString(currentLanguage))
 
   const javascript = {
-    program: `console.log(verify_keys(keys).toString());
+    program: `const expectedKey = "049d57ded01d3a7652a957cf86fd4c3d2a76e76e83d3c965e1dca45f1ee06630636b8bcbc3df3fbc9669efa2ccd5d7fa5a89fe1c0045684189f01ea915b8a746a6";
+const validKeys = keys.slice(0, 5);
+const invalidKeys = keys.filter((key) => key !== expectedKey).slice(0, 5);
+const baselineResult = verify_keys(validKeys);
+const invalidResult = verify_keys(invalidKeys);
+console.log((baselineResult === expectedKey && (invalidResult === undefined || invalidResult === null)).toString());
 console.log("KILL")
 `,
     defaultFunction: {
@@ -107,17 +112,8 @@ function verify_keys(keys) {
 }
 `,
     validate: async (answer) => {
-      if (
-        answer ===
-        '049d57ded01d3a7652a957cf86fd4c3d2a76e76e83d3c965e1dca45f1ee06630636b8bcbc3df3fbc9669efa2ccd5d7fa5a89fe1c0045684189f01ea915b8a746a6'
-      ) {
-        return [true, t('chapter_five.validate_signature_four.success')]
-      }
       if (answer === 'true') {
-        return [
-          false,
-          'Make sure you are returning the public key Vanderpoole used and not a boolean value',
-        ]
+        return [true, t('chapter_five.validate_signature_four.success')]
       }
       return [false, 'That is not quite right, try again.']
     },
@@ -125,7 +121,12 @@ function verify_keys(keys) {
 
   const python = {
     program: `
-print(verify_keys(keys));
+expected_key = "049d57ded01d3a7652a957cf86fd4c3d2a76e76e83d3c965e1dca45f1ee06630636b8bcbc3df3fbc9669efa2ccd5d7fa5a89fe1c0045684189f01ea915b8a746a6"
+valid_keys = keys[:5]
+invalid_keys = [key for key in keys if key != expected_key]
+baseline_result = verify_keys(valid_keys)
+invalid_result = verify_keys(invalid_keys[:5])
+print(baseline_result == expected_key and invalid_result is None)
 print("KILL")
 `,
     defaultFunction: {
@@ -190,17 +191,8 @@ def verify_keys(keys):
     # YOUR CODE HERE
 `,
     validate: async (answer) => {
-      if (
-        answer ===
-        '049d57ded01d3a7652a957cf86fd4c3d2a76e76e83d3c965e1dca45f1ee06630636b8bcbc3df3fbc9669efa2ccd5d7fa5a89fe1c0045684189f01ea915b8a746a6'
-      ) {
-        return [true, t('chapter_five.validate_signature_four.success')]
-      }
       if (answer === 'True') {
-        return [
-          false,
-          'Make sure you are returning the public key Vanderpoole used and not a boolean value',
-        ]
+        return [true, t('chapter_five.validate_signature_four.success')]
       }
       return [false, 'That is not quite right, try again.']
     },


### PR DESCRIPTION
Closes #1145 

There's a problem in `/chapter-5/validate-signature-4` where the user could simply use `return key[2]` as their solution and it would pass. I tightened the validation so it’s harder to pass with a hardcoded answer while keeping the lesson flow the same. Instead of validating a single run, it now calls `verify_keys` twice for both JavaScript and Python: one with a valid list that should return Vanderpoole’s key, and one with a different list (same length, but without the real key) that should return no match. The validator only passes when both conditions are true, which blocks easy bypasses like always returning the known key or branching on array length.

<img width="1441" height="741" alt="image" src="https://github.com/user-attachments/assets/3a33de2c-e26c-4615-a789-2f93f0842814" />

## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title
- [x] Clean commit history
