### PR TITLE
Use Transaction flags field in CH6PUT3_HARD spoiler

### DIFF
--- a/content/resources/chapter-6/put-it-together-3-hard.tsx
+++ b/content/resources/chapter-6/put-it-together-3-hard.tsx
@@ -133,7 +133,7 @@ const pythonChallenge = {
         # Append the transaction locktime in little endian to the main buffer
         s += pack("<I", self.locktime)
         # Append the sighash flags in little endian to the main buffer
-        s += pack("<I", 1)
+        s += pack("<I", int.from_bytes(self.flags))
 
         # Finally, return the double-SHA256 of the entire main buffer
         return dsha256(s)`,


### PR DESCRIPTION
Closes #1448 

This is a very small change to improve the spoiler code for `/chapter-6/put-it-together-3-hard`.  It currently contains the following:
```
s += pack("<I", 1)
```

As suggested in #1449, it would be better to make use of the `flags` field in the `Transaction` class to avoid hard-coded numbers. I have updated the spoiler code to be:
```py
s += pack("<I", int.from_bytes(self.flags))
```

<img width="1439" height="949" alt="image" src="https://github.com/user-attachments/assets/53697b89-94d9-489e-8915-ef2e196ec28b" />

## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title
- [x] Clean commit history
