### PR TITLE
Fix e2e tests failing on PRs from forked repos

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,10 +2,16 @@ name: E2E Tests
 
 on:
   pull_request:
+  pull_request_target: # Give access to the challenges token for PRs from forks
 
 jobs:
   tests:
     runs-on: ubuntu-latest
+    # Use pull_request for same-repo branches, pull_request_target for forks.
+    # This prevents duplicate runs since both events fire for fork PRs.
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
 
     services:
       postgres:
@@ -22,6 +28,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout challenges repo (private)
         uses: actions/checkout@v4
@@ -29,6 +37,7 @@ jobs:
           repository: saving-satoshi/challenges
           token: ${{ secrets.CHALLENGES_REPO_TOKEN }}
           path: test/e2e/answers
+          persist-credentials: false
 
       - name: Clone backend repo (public)
         run: git clone --depth 1 https://github.com/saving-satoshi/saving-satoshi-backend.git ../saving-satoshi-backend


### PR DESCRIPTION
The E2E workflow was failing for PRs opened from forked repositories (e.g. #1428). GitHub does not expose repository secrets to workflows triggered by `pull_request` events from forks. This is an intentional security sandbox. The result was an immediate failure on the "Checkout challenges repo (private)" step:

```
Error: Input required and not supplied: token
```

This meant any outside contributor submitting a PR would see the E2E job fail before a single test ran.

To fix this, three changes were made:

1. Added the workflow trigger `pull_request_target` in addition to `pull_request`. This runs the workflow in the context of the base repository rather than the fork, so secrets are available. I also added an `if` condition to prevent duplicate runs because both events are fired for PRs opened from forks. Same-repo PRs will only fire the `pull_request` event.
2. Added `ref: ${{ github.event.pull_request.head.sha }}` to the main checkout step. Without this, `pull_request_target` defaults to checking out the base branch instead of the PR's code.
3. Added `persist-credentials: false` to the challenges repo checkout. By default, `actions/checkout` stores the token in `.git/config` as a base64-encoded HTTP header so that subsequent git operations can authenticate. Since the tests only need the files and not push access, there is no reason to keep the credential on disk after the clone completes.

**Security note**

`pull_request_target` is a more privileged trigger and warrants some explanation. The workflow file that executes always comes from the base branch, not the PR. So a fork PR that modifies `e2e.yml` has no effect on what actually runs. The `CHALLENGES_REPO_TOKEN` is not injected into any environment variable, so the Next.js app has no path to it. The only vector would have been reading the token out of `test/e2e/answers/.git/config`, which `persist-credentials: false` closes. With these mitigations in place, there is no realistic path for PR code to access the secret.

## Pull Request checklist

Please review the below PR requirements:

- [ ] Build was run locally and any changes were pushed
- [ ] Ensure that the title clearly describes the changes
- [ ] Issue to be referenced in the PR description rather than in the commits or PR title
- [ ] Clean commit history
