### PR TITLE
Fix editor hotkey sending stale code/language

### DIFF
--- a/ui/lesson/ScriptingChallenge/Runner/index.tsx
+++ b/ui/lesson/ScriptingChallenge/Runner/index.tsx
@@ -2,7 +2,7 @@
 
 import clsx from 'clsx'
 import { useMediaQuery, useTranslations } from 'hooks'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import Convert from 'ansi-to-html'
 
 import { Loader } from 'shared'
@@ -109,13 +109,7 @@ export default function Runner({
 
   useDynamicHeight([activeView])
 
-  const handleRunKeyPress = (event) => {
-    if ((event.altKey || event.metaKey) && event.key === 'Enter') {
-      handleRun()
-    }
-  }
-
-  const handleRun = async () => {
+  const handleRun = useCallback(async () => {
     setActiveView(LessonView.Execute)
     hasResult.current = false
     outputBuffer.current = []
@@ -263,7 +257,26 @@ export default function Runner({
       console.error(ex)
       setIsRunning(false)
     }
-  }
+  }, [
+    code,
+    goodMessage,
+    language,
+    onValidate,
+    poorMessage,
+    program,
+    setActiveView,
+    setErrors,
+    t,
+  ])
+
+  const handleRunKeyPress = useCallback(
+    (event: KeyboardEvent) => {
+      if ((event.altKey || event.metaKey) && event.key === 'Enter') {
+        handleRun()
+      }
+    },
+    [handleRun]
+  )
 
   useEffect(() => {
     if (ws) {
@@ -309,7 +322,7 @@ export default function Runner({
     return () => {
       document.removeEventListener('keydown', handleRunKeyPress)
     }
-  }, [])
+  }, [handleRunKeyPress])
 
   return (
     <>


### PR DESCRIPTION
Closes #1462

When a user used the hotkey Alt+Enter (or Opt+Return on Mac) to run scripting challenges, the code or language that is sent to the server would be stale. It always sends `javascript` and the initial code set on page load, even after you've changed the language or code. If you click the "Run the Script" button, then the correct values would be sent to the server.

The root of the problem is that the `handleRunKeyPress` function was registered as a `keydown` event listener inside a `useEffect` with an empty dependency array `[]`. This meant it was only registered once on mount and never updated. Because of JavaScript closures, the handler captured the initial values of `code`, `language`, and `program` from that first render. 

To resolve this, I wrapped `handleRunKeyPress` and `handleRun` in `useCallback` with the appropriate dependencies, and updated the `useEffect` dependency array to `[handleRunKeyPress]`. Now the event listener is re-registered whenever the relevant values change, so Alt+Enter and the "Run the Script" button always behave identically.

### Testing

1. Start the frontend and backend locally
2. Navigate to a challenge (e.g., `/chapters/chapter-8/building-blocks-3`)
3. Switch to the Python tab and enter the correct solution
4. Press Alt+Enter (or Opt+Return on Mac) which should return a success. This previously would return an error.

## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title
- [x] Clean commit history
