### PR TITLE
Add explicit error handling for HTTP error responses that lack `errors` field in their body

### DIFF
--- a/utils/fetch.ts
+++ b/utils/fetch.ts
@@ -28,6 +28,9 @@ export async function get(options: FetchOptions) {
 
     if (json.errors) {
       throw json.errors
+    } else if (res.status >= 400) {
+      const error = { body: json, status: res.status, message: res.statusText }
+      throw error
     }
 
     return json
@@ -62,6 +65,9 @@ export async function post(options: FetchOptions) {
 
     if (json.errors) {
       throw json.errors
+    } else if (res.status >= 400) {
+      const error = { body: json, status: res.status, message: res.statusText }
+      throw error
     }
 
     return json
@@ -96,6 +102,9 @@ export async function put(options: FetchOptions) {
 
     if (json.errors) {
       throw json.errors
+    } else if (res.status >= 400) {
+      const error = { body: json, status: res.status, message: res.statusText }
+      throw error
     }
 
     return json


### PR DESCRIPTION
## Motivation
Currently, the `fetch` utility only throws an error if the response body contains an explicit `errors` field. If the API returns a standard HTTP error (e.g., `401`, `404`, `500`) without that specific field, the failure goes unhandled, potentially leading to silent failures or crashes in the UI.

## Changes
This PR updates the `get`, `post`, and `put` fetch utilities to:
- Check HTTP status codes: Explicitly catch any response where `status >= 400` i.e. error caused by the client- or server- side.
- Standardize error objects: Construct and throw a consistent error object containing the `body`, `status`, and `statusText`.
- Improve reliability: Ensure all API-level failures are properly propagated to the caller even when the response body is malformed or missing the `errors` key.