### PR TITLE
Fix lottie error in chapter 4 public-key-2

### DIFF
--- a/content/lessons/chapter-4/public-key-2.tsx
+++ b/content/lessons/chapter-4/public-key-2.tsx
@@ -97,6 +97,9 @@ export default function PublicKey2({ lang }) {
                 height={lottieScreen[0]}
                 width={lottieScreen[1]}
                 isStopped={lottiePause}
+                // This empty array is needed to prevent unmount issues causing an
+                // error page to be shown.
+                eventListeners={[]}
               />
               <div
                 className={`${hiddenPoint} relative left-[-97px] top-[-121px] flex items-center justify-center xl:left-[-196px] xl:top-[-246px]`}


### PR DESCRIPTION
Closes #1465

When navigating from `/chapter-4/public-key-2` to `public-key-3`, the Lottie animation component crashes during unmount, showing an error page. Clicking Retry loads the page successfully.

Resolving this took a fair bit of investigation because the cause is a very subtle interaction between `react-lottie` and `next/dynamic`. The root cause is that the `react-lottie` library's `componentWillUnmount` calls `this.deRegisterEvents(this.props.eventListeners)`, which calls `.forEach()` on the `eventListeners` prop. The library defines `defaultProps: { eventListeners: [] }` to protect against this, but `next/dynamic()` wraps the class component in a higher-order component that doesn't propagate the inner component's `defaultProps`. Since we don't pass `eventListeners` explicitly, the prop is `undefined` at unmount time, and `undefined.forEach()` throws a `TypeError`. This is what causes `public-key-2` to display an error every time it unmounts.

To fix this, we now pass `eventListeners={[]}` explicitly to the Lottie component, bypassing the broken `defaultProps` resolution. 

### Testing

1. Navigate to http://localhost:3000/en/chapters/chapter-4/public-key-2
2. Click Continue
3. `public-key-3` loads without an error page

## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title
- [x] Clean commit history
