### PR TITLE
add dismiss, maximize & minimize buttons for error dialog box

### DIFF
--- a/ui/lesson/ScriptingChallenge/Editor.tsx
+++ b/ui/lesson/ScriptingChallenge/Editor.tsx
@@ -23,6 +23,8 @@ export default function Editor({
   hiddenRange,
   loadingSavedCode,
   rangeToNotCollapse = [],
+  terminalVisible = true,
+  terminalHeight = 204,
 }: {
   language: string
   value?: string
@@ -33,6 +35,8 @@ export default function Editor({
   hiddenRange?: number[]
   loadingSavedCode?: boolean
   rangeToNotCollapse?: EditorRange[]
+  terminalVisible?: boolean
+  terminalHeight?: number
 }) {
   const { activeView } = useLessonContext()
   const isActive = activeView === LessonView.Code
@@ -100,12 +104,12 @@ export default function Editor({
   const headerHeight = 70
   const mobileTabsHeight = 48
   const languageTabsHeight = 40
-  const terminalHeight = 204
+  const resolvedTerminalHeight = terminalVisible ? terminalHeight : 0
   const runnerHeight = 56
 
   const totalHeight = isSmallScreen
     ? headerHeight + mobileTabsHeight + languageTabsHeight + runnerHeight
-    : headerHeight + languageTabsHeight + terminalHeight + runnerHeight
+    : headerHeight + languageTabsHeight + resolvedTerminalHeight + runnerHeight
 
   useEffect(() => {
     hiddenRange && setEditorOptions(createMonacoOptions(hiddenRange[2]))

--- a/ui/lesson/ScriptingChallenge/Runner/OutputSection.tsx
+++ b/ui/lesson/ScriptingChallenge/Runner/OutputSection.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import clsx from 'clsx'
+
+import { LessonView } from 'types'
+import { HasherState } from './Hasher'
+import Terminal from './Terminal'
+import { OUTPUT_COPY } from './constants'
+
+function StaticOutputState({
+  title,
+  message,
+}: {
+  title: string
+  message: string
+}) {
+  return (
+    <div className="h-[204px] w-full border-t border-white border-opacity-30 bg-black bg-opacity-20 p-4">
+      <div className="font-mono text-xs text-white">{title}</div>
+      <div className="font-mono text-xs text-white text-opacity-60">
+        {message}
+      </div>
+    </div>
+  )
+}
+
+export default function OutputSection({
+  isOutputCollapsed,
+  isSmallScreen,
+  activeView,
+  hasherState,
+  showIdlePanel,
+  showBuildingPanel,
+  showResultPanel,
+  isErrorState,
+  outputPanelHeight,
+  defaultOutputHeight,
+  isResizingOutput,
+  handleResizeStart,
+  closeOutput,
+  terminalRef,
+}: {
+  isOutputCollapsed: boolean
+  isSmallScreen: boolean
+  activeView: LessonView
+  hasherState: HasherState
+  showIdlePanel: boolean
+  showBuildingPanel: boolean
+  showResultPanel: boolean
+  isErrorState: boolean
+  outputPanelHeight: number
+  defaultOutputHeight: number
+  isResizingOutput: boolean
+  handleResizeStart: (event: React.PointerEvent<HTMLButtonElement>) => void
+  closeOutput: () => void
+  terminalRef: React.RefObject<HTMLIFrameElement | null>
+}) {
+  if (isOutputCollapsed) {
+    return null
+  }
+
+  return (
+    <div
+      className={clsx('w-full shrink-0 flex-col overflow-hidden', {
+        'hidden md:flex md:flex-col':
+          !isSmallScreen ||
+          (activeView !== LessonView.Execute &&
+            hasherState !== HasherState.Running),
+        'flex flex-col':
+          isSmallScreen &&
+          (activeView === LessonView.Execute ||
+            hasherState === HasherState.Running),
+      })}
+    >
+      {showIdlePanel && (
+        <StaticOutputState
+          title={OUTPUT_COPY.idleTitle}
+          message={OUTPUT_COPY.idleMessage}
+        />
+      )}
+
+      {showBuildingPanel && (
+        <StaticOutputState
+          title={OUTPUT_COPY.buildingTitle}
+          message={OUTPUT_COPY.buildingMessage}
+        />
+      )}
+
+      {showResultPanel && (
+        <div
+          className="flex w-full shrink-0 flex-col overflow-hidden"
+          style={{
+            height: isSmallScreen
+              ? `${defaultOutputHeight}px`
+              : `${outputPanelHeight}px`,
+            maxHeight: `${defaultOutputHeight}px`,
+            willChange:
+              !isSmallScreen && isResizingOutput ? 'height' : undefined,
+          }}
+        >
+          {!isSmallScreen && (
+            <button
+              type="button"
+              aria-label="Resize output panel"
+              title="Drag to resize output panel"
+              className="flex h-3 w-full shrink-0 cursor-row-resize touch-none items-center justify-center bg-white/5"
+              onPointerDown={handleResizeStart}
+            >
+              <span
+                className={clsx(
+                  'h-1 w-12 rounded-full bg-white/20 transition',
+                  {
+                    'bg-white/40': isResizingOutput,
+                  }
+                )}
+              />
+            </button>
+          )}
+
+          <div className="relative flex min-h-0 w-full grow flex-col">
+            {isErrorState && (
+              <button
+                type="button"
+                aria-label="Close error panel"
+                className="absolute right-3 top-3 z-10 flex h-5 w-5 items-center justify-center rounded border border-white/20 bg-black/30 font-mono text-sm leading-none text-white/80 transition hover:text-white md:right-5"
+                onClick={closeOutput}
+              >
+                ×
+              </button>
+            )}
+
+            <Terminal
+              ref={terminalRef}
+              className={clsx('h-full min-h-0', {
+                'pointer-events-none': isResizingOutput,
+              })}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/lesson/ScriptingChallenge/Runner/Terminal.tsx
+++ b/ui/lesson/ScriptingChallenge/Runner/Terminal.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import clsx from 'clsx'
-import Convert from 'ansi-to-html'
 
 function Terminal({ className }: { className?: string }, ref) {
   return (
@@ -17,7 +16,8 @@ function Terminal({ className }: { className?: string }, ref) {
           `<style>
                   body {
                     padding: 16px;
-                    margin:0;
+                    margin: 0;
+                    overflow-y: auto;
                   }
                   .output {
                     font-family: monospace;

--- a/ui/lesson/ScriptingChallenge/Runner/constants.ts
+++ b/ui/lesson/ScriptingChallenge/Runner/constants.ts
@@ -1,0 +1,20 @@
+export enum RunnerState {
+  Idle = 'idle',
+  Building = 'building',
+  Running = 'running',
+  Error = 'error',
+  Complete = 'complete',
+}
+
+export const DEFAULT_OUTPUT_HEIGHT = 204
+export const MIN_OUTPUT_HEIGHT = 40
+export const RUNNER_WS_ENDPOINT =
+  process.env.NEXT_PUBLIC_WS_ENDPOINT || 'wss://api.savingsatoshi.com'
+
+export const OUTPUT_COPY = {
+  idleTitle: 'Script output',
+  idleMessage: 'Waiting for you to run the script...',
+  buildingTitle: 'Starting up',
+  buildingMessage: 'This will take just a few seconds...',
+  timeoutMessage: 'Repl timed out without a response. Please try again.',
+} as const

--- a/ui/lesson/ScriptingChallenge/Runner/index.tsx
+++ b/ui/lesson/ScriptingChallenge/Runner/index.tsx
@@ -3,7 +3,6 @@
 import clsx from 'clsx'
 import { useMediaQuery, useTranslations } from 'hooks'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import Convert from 'ansi-to-html'
 
 import { Loader } from 'shared'
 import Icon from 'shared/Icon'
@@ -11,41 +10,10 @@ import { HasherState } from './Hasher'
 import { EditorConfig, LessonView, StoredLessonData } from 'types'
 import { useLessonContext, StatusBar } from 'ui'
 import { useDynamicHeight } from 'hooks'
-import Terminal from './Terminal'
-import { Base64String } from 'types/classes'
-
-enum State {
-  Idle = 'idle',
-  Building = 'building',
-  Running = 'running',
-  Error = 'error',
-  Complete = 'complete',
-}
-
-function escapeHtml(text) {
-  return text
-    .replace(/&/g, '&amp;') // Replace & with &amp;
-    .replace(/</g, '&lt;') // Replace < with &lt;
-    .replace(/>/g, '&gt;') // Replace > with &gt;
-    .replace(/"/g, '&quot;') // Replace " with &quot;
-    .replace(/'/g, '&#039;') // Replace ' with &#039;
-}
-
-const convert = new Convert()
-const wsEndpoint =
-  process.env.NEXT_PUBLIC_WS_ENDPOINT || 'wss://api.savingsatoshi.com'
-
-let ws: WebSocket | undefined = undefined
-
-const send = (action: string, payload: any) => {
-  if (!ws) {
-    throw new Error('WebSocket uninitialized')
-  }
-  ws.send(JSON.stringify({ action, payload }))
-}
-
-let success: boolean | 0 | 1 | 2 | 3 | 4 | 5
-success = false
+import OutputSection from './OutputSection'
+import { DEFAULT_OUTPUT_HEIGHT, RunnerState } from './constants'
+import useOutputResize from './useOutputResize'
+import useRunnerExecution from './useRunnerExecution'
 
 export default function Runner({
   language,
@@ -59,6 +27,11 @@ export default function Runner({
   poorMessage,
   goodMessage,
   setErrors,
+  isOutputCollapsed,
+  terminalHeight,
+  setTerminalHeight,
+  closeOutput,
+  showOutput,
 }: {
   language: string
   code?: string
@@ -71,203 +44,59 @@ export default function Runner({
   poorMessage: string
   goodMessage: string
   setErrors: (errors: string[]) => void
+  isOutputCollapsed: boolean
+  terminalHeight: number
+  setTerminalHeight: React.Dispatch<React.SetStateAction<number>>
+  closeOutput: () => void
+  showOutput: () => void
 }) {
   const t = useTranslations(lang)
   const { activeView, setActiveView } = useLessonContext()
-  const terminalRef = useRef()
+  const terminalRef = useRef<HTMLIFrameElement | null>(null)
 
-  const [state, setState] = useState<State>(State.Idle)
-
-  const [loading, setLoading] = useState<boolean>(false)
-  const [isRunning, setIsRunning] = useState<boolean>(false)
-  const hasResult = useRef(false)
-  const outputBuffer = useRef<string[]>([])
   const isActive = activeView !== LessonView.Info
   const [isTryAgain, setIsTryAgain] = useState<boolean | null>(null)
-  const [hasherState, setHasherState] = useState<HasherState>(
-    HasherState.Waiting
-  )
 
   const isSmallScreen = useMediaQuery({ width: 767 })
+  const { outputPanelHeight, isResizingOutput, handleResizeStart } =
+    useOutputResize({
+      isSmallScreen,
+      terminalHeight,
+      setTerminalHeight,
+    })
 
-  const sendTerminal = (action: string, payload?: any) => {
-    if (!terminalRef.current) {
-      return
-    }
+  const {
+    state,
+    loading,
+    isRunning,
+    success,
+    hasherState,
+    handleRun,
+    resetHasherState,
+  } = useRunnerExecution({
+    terminalRef,
+    language,
+    code,
+    program,
+    onValidate,
+    isOutputCollapsed,
+    showOutput,
+    setErrors,
+    poorMessage,
+    goodMessage,
+    setActiveView,
+    setTerminalHeight,
+    t,
+  })
 
-    if (payload && payload.includes('<GE')) {
-      payload = escapeHtml(payload)
-    }
-
-    if (payload) {
-      payload = convert.toHtml(payload)
-    }
-    // @ts-ignore
-    const win = terminalRef.current.contentWindow
-    win.postMessage(JSON.stringify({ action, payload }), '*')
-  }
+  const canShowOutput = [
+    RunnerState.Running,
+    RunnerState.Error,
+    RunnerState.Complete,
+  ].includes(state)
+  const isErrorState = state === RunnerState.Error
 
   useDynamicHeight([activeView])
-
-  const handleRun = useCallback(async () => {
-    setActiveView(LessonView.Execute)
-    hasResult.current = false
-    outputBuffer.current = []
-    try {
-      success = false
-      setState(State.Building)
-      setErrors([])
-      setIsRunning(true)
-      setHasherState(HasherState.Running)
-
-      sendTerminal('clear')
-      sendTerminal('print', t('runner.result'))
-      sendTerminal('running', t('runner.computing'))
-
-      if (ws) {
-        ws.close()
-      }
-
-      ws = new WebSocket(wsEndpoint)
-      ws.onopen = () =>
-        send('repl', {
-          code: Buffer.from(`${code}\n${program}`).toString('base64'),
-          language,
-        })
-      ws.onmessage = async (e) => {
-        let { type, payload } = JSON.parse(e.data)
-        switch (type) {
-          case 'status': {
-            if (payload === 'running') {
-              setState(State.Running)
-            }
-            break
-          }
-          case 'error': {
-            const error = payload.message.trim()
-            const lines = error.split('\n')
-            sendTerminal('clear')
-            sendTerminal('print', t('runner.result'))
-            lines.forEach((line) =>
-              sendTerminal('error', line.replace(' ', '&nbsp;'))
-            )
-            setHasherState(HasherState.Error)
-            setIsRunning(false)
-            setState(State.Error)
-            ws?.close()
-
-            break
-          }
-          case 'debug': {
-            const wsRemovedRegex =
-              /\[system\] Image [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12} removed\./
-            if (hasResult.current === false && wsRemovedRegex.test(payload)) {
-              sendTerminal('clear')
-              sendTerminal('print', t('runner.result'))
-              sendTerminal(
-                'error',
-                'Repl timed out without a response. Please try again.'
-              )
-              setHasherState(HasherState.Error)
-              setIsRunning(false)
-              setState(State.Error)
-              ws?.close()
-            }
-            break
-          }
-          case 'output': {
-            // Let's accumulate output chunks
-            payload = payload.trim()
-            if (payload) {
-              outputBuffer.current.push(payload)
-              hasResult.current = true
-            }
-            // we shoulnd't display or close websocket here, we should wait for 'end' message
-            break
-          }
-          case 'end': {
-            if (hasResult.current === false) {
-              sendTerminal('clear')
-              sendTerminal('print', t('runner.result'))
-              sendTerminal(
-                'error',
-                'Repl timed out without a response. Please try again.'
-              )
-              setHasherState(HasherState.Error)
-              setIsRunning(false)
-              setState(State.Error)
-              ws?.close()
-              break
-            }
-
-            // we can now display the accumulated output
-            const completeOutput = outputBuffer.current.join('')
-            sendTerminal('clear')
-            sendTerminal('print', t('runner.result'))
-            sendTerminal('print', completeOutput)
-
-            const [res, msg] = await onValidate({
-              code: new Base64String(`${code}\n${program}`),
-              answer: completeOutput,
-            })
-
-            if (!res || res === 2) {
-              setIsRunning(false)
-              setHasherState(HasherState.Error)
-              if (msg) {
-                sendTerminal('error', msg)
-              }
-              ws?.close()
-              break
-            }
-            if (res === 3) {
-              setIsRunning(false)
-              setHasherState(HasherState.Success)
-              success = 3
-              sendTerminal('success', t('runner.evaluation'))
-              sendTerminal('success', poorMessage)
-              ws?.close()
-              break
-            }
-            if (res === 4) {
-              setIsRunning(false)
-              setHasherState(HasherState.Success)
-              success = 4
-              sendTerminal('success', t('runner.evaluation'))
-              sendTerminal('success', goodMessage)
-              ws?.close()
-              break
-            }
-
-            success = true
-            setIsRunning(false)
-            setHasherState(HasherState.Success)
-            sendTerminal('success', t('runner.evaluation'))
-            sendTerminal('success', msg)
-            ws?.close()
-            break
-          }
-        }
-      }
-
-      ws.onerror = (err) => {
-        setIsRunning(false)
-      }
-    } catch (ex) {
-      console.error(ex)
-      setIsRunning(false)
-    }
-  }, [
-    code,
-    goodMessage,
-    language,
-    onValidate,
-    poorMessage,
-    program,
-    setActiveView,
-    setErrors,
-    t,
-  ])
 
   const handleRunKeyPress = useCallback(
     (event: KeyboardEvent) => {
@@ -278,43 +107,17 @@ export default function Runner({
     [handleRun]
   )
 
-  useEffect(() => {
-    if (ws) {
-      ws.close()
-    }
-
-    sendTerminal('clear')
-  }, [language])
-
   const onTryAgain = () => {
     setIsTryAgain(true)
     handleTryAgain(true)
   }
 
   useEffect(() => {
-    isTryAgain && setHasherState(HasherState.Waiting)
+    if (isTryAgain) {
+      resetHasherState()
+    }
     setIsTryAgain(false)
-  }, [isTryAgain, code])
-
-  useEffect(() => {
-    const handleMessage = (e) => {
-      try {
-        const { action, payload } = JSON.parse(e.data)
-        switch (action) {
-          case 'ready': {
-            sendTerminal('clear')
-            break
-          }
-        }
-      } catch (ex) {}
-    }
-    if (terminalRef.current) {
-      window.addEventListener('message', handleMessage)
-    }
-    return () => {
-      window.removeEventListener('message', handleMessage)
-    }
-  }, [terminalRef])
+  }, [code, isTryAgain, resetHasherState])
 
   useEffect(() => {
     document.addEventListener('keydown', handleRunKeyPress)
@@ -324,8 +127,27 @@ export default function Runner({
     }
   }, [handleRunKeyPress])
 
+  const outputSection = (
+    <OutputSection
+      isOutputCollapsed={isOutputCollapsed}
+      isSmallScreen={isSmallScreen}
+      activeView={activeView}
+      hasherState={hasherState}
+      showIdlePanel={state === RunnerState.Idle}
+      showBuildingPanel={state === RunnerState.Building}
+      showResultPanel={canShowOutput}
+      isErrorState={isErrorState}
+      outputPanelHeight={outputPanelHeight}
+      defaultOutputHeight={DEFAULT_OUTPUT_HEIGHT}
+      isResizingOutput={isResizingOutput}
+      handleResizeStart={handleResizeStart}
+      closeOutput={closeOutput}
+      terminalRef={terminalRef}
+    />
+  )
+
   return (
-    <>
+    <div className="flex min-h-0 w-full flex-col">
       {loading && (
         <div
           className={clsx(
@@ -340,56 +162,21 @@ export default function Runner({
         </div>
       )}
 
-      <div
-        className={clsx({
-          'hidden md:flex':
-            !isSmallScreen ||
-            (activeView !== LessonView.Execute &&
-              hasherState !== HasherState.Running),
-        })}
-      >
-        {state === State.Idle && (
-          <div className="w-full border-t border-white border-opacity-30 bg-black bg-opacity-20 p-4">
-            <div className="font-mono text-xs text-white">Script output</div>
-            <div className="font-mono text-xs text-white text-opacity-60">
-              Waiting for you to run the script...
-            </div>
-          </div>
-        )}
-        {state === State.Building && (
-          <div className="h-full w-full grow border-t border-white border-opacity-30 bg-black bg-opacity-20 p-4">
-            <div className="font-mono text-xs text-white">Starting up</div>
-            <div className="font-mono text-xs text-white text-opacity-60">
-              This will take just a few seconds...
-            </div>
-          </div>
-        )}
-        <Terminal
-          ref={terminalRef}
-          className={clsx({
-            block:
-              [State.Running, State.Error, State.Complete].indexOf(state) !==
-              -1,
-            hidden:
-              [State.Running, State.Error, State.Complete].indexOf(state) ===
-              -1,
-          })}
-        />
-      </div>
+      {outputSection}
 
       <div
         className={clsx(
-          'flex h-14 min-h-14 w-full items-start border-t border-white border-opacity-30',
+          'sticky bottom-0 z-10 h-14 min-h-14 w-full shrink-0 items-start border-t border-white border-opacity-30 bg-black/10',
           {
-            'hidden md:flex':
-              !isSmallScreen &&
-              activeView !== LessonView.Execute &&
-              hasherState !== HasherState.Success,
             hidden:
               hasherState === HasherState.Success ||
               loading ||
-              activeView === 'info',
-            flex: isActive,
+              (isSmallScreen && activeView === LessonView.Info),
+            flex: !(
+              hasherState === HasherState.Success ||
+              loading ||
+              (isSmallScreen && activeView === LessonView.Info)
+            ),
           }
         )}
       >
@@ -423,7 +210,7 @@ export default function Runner({
           {isRunning && (
             <>
               <Loader className="h-6 w-6 text-white" />
-              <span>Running...</span>
+              <span>{t('runner.computing')}</span>
             </>
           )}
         </button>
@@ -437,6 +224,6 @@ export default function Runner({
           tooltipDisabled
         />
       )}
-    </>
+    </div>
   )
 }

--- a/ui/lesson/ScriptingChallenge/Runner/useOutputResize.ts
+++ b/ui/lesson/ScriptingChallenge/Runner/useOutputResize.ts
@@ -1,0 +1,99 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { Dispatch, SetStateAction } from 'react'
+
+import { DEFAULT_OUTPUT_HEIGHT, MIN_OUTPUT_HEIGHT } from './constants'
+
+export default function useOutputResize({
+  isSmallScreen,
+  terminalHeight,
+  setTerminalHeight,
+}: {
+  isSmallScreen: boolean
+  terminalHeight: number
+  setTerminalHeight: Dispatch<SetStateAction<number>>
+}) {
+  const resizeStartY = useRef(0)
+  const resizeStartHeight = useRef(DEFAULT_OUTPUT_HEIGHT)
+  const resizeFrameRef = useRef<number | null>(null)
+  const [isResizingOutput, setIsResizingOutput] = useState(false)
+
+  const clampTerminalHeight = useCallback(
+    (nextHeight: number) =>
+      Math.min(DEFAULT_OUTPUT_HEIGHT, Math.max(MIN_OUTPUT_HEIGHT, nextHeight)),
+    []
+  )
+
+  const outputPanelHeight = clampTerminalHeight(terminalHeight)
+
+  const handleResizeStart = useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      if (isSmallScreen) {
+        return
+      }
+
+      event.preventDefault()
+      event.currentTarget.setPointerCapture?.(event.pointerId)
+      resizeStartY.current = event.clientY
+      resizeStartHeight.current = outputPanelHeight
+      setIsResizingOutput(true)
+    },
+    [isSmallScreen, outputPanelHeight]
+  )
+
+  useEffect(() => {
+    if (!isResizingOutput) {
+      return
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const delta = resizeStartY.current - event.clientY
+      const nextHeight = clampTerminalHeight(resizeStartHeight.current + delta)
+
+      if (resizeFrameRef.current !== null) {
+        window.cancelAnimationFrame(resizeFrameRef.current)
+      }
+
+      resizeFrameRef.current = window.requestAnimationFrame(() => {
+        setTerminalHeight((currentHeight) =>
+          currentHeight === nextHeight ? currentHeight : nextHeight
+        )
+        resizeFrameRef.current = null
+      })
+    }
+
+    const stopResizing = () => {
+      if (resizeFrameRef.current !== null) {
+        window.cancelAnimationFrame(resizeFrameRef.current)
+        resizeFrameRef.current = null
+      }
+      setIsResizingOutput(false)
+    }
+
+    document.body.style.cursor = 'row-resize'
+    document.body.style.userSelect = 'none'
+
+    window.addEventListener('pointermove', handlePointerMove, { passive: true })
+    window.addEventListener('pointerup', stopResizing)
+    window.addEventListener('pointercancel', stopResizing)
+
+    return () => {
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+      if (resizeFrameRef.current !== null) {
+        window.cancelAnimationFrame(resizeFrameRef.current)
+        resizeFrameRef.current = null
+      }
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', stopResizing)
+      window.removeEventListener('pointercancel', stopResizing)
+    }
+  }, [clampTerminalHeight, isResizingOutput, setTerminalHeight])
+
+  return {
+    outputPanelHeight,
+    isResizingOutput,
+    handleResizeStart,
+  }
+}

--- a/ui/lesson/ScriptingChallenge/Runner/useRunnerExecution.ts
+++ b/ui/lesson/ScriptingChallenge/Runner/useRunnerExecution.ts
@@ -1,0 +1,305 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { Dispatch, RefObject, SetStateAction } from 'react'
+import Convert from 'ansi-to-html'
+
+import { LessonView, StoredLessonData } from 'types'
+import { Base64String } from 'types/classes'
+import { HasherState } from './Hasher'
+import {
+  DEFAULT_OUTPUT_HEIGHT,
+  OUTPUT_COPY,
+  RUNNER_WS_ENDPOINT,
+  RunnerState,
+} from './constants'
+
+let ws: WebSocket | undefined = undefined
+
+function escapeHtml(text: string) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
+}
+
+const convert = new Convert()
+
+const send = (action: string, payload: any) => {
+  if (!ws) {
+    throw new Error('WebSocket uninitialized')
+  }
+  ws.send(JSON.stringify({ action, payload }))
+}
+
+export default function useRunnerExecution({
+  terminalRef,
+  language,
+  code,
+  program,
+  onValidate,
+  isOutputCollapsed,
+  showOutput,
+  setErrors,
+  poorMessage,
+  goodMessage,
+  setActiveView,
+  setTerminalHeight,
+  t,
+}: {
+  terminalRef: RefObject<HTMLIFrameElement | null>
+  language: string
+  code?: string
+  program: string
+  onValidate: (data: StoredLessonData) => Promise<any[]>
+  isOutputCollapsed: boolean
+  showOutput: () => void
+  setErrors: (errors: string[]) => void
+  poorMessage: string
+  goodMessage: string
+  setActiveView: Dispatch<SetStateAction<LessonView>>
+  setTerminalHeight: Dispatch<SetStateAction<number>>
+  t: (key: string) => string
+}) {
+  const [state, setState] = useState<RunnerState>(RunnerState.Idle)
+  const [loading] = useState(false)
+  const [isRunning, setIsRunning] = useState(false)
+  const [success, setSuccess] = useState<boolean | 0 | 1 | 2 | 3 | 4 | 5>(false)
+  const [hasherState, setHasherState] = useState<HasherState>(
+    HasherState.Waiting
+  )
+  const hasResult = useRef(false)
+  const outputBuffer = useRef<string[]>([])
+
+  const sendTerminal = useCallback(
+    (action: string, payload?: any) => {
+      const win = terminalRef.current?.contentWindow
+
+      if (!win) {
+        return
+      }
+
+      if (payload && payload.includes('<GE')) {
+        payload = escapeHtml(payload)
+      }
+
+      if (payload) {
+        payload = convert.toHtml(payload)
+      }
+
+      win.postMessage(JSON.stringify({ action, payload }), '*')
+    },
+    [terminalRef]
+  )
+
+  const handleRun = useCallback(async () => {
+    setActiveView(LessonView.Execute)
+    hasResult.current = false
+    outputBuffer.current = []
+
+    try {
+      setSuccess(false)
+      setState(RunnerState.Building)
+      if (isOutputCollapsed) {
+        showOutput()
+      }
+      setErrors([])
+      setIsRunning(true)
+      setHasherState(HasherState.Running)
+      setTerminalHeight(DEFAULT_OUTPUT_HEIGHT)
+      sendTerminal('clear')
+      sendTerminal('print', t('runner.result'))
+      sendTerminal('running', t('runner.computing'))
+
+      if (ws) {
+        ws.close()
+      }
+
+      ws = new WebSocket(RUNNER_WS_ENDPOINT)
+      ws.onopen = () =>
+        send('repl', {
+          code: Buffer.from(`${code}\n${program}`).toString('base64'),
+          language,
+        })
+
+      ws.onmessage = async (event) => {
+        const { type, payload } = JSON.parse(event.data)
+
+        switch (type) {
+          case 'status': {
+            if (payload === 'running') {
+              setState(RunnerState.Running)
+            }
+            break
+          }
+          case 'error': {
+            const error = payload.message.trim()
+            const lines = error.split('\n')
+            sendTerminal('clear')
+            sendTerminal('print', t('runner.result'))
+            lines.forEach((line) =>
+              sendTerminal('error', line.replace(' ', '&nbsp;'))
+            )
+            setHasherState(HasherState.Error)
+            setIsRunning(false)
+            setState(RunnerState.Error)
+            ws?.close()
+            break
+          }
+          case 'debug': {
+            const wsRemovedRegex =
+              /\[system\] Image [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12} removed\./
+            if (hasResult.current === false && wsRemovedRegex.test(payload)) {
+              sendTerminal('clear')
+              sendTerminal('print', t('runner.result'))
+              sendTerminal('error', OUTPUT_COPY.timeoutMessage)
+              setHasherState(HasherState.Error)
+              setIsRunning(false)
+              setState(RunnerState.Error)
+              ws?.close()
+            }
+            break
+          }
+          case 'output': {
+            const trimmedPayload = payload.trim()
+            if (trimmedPayload) {
+              outputBuffer.current.push(trimmedPayload)
+              hasResult.current = true
+            }
+            break
+          }
+          case 'end': {
+            if (hasResult.current === false) {
+              sendTerminal('clear')
+              sendTerminal('print', t('runner.result'))
+              sendTerminal('error', OUTPUT_COPY.timeoutMessage)
+              setHasherState(HasherState.Error)
+              setIsRunning(false)
+              setState(RunnerState.Error)
+              ws?.close()
+              break
+            }
+
+            const completeOutput = outputBuffer.current.join('')
+            sendTerminal('clear')
+            sendTerminal('print', t('runner.result'))
+            sendTerminal('print', completeOutput)
+
+            const [res, msg] = await onValidate({
+              code: new Base64String(`${code}\n${program}`),
+              answer: completeOutput,
+            })
+
+            if (!res || res === 2) {
+              setIsRunning(false)
+              setHasherState(HasherState.Error)
+              setState(RunnerState.Error)
+              if (msg) {
+                sendTerminal('error', msg)
+              }
+              ws?.close()
+              break
+            }
+
+            if (res === 3) {
+              setSuccess(3)
+              setIsRunning(false)
+              setHasherState(HasherState.Success)
+              setState(RunnerState.Complete)
+              sendTerminal('success', t('runner.evaluation'))
+              sendTerminal('success', poorMessage)
+              ws?.close()
+              break
+            }
+
+            if (res === 4) {
+              setSuccess(4)
+              setIsRunning(false)
+              setHasherState(HasherState.Success)
+              setState(RunnerState.Complete)
+              sendTerminal('success', t('runner.evaluation'))
+              sendTerminal('success', goodMessage)
+              ws?.close()
+              break
+            }
+
+            setSuccess(true)
+            setIsRunning(false)
+            setHasherState(HasherState.Success)
+            setState(RunnerState.Complete)
+            sendTerminal('success', t('runner.evaluation'))
+            sendTerminal('success', msg)
+            ws?.close()
+            break
+          }
+        }
+      }
+
+      ws.onerror = () => {
+        setIsRunning(false)
+      }
+    } catch (error) {
+      console.error(error)
+      setIsRunning(false)
+    }
+  }, [
+    code,
+    goodMessage,
+    isOutputCollapsed,
+    language,
+    onValidate,
+    poorMessage,
+    program,
+    sendTerminal,
+    setActiveView,
+    setErrors,
+    setTerminalHeight,
+    showOutput,
+    t,
+  ])
+
+  useEffect(() => {
+    if (ws) {
+      ws.close()
+    }
+
+    sendTerminal('clear')
+  }, [language, sendTerminal])
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      try {
+        const { action } = JSON.parse(event.data)
+        if (action === 'ready') {
+          sendTerminal('clear')
+        }
+      } catch {
+        // ignore invalid postMessage payloads
+      }
+    }
+
+    if (terminalRef.current) {
+      window.addEventListener('message', handleMessage)
+    }
+
+    return () => {
+      window.removeEventListener('message', handleMessage)
+    }
+  }, [sendTerminal, terminalRef])
+
+  const resetHasherState = useCallback(() => {
+    setHasherState(HasherState.Waiting)
+  }, [])
+
+  return {
+    state,
+    loading,
+    isRunning,
+    success,
+    hasherState,
+    handleRun,
+    resetHasherState,
+  }
+}

--- a/ui/lesson/ScriptingChallenge/index.tsx
+++ b/ui/lesson/ScriptingChallenge/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import LanguageTabs from './LanguageTabs'
 import Editor from './Editor'
@@ -35,6 +35,8 @@ const tabData = [
     text: 'Execute',
   },
 ]
+
+const DEFAULT_OUTPUT_HEIGHT = 204
 
 function trimLastTwoLines(code: string): string {
   let lines = code.split('\n')
@@ -85,7 +87,21 @@ export default function ScriptingChallenge({
   const [challengeSuccess, setChallengeSuccess] = useState(false)
   const [hydrated, setHydrated] = useState(false)
   const [errors, setErrors] = useState<string[]>([])
+  const [isOutputCollapsed, setIsOutputCollapsed] = useState(false)
+  const [outputPanelHeight, setOutputPanelHeight] = useState(
+    DEFAULT_OUTPUT_HEIGHT
+  )
   const debouncedCode = useDebounce(code, 500)
+
+  const closeOutput = useCallback(() => {
+    setIsOutputCollapsed(true)
+    setOutputPanelHeight(DEFAULT_OUTPUT_HEIGHT)
+  }, [])
+
+  const showOutput = useCallback(() => {
+    setIsOutputCollapsed(false)
+    setOutputPanelHeight(DEFAULT_OUTPUT_HEIGHT)
+  }, [])
   const hasLoaded = useRef(false)
 
   // Hydrate editor from localStorage before enabling autosave.
@@ -241,7 +257,7 @@ export default function ScriptingChallenge({
 
         <div
           className={clsx(
-            'code-editor flex grow flex-col justify-between border-white/25 md:max-w-[50vw] md:basis-1/3 md:border-l',
+            'code-editor flex min-h-0 grow flex-col border-white/25 md:max-w-[50vw] md:basis-1/3 md:border-l',
             {
               hidden: activeView === LessonView.Info,
             }
@@ -269,6 +285,8 @@ export default function ScriptingChallenge({
               constraints={constraints}
               loadingSavedCode={loadingSavedCode}
               rangeToNotCollapse={config.languages[language].rangeToNotCollapse}
+              terminalVisible={!isOutputCollapsed}
+              terminalHeight={isOutputCollapsed ? 0 : outputPanelHeight}
               options={editorOptions}
             />
           </div>
@@ -284,6 +302,11 @@ export default function ScriptingChallenge({
             handleTryAgain={handleTryAgain}
             poorMessage={poorMessage ?? ''}
             goodMessage={goodMessage ?? ''}
+            isOutputCollapsed={isOutputCollapsed}
+            terminalHeight={outputPanelHeight}
+            setTerminalHeight={setOutputPanelHeight}
+            closeOutput={closeOutput}
+            showOutput={showOutput}
           />
         </div>
       </Lesson>


### PR DESCRIPTION
This PR fixes #1356 by making the scripting challenge error/output panel dismissible and resizable such that it no longer blocks the editor after a script error.

### Changes
- add a dismiss (`×`) button to the error panel
- add minimize/maximize and drag-resize behavior to the output area

## Pull Request checklist

Please review the below PR requirements:

- [x] Build was run locally and any changes were pushed
- [x] Ensure that the title clearly describes the changes
- [x] Issue to be referenced in the PR description rather than in the commits or PR title
- [x] Clean commit history

## Demo

https://github.com/user-attachments/assets/f23a6641-ed91-46a4-ab5e-cc873bf08796


