### PR TITLE
Fix code persistence in ScriptingChallenge

### DIFF
--- a/ui/lesson/ScriptingChallenge/index.tsx
+++ b/ui/lesson/ScriptingChallenge/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import LanguageTabs from './LanguageTabs'
 import Editor from './Editor'
@@ -86,17 +86,35 @@ export default function ScriptingChallenge({
   const [hydrated, setHydrated] = useState(false)
   const [errors, setErrors] = useState<string[]>([])
   const debouncedCode = useDebounce(code, 500)
+  const hasLoaded = useRef(false)
 
+  // Hydrate editor from localStorage before enabling autosave.
   useEffect(() => {
     const savedCode = localStorage.getItem(`${lessonKey}-${language}`)
     if (savedCode) {
       setCode(savedCode)
     }
-  }, [])
+    hasLoaded.current = true
+  }, [lessonKey, language])
 
+  // Autosave to localStorage, gated on hydration to prevent overwriting saved drafts.
   useEffect(() => {
-    localStorage.setItem(`${lessonKey}-${language}`, debouncedCode)
+    if (hasLoaded.current) {
+      localStorage.setItem(`${lessonKey}-${language}`, debouncedCode)
+    }
   }, [debouncedCode, lessonKey, language])
+
+  // Sync local language state when the atom hydrates from localStorage.
+  useEffect(() => {
+    const langStr = getLanguageString(currentLanguage)
+    if (langStr !== language && langStr !== 'unknown') {
+      setLanguage(langStr)
+      const savedCode = localStorage.getItem(`${lessonKey}-${langStr}`)
+      setCode(savedCode || config.languages[langStr].defaultCode?.toString())
+      setHiddenRange(config.languages[langStr].hiddenRange)
+      setConstraints(config.languages[langStr].constraints)
+    }
+  }, [currentLanguage, language, lessonKey, config.languages])
 
   useDynamicHeight()
   const isSmallScreen = useMediaQuery({ width: 767 })


### PR DESCRIPTION
Closes #1467

There is an issue where in-progress code is lost when refreshing the page or navigating to a challenge via Continue/Next. The code is saved to React state (so browser back works) but gets lost from localStorage on remount.

I have found two bugs in the `ScriptingChallenge ` component:

**Bug 1: Autosave overwrites saved drafts on mount.** The autosave effect runs on mount with `debouncedCode` still set to `defaultCode`, writing the starter code to localStorage before the load effect's `setCode` call takes effect.

**Bug 2: Language atom hydration race.** `currentLanguageAtom` uses `atomWithStorage`, which returns JavaScript (the default) on the first render before asynchronously hydrating from localStorage. For Python users, the component reads from the wrong storage key (`CH6INO5-javascript` instead of `CH6INO5-python`), finds nothing, and shows default code. The local `language` state is initialized once via `useState` and never updates when the atom hydrates.

To fix this:

1. I added a `hasLoaded` ref that stalls the autosave effect. It won't write to localStorage until after the initial hydration read completes.
2. I added a sync effect that watches `currentLanguageAtom` and updates local `language` state when the atom hydrates, loading the correct per-language draft.

### Testing

1. Open any scripting challenge (e.g. `chapter-4/public-key-4`), write some code, wait a couple seconds for autosave
2. Refresh the page and confirm draft should be restored
3. Navigate away via chapter menu, then back and confirm draft should be restored
4. Go to the previous lesson (e.g. `public-key-3`), click Continue and confirm the code should be your saved draft
5. Use the editor refresh/reset button and confirm it reverts to starter code
6. Repeat steps 1-4 using Python instead of JavaScript

## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title
- [x] Clean commit history
