### PR TITLE
fix(copy): update Chapter 8 instructions to return instead of print

### DIFF
--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1907,7 +1907,7 @@ const translations = {
       paragraph_three: `In other words, the miner gets to keep whatever bitcoin that was sent in to the transaction but not sent back out to the transaction recipients.`,
       paragraph_four: `There is a transaction with the txid:`,
       paragraph_five: `in a block with the hash:`,
-      paragraph_six: `Print that transaction's fee in satoshis.`,
+      paragraph_six: `Return that transaction's fee in satoshis.`,
       success: `Nicely Done`,
     },
     building_blocks_six: {

--- a/i18n/locales/fr.ts
+++ b/i18n/locales/fr.ts
@@ -2270,7 +2270,7 @@ const translations = {
       paragraph_three: `In other words, the miner gets to keep whatever bitcoin that was sent in to the transaction but not sent back out to the transaction recipients.`,
       paragraph_four: `There is a transaction with the txid:`,
       paragraph_five: `in a block with the hash:`,
-      paragraph_six: `Print that transaction's fee in satoshis.`,
+      paragraph_six: `Return that transaction's fee in satoshis.`,
       success: `Nicely Done`,
     },
     building_blocks_six: {


### PR DESCRIPTION
**Description:**
This PR addresses the double-printing bug in the Python Chapter 8 "Building blocks" lesson. 

**Changes Made:**
* Updated the copy in the English (`en.ts`) and French (`fr.ts`) locale files.
* Changed the instruction from "Print that transaction's fee..." to "Return that transaction's fee..." so it aligns with the expected test output.

Fixes #1463