### PR TITLE
Improve reset button in CH9 two-step opcode challenges

### DIFF
--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -2163,8 +2163,8 @@ const translations = {
       heading: `Conditional time locked transaction`,
       paragraph_one: `Wait a minute, that doesn't make sense—you don't want to deal with him forever! The new deal is you get all donations for the next two hours while you are still on TV. The Lil Bits Foundation gets anything that comes in afterwards. You look at the bitcoin block clock on the wall in the studio and agree that block height 6930300 will probably be mined in about two hours.`,
       paragraph_two: `Remember Vanderpoole's public key is PUBKEY(vanderpoole) and yours is PUBKEY(me).`,
-      paragraph_three: `Provide the initial stack to spend from the script.`,
-      next_step_message: `Looks good! Now lets try with your own signature.`,
+      paragraph_three: `Provide two initial stacks in sequence: first, enter the stack you would use to spend yourself. After that succeeds, enter Vanderpoole's stack and run again.`,
+      next_step_message: `Nice first spend. Now enter Vanderpoole's stack.`,
     },
     proposal_four: {
       title: `Secret preimage locked transaction`,
@@ -2177,13 +2177,13 @@ const translations = {
         b: ` one second earlier!`,
       },
       paragraph_four: `Remember Vanderpoole's public key is PUBKEY(vanderpoole) and yours is PUBKEY(me).`,
-      paragraph_five: `Provide the initial stack to spend from the script.`,
+      paragraph_five: `Provide two initial stacks in sequence: first Vanderpoole's spending stack, then your stack with the revealed preimage.`,
       tooltip_one: {
         question: `What is a satoshi?`,
         link: `https://chat.bitcoinsearch.xyz/?author=holocat&question=What%2520is%2520a%2520satoshi%253F`,
         highlighted: `satoshi`,
       },
-      next_step_message: `Let's see if we used our signature with the preimage correctly.`,
+      next_step_message: `Great first spend. Now enter your stack with the preimage.`,
     },
     outro_one: {
       title: `Outro`,

--- a/ui/common/StatusBar.tsx
+++ b/ui/common/StatusBar.tsx
@@ -26,6 +26,7 @@ export interface StatusBarType {
   errorMessage?: string
   nextStepMessage?: string
   nextStepButton?: string
+  hideNextStepBtn?: boolean
   tooltipDisabled?: boolean
   full?: boolean
   hints?: boolean | null
@@ -41,6 +42,7 @@ export default function StatusBar({
   inProgressMessage,
   nextStepMessage,
   nextStepButton,
+  hideNextStepBtn,
   tooltipDisabled,
   errorMessage,
   full,
@@ -199,11 +201,13 @@ export default function StatusBar({
             <Button
               onClick={handleSubmit}
               classes={clsx('h-full md:text-2xl', {
-                hidden: !(
-                  getStatus() === Status.Poor ||
-                  getStatus() === Status.Good ||
-                  getStatus() == Status.NextStep
-                ),
+                hidden:
+                  hideNextStepBtn ||
+                  !(
+                    getStatus() === Status.Poor ||
+                    getStatus() === Status.Good ||
+                    getStatus() == Status.NextStep
+                  ),
               })}
             >
               {nextStepButton || t('status_bar.try_again')}

--- a/ui/lesson/OpCodeChallenge/OpRunner.tsx
+++ b/ui/lesson/OpCodeChallenge/OpRunner.tsx
@@ -167,6 +167,8 @@ const OpRunner = ({
   const scrollPosition = useHorizontalScroll(scrollRef)
 
   const [executor, setExecutor] = useState<LanguageExecutor | null>(null)
+  const isWaitingForSecondAnswer =
+    advancedChallenge && step === 2 && lastSuccessState !== 5
 
   const redrawArrows = useCallback(() => {
     if (arrowContainerRef?.current) {
@@ -367,6 +369,7 @@ const OpRunner = ({
   }, [lastSuccessState])
 
   const handleTryAgain = () => {
+    setLastSuccessState(0)
     setSuccess(0)
     setStep(1)
     initialHeight && height && setHeight(height - 1)
@@ -448,6 +451,14 @@ const OpRunner = ({
         >
           <div className="flex w-full flex-row justify-between">
             <p className="font-mono text-[15px] font-bold">Execution stack</p>
+            {isWaitingForSecondAnswer && lastSuccessState !== 1 && (
+              <button
+                onClick={handleTryAgain}
+                className={clsx(btnClassName, 'text-[13px]')}
+              >
+                {t('opcode.reset')}
+              </button>
+            )}
           </div>
           <div
             ref={scrollRef}
@@ -615,6 +626,8 @@ const OpRunner = ({
         handleTryAgain={handleTryAgain}
         handleRun={handleStep}
         success={lastSuccessState}
+        nextStepMessage={nextStepMessage}
+        hideNextStepBtn={isWaitingForSecondAnswer}
       />
     </div>
   )

--- a/ui/lesson/OpCodeChallenge/Runner/index.tsx
+++ b/ui/lesson/OpCodeChallenge/Runner/index.tsx
@@ -13,6 +13,7 @@ import { StatusBarType, SuccessNumbers } from 'ui/common/StatusBar'
 export interface OpCodeRunnerType extends StatusBarType {
   lang: string
   handleRun: () => void
+  hideNextStepBtn?: boolean
 }
 
 export default function OpCodeRunner({
@@ -22,6 +23,7 @@ export default function OpCodeRunner({
   success,
   nextStepMessage,
   errorMessage,
+  hideNextStepBtn,
 }: OpCodeRunnerType) {
   const t = useTranslations(lang)
   const { activeView, setActiveView } = useLessonContext()
@@ -92,6 +94,7 @@ export default function OpCodeRunner({
           hints
           nextStepMessage={nextStepMessage}
           nextStepButton={t('opcode.reset')}
+          hideNextStepBtn={hideNextStepBtn}
         />
       </div>
     </div>


### PR DESCRIPTION
Closes #1382 & #1383

Chapter 9 `proposal-3` and `proposal-4` are two-step OpCode Challenges which contain conditional `OP_IF` scripts. First, the user submits their script and initial stack. If it is correct, they are prompted to provide a second stack and execute the script again. The confusion comes in because on the second step there is a large Reset button when the Next button normally lives. So user's instincts are to click this primary CTA, which discards their step 1 progress.

As suggested in https://github.com/saving-satoshi/saving-satoshi/issues/1383#issuecomment-3728562644, the Figma designs show a more subtle Reset button in the Execution Stack section. 

I have updated the OpCode Challenge components to move the Reset button to match the Figma design. When the user completes step 1, the large primary CTA does not become visible. They must update the Initial Stack field above then click the play button again. If they complete step 2, then the large Next button becomes visible and they can proceed to the next lesson.

I have also updated the instructions on the left panel to be more clear.

I have tested all of the lessons in chapter 9 to ensure that these changes did not break any of the other lessons.

## Screenshots

`/chapters/proposal-3` Step 1 completed

<img width="1439" height="846" alt="image" src="https://github.com/user-attachments/assets/7bbaf8ca-695c-4036-b504-a6dad8c62951" />

`/chapters/proposal-3` Step 2 completed

<img width="1438" height="843" alt="image" src="https://github.com/user-attachments/assets/9f604a44-277d-445c-a14d-f063df7a7812" />

`/chapters/proposal-1` Step 1 completed

<img width="1439" height="1089" alt="image" src="https://github.com/user-attachments/assets/396a6196-b2b1-42fe-b9d4-e134724177ad" />


## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title
- [x] Clean commit history
